### PR TITLE
isdisjoint() can't be use with lists

### DIFF
--- a/lib/ansiblelint/__init__.py
+++ b/lib/ansiblelint/__init__.py
@@ -45,8 +45,8 @@ class RulesCollection(object):
         with open(playbookfile, 'r') as f:
             text = f.read()
         for rule in self.rules:
-            if not tags or not rule.tags.isdisjoint(tags):
-                if rule.tags.isdisjoint(skip_tags):
+            if not tags or not set(rule.tags).isdisjoint(tags):
+                if set(rule.tags).isdisjoint(skip_tags):
                     matches.extend(rule.matchlines(playbookfile, text))
 
         return matches


### PR DESCRIPTION
```
$ ./bin/ansible-lint examples/example.yml
Traceback (most recent call last):
  File "./bin/ansible-lint", line 68, in <module>
    sys.exit(main(sys.argv[1:]))
  File "./bin/ansible-lint", line 61, in main
    matches.extend(rules.run(playbook, tags=set(options.tags), skip_tags=set(options.skip_tags)))
  File "~/Dev/ansible-lint/lib/ansiblelint/__init__.py", line 49, in run
    if rule.tags.isdisjoint(skip_tags):
AttributeError: 'list' object has no attribute 'isdisjoint'
```

```
$ python --version
Python 2.7.2
```
