### PR TITLE
Fix: TypeError: 'NoneType' object is not iterable

### DIFF
--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -42,6 +42,8 @@ def tokenize(line):
 def _playbook_items(pb_data):
     if isinstance(pb_data, dict):
         return pb_data.items()
+    elif not pb_data:
+        return []
     else:
         return [item for play in pb_data for item in play.items()]
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "./bin/ansible-lint", line 68, in <module>
    sys.exit(main(sys.argv[1:]))
  File "./bin/ansible-lint", line 56, in main
    playbooks |= set(utils.find_children(arg))
  File "~/Dev/ansible-lint/lib/ansiblelint/utils.py", line 54, in find_children
    items = _playbook_items(pb_data)
  File "~/Dev/ansible-lint/lib/ansiblelint/utils.py", line 46, in _playbook_items
    return [item for play in pb_data for item in play.items()]
TypeError: 'NoneType' object is not iterable
```
