### PR TITLE
Strip hyphen at the begining of the line

### DIFF
--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -25,7 +25,9 @@ def load_plugins(directory):
 def tokenize(line):
     result = list()
     tokens = line.lstrip().split(" ")
-    if tokens[0] == 'action:': 
+    if tokens[0] == '-':
+        tokens = tokens[1:]
+    if tokens[0] == 'action:':
         tokens = tokens[1:]
     command = tokens[0].replace(":", "")
 


### PR DESCRIPTION
The `tokenize` function now return the name of the command instead of an hyphen, if the line starts with `-`.

If you write a tasks which looks like to:

```
- git: a=b c=d
```

The `GitHasVersionRule` is now able to check that a specific version is specified.
