### PR TITLE
The -t and -x options now work.

### DIFF
--- a/bin/ansible-lint
+++ b/bin/ansible-lint
@@ -57,8 +57,12 @@ def main(args):
             visited.add(arg)
 
     matches = list()
-    for playbook in playbooks: 
-        matches.extend(rules.run(playbook, tags=set(options.tags.split(',')), skip_tags=set(options.skip_tags.split(','))))
+    for playbook in playbooks:
+        if isinstance(options.tags, basestring):
+          options.tags = options.tags.split(',')
+        if isinstance(options.skip_tags, basestring):
+          options.skip_tags = options.skip_tags.split(',')
+        matches.extend(rules.run(playbook, tags=set(options.tags), skip_tags=set(options.skip_tags)))
 
     for match in matches:
         print formatter.format(match)


### PR DESCRIPTION
Before, the tags specified in the command line are converted in a `set` by making one item with each character. It's now split with the `,`.
