### PR TITLE
README.md: Simplify setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,8 @@ potentially be improved
 Setup
 -----
 
-You'll need to add ansible-lint/lib to your PYTHONPATH
 ```
-export PYTHONPATH=$PYTHONPATH:`pwd`/lib
+pip install https://github.com/willthames/ansible-lint/archive/master.zip
 ```
 
 Usage
@@ -156,4 +155,6 @@ Contributing
 ============
 
 Please read
-[CONTRIBUTING.md](https://github.com/willthames/ansible-lint/blob/master/CONTRIBUTING.md) if you wish to contribute.
+[CONTRIBUTING.md](https://github.com/willthames/ansible-lint/blob/master/CONTRIBUTING.md)
+if you wish to contribute.
+


### PR DESCRIPTION
and wrap a long line.

Demonstration that package is now pip-installable and works:

```
$ mktmpenv
New python executable in tmp-9b22ed82713ea029/bin/python
Installing setuptools, pip...done.
This is a temporary environment. It will be deleted when you run 'deactivate'.

$ pip install https://github.com/willthames/ansible-lint/archive/master.zip
...
Successfully installed ansible ansiblelint paramiko jinja2 PyYAML pycrypto ecdsa markupsafe
Cleaning up...

$ ansible-lint ~/dev/git-repos/ansible-lint/examples/example.yml
[ANSIBLE0006] git used in place of git module
/Users/marca/dev/git-repos/ansible-lint/examples/example.yml:31
    action: command git clone blah

[ANSIBLE0006] git used in place of git module
/Users/marca/dev/git-repos/ansible-lint/examples/example.yml:34
    action: command chdir=bobbins creates=whatever /usr/bin/git clone blah

[ANSIBLE0001] Old style (${var}) brackets
/Users/marca/dev/git-repos/ansible-lint/examples/example.yml:10
    action: command echo ${oldskool}

[ANSIBLE0004] Checkouts must contain explicit version
/Users/marca/dev/git-repos/ansible-lint/examples/example.yml:22
    action: git a=b c=d

[ANSIBLE0004] Checkouts must contain explicit version
/Users/marca/dev/git-repos/ansible-lint/examples/example.yml:25
    action: git version=HEAD c=d

[ANSIBLE0004] Checkouts must contain explicit version
/Users/marca/dev/git-repos/ansible-lint/examples/example.yml:37
    action: git command

[ANSIBLE0003] Mismatched { and }
/Users/marca/dev/git-repos/ansible-lint/examples/example.yml:13
    action: debug oops a missing {{bracket}

[ANSIBLE0002] Trailing whitespace
/Users/marca/dev/git-repos/ansible-lint/examples/example.yml:19
    action: do nothing
```
