### PR TITLE
Fix for unified read and a bracket in MercurialHasRevisionRule

### DIFF
--- a/lib/ansiblelint/__init__.py
+++ b/lib/ansiblelint/__init__.py
@@ -69,7 +69,7 @@ class RulesCollection(object):
     def run(self, playbookfile, tags=set(), skip_tags=set()):
         text = ""
         matches = list()
-        with open(playbookfile['path'], 'r') as f:
+        with open(playbookfile['path'], 'Ur') as f:
             text = f.read()
         for rule in self.rules:
             if not tags or not set(rule.tags).isdisjoint(tags):

--- a/lib/ansiblelint/rules/MercurialHasRevisionRule.py
+++ b/lib/ansiblelint/rules/MercurialHasRevisionRule.py
@@ -11,4 +11,4 @@ class MercurialHasRevisionRule(AnsibleLintRule):
 
 
     def matchtask(self, file, task):
-        return task['action']['module'] == 'hg' and task['action'].get('revision', 'default') == 'default')
+        return task['action']['module'] == 'hg' and task['action'].get('revision', 'default') == 'default'


### PR DESCRIPTION
Added unified read when opening playbook files, prevents issues with trailing whitspace check when running in a mixed (*nix, Win) environment. Removed unneccesary bracket in MercurialHasRevisionRule.
