### PR TITLE
Indent the description when using the option -L

### DIFF
--- a/lib/ansiblelint/__init__.py
+++ b/lib/ansiblelint/__init__.py
@@ -31,7 +31,7 @@ class AnsibleLintRule(object):
         return self.id + ": " + self.shortdesc
 
     def verbose(self):
-        return self.id + ": " + self.shortdesc + "\n" + self.description
+        return self.id + ": " + self.shortdesc + "\n  " + self.description
 
     def match(self, file="", line=""):
         return []


### PR DESCRIPTION
having some space before improve readability, since you
can more easily see what is the name of the rule.
