### PR TITLE
Added skip_ansible_lint to avoid specific tasks

### DIFF
--- a/lib/ansiblelint/__init__.py
+++ b/lib/ansiblelint/__init__.py
@@ -58,6 +58,8 @@ class AnsibleLintRule(object):
         yaml = ansible.utils.parse_yaml(text)
         if yaml:
             for task in utils.get_action_tasks(yaml, file):
+                if 'skip_ansible_lint' in task.get('tags', []):
+                    continue
                 if 'action' in task:
                     result = self.matchtask(file, task)
                     if result:

--- a/test/TestSkippedTasks.py
+++ b/test/TestSkippedTasks.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2013-2014 Will Thames <will@thames.id.au>
+#               2014      Akira Yoshiyama <akirayoshiyama@gmail.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import os
+import unittest
+
+import ansiblelint
+from ansiblelint import RulesCollection
+
+
+class TestRule(unittest.TestCase):
+
+    def setUp(self):
+        rulesdir = os.path.join('lib', 'ansiblelint', 'rules')
+        self.rules = RulesCollection.create_from_directory(rulesdir)
+
+    def test_runner_count(self):
+        filename = 'test/skiptasks.txt'
+        runner = ansiblelint.Runner(self.rules, {filename}, [], [])
+        self.assertEqual(len(runner.run()), 4)

--- a/test/skiptasks.txt
+++ b/test/skiptasks.txt
@@ -1,0 +1,36 @@
+---
+- hosts: all
+
+  tasks:
+
+    - name: test ANSIBLE0004
+      action: git
+
+    - name: test ANSIBLE0005
+      action: hg
+
+    - name: test ANSIBLE0006
+      command: git log
+
+    - name: test ANSIBLE0007
+      command: chmod 644 A
+
+    - name: test ANSIBLE0004 (skip)
+      action: git
+      tags:
+        - skip_ansible_lint
+
+    - name: test ANSIBLE0005 (skip)
+      action: hg
+      tags:
+        - skip_ansible_lint
+
+    - name: test ANSIBLE0006 (skip)
+      command: git log
+      tags:
+        - skip_ansible_lint
+
+    - name: test ANSIBLE0007 (skip)
+      command: chmod 644 A
+      tags:
+        - skip_ansible_lint


### PR DESCRIPTION
This patch makes ansible-lint not checking tasks with tag "skip_ansible_lint".

For example,

```
- name: Modify permissions
  command: >
    chmod -R g-w /home/user
  tags:
    - skip_ansible_lint
  sudo: yes
```
