### PR TITLE
UsingBareVariablesIsDeprecatedRule supports multiline templates

### DIFF
--- a/lib/ansiblelint/rules/UsingBareVariablesIsDeprecatedRule.py
+++ b/lib/ansiblelint/rules/UsingBareVariablesIsDeprecatedRule.py
@@ -35,7 +35,7 @@ class UsingBareVariablesIsDeprecatedRule(AnsibleLintRule):
     tags = ['deprecated', 'formatting', 'ANSIBLE0015']
     version_added = 'historic'
 
-    _jinja = re.compile(r"{{.*}}")
+    _jinja = re.compile(r"{{.*}}", re.DOTALL)
     _glob = re.compile('[][*?]')
 
     def matchtask(self, file, task):

--- a/test/using-bare-variables-success.yml
+++ b/test/using-bare-variables-success.yml
@@ -166,6 +166,14 @@
         msg: "{{ item }}"
       with_flattened: "{{ my_list_of_lists }}"
 
+    - name: with_flattened loop with a multiline template
+      debug:
+        msg: "{{ item }}"
+      with_flattened: >
+        {{ my_list
+           | union(my_list2)
+           | list }}
+
     - name: with_inventory_hostnames loop
       debug:
         msg: "{{ item }}"


### PR DESCRIPTION
should fix issue #250 