### PR TITLE
Updated rule TrailingWhitespaceRule.py to remove carriage return char…

### DIFF
--- a/lib/ansiblelint/rules/TrailingWhitespaceRule.py
+++ b/lib/ansiblelint/rules/TrailingWhitespaceRule.py
@@ -28,4 +28,5 @@ class TrailingWhitespaceRule(AnsibleLintRule):
     tags = ['formatting']
 
     def match(self, file, line):
+        line = line.replace("\r", "")
         return line.rstrip() != line


### PR DESCRIPTION
Files that have \r\n as line separator trigger TrailingWhitespaceRule on each line. This one removes '\r' characters before actual evaluation.