### PR TITLE
enhancement: add -F/--format option and JSON output formatter

### DIFF
--- a/lib/ansiblelint/__init__.py
+++ b/lib/ansiblelint/__init__.py
@@ -176,6 +176,11 @@ class Match(object):
         return formatstr.format(self.rule.id, self.message,
                                 self.filename, self.linenumber, self.line)
 
+    def as_dict(self):
+        return dict(rule_id=self.rule.id, message=self.message,
+                    filename=self.filename, linenumber=self.linenumber,
+                    line=self.line)
+
 
 class Runner(object):
 

--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -35,6 +35,13 @@ import yaml
 import os
 
 
+__FORMATTERS = (formatters.Formatter,
+                formatters.QuietFormatter,
+                formatters.ParseableFormatter,
+                formatters.JsonFormatter)
+_FORMATTERS = dict((fmtr.name(), fmtr) for fmtr in __FORMATTERS)
+
+
 def load_config(config_file):
     config_path = config_file if config_file else ".ansible-lint"
 
@@ -101,6 +108,9 @@ def main():
                       help='path to directories or files to skip. This option'
                            ' is repeatable.',
                       default=[])
+    parser.add_option('-F', '--format', default=None,
+                      help='Specify the output format. Choices are: '
+                           '%s [default]' % ', '.join(sorted(_FORMATTERS.keys())))
     parser.add_option('-c', help='Specify configuration file to use.  Defaults to ".ansible-lint"')
     options, args = parser.parse_args(sys.argv[1:])
 
@@ -157,6 +167,9 @@ def main():
     if options.listtags:
         print(rules.listtags())
         return 0
+
+    if options.format:
+        formatter = _FORMATTERS.get(options.format, formatters.Formatter)()
 
     if isinstance(options.tags, six.string_types):
         options.tags = options.tags.split(',')

--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -179,11 +179,9 @@ def main():
 
     if matches:
         print(formatter.formats(matches, colored=options.colored))
-
-    if len(matches):
         return 2
-    else:
-        return 0
+
+    return 0
 
 
 if __name__ == "__main__":

--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -177,8 +177,8 @@ def main():
 
     matches.sort(key=lambda x: (x.filename, x.linenumber, x.rule.id))
 
-    for match in matches:
-        print(formatter.format(match, options.colored))
+    if matches:
+        print(formatter.formats(matches, colored=options.colored))
 
     if len(matches):
         return 2

--- a/lib/ansiblelint/formatters/__init__.py
+++ b/lib/ansiblelint/formatters/__init__.py
@@ -1,10 +1,15 @@
+from __future__ import absolute_import
+
 try:
     from ansible import color
 except ImportError:
     from ansible.utils import color
 
+from .base import BaseFormatter
 
-class Formatter(object):
+
+class Formatter(BaseFormatter):
+    _name = "default"
 
     def format(self, match, colored=False):
         formatstr = u"{0} {1}\n{2}:{3}\n{4}\n"
@@ -23,7 +28,7 @@ class Formatter(object):
                                     match.line)
 
 
-class QuietFormatter(object):
+class QuietFormatter(BaseFormatter):
 
     def format(self, match, colored=False):
         formatstr = u"{0} {1}:{2}"
@@ -37,7 +42,7 @@ class QuietFormatter(object):
                                     match.linenumber)
 
 
-class ParseableFormatter(object):
+class ParseableFormatter(BaseFormatter):
 
     def format(self, match, colored=False):
         formatstr = u"{0}:{1}: [{2}] {3}"

--- a/lib/ansiblelint/formatters/__init__.py
+++ b/lib/ansiblelint/formatters/__init__.py
@@ -6,7 +6,7 @@ except ImportError:
     from ansible.utils import color
 
 from .base import BaseFormatter
-from ._json import JsonFormatter  # flake8: noqa
+from ._json import JsonFormatter  # noqa: F401
 
 
 class Formatter(BaseFormatter):

--- a/lib/ansiblelint/formatters/__init__.py
+++ b/lib/ansiblelint/formatters/__init__.py
@@ -6,6 +6,7 @@ except ImportError:
     from ansible.utils import color
 
 from .base import BaseFormatter
+from ._json import JsonFormatter  # flake8: noqa
 
 
 class Formatter(BaseFormatter):

--- a/lib/ansiblelint/formatters/_json.py
+++ b/lib/ansiblelint/formatters/_json.py
@@ -1,0 +1,15 @@
+r"""JSON formatter
+"""
+from __future__ import absolute_import
+import json
+from .base import BaseFormatter
+
+
+class JsonFormatter(BaseFormatter):
+
+    def formats(self, matches, **kwargs):
+        """
+        :param matches: A list of :class:`ansiblelint.Match` objects
+        :return: Formatted string for matches
+        """
+        return json.dumps([m.as_dict() for m in matches], indent=2)

--- a/lib/ansiblelint/formatters/base.py
+++ b/lib/ansiblelint/formatters/base.py
@@ -1,0 +1,29 @@
+r"""Abstract formatters
+"""
+from __future__ import absolute_import
+import os
+
+
+class BaseFormatter(object):
+
+    @classmethod
+    def name(cls):
+        return getattr(cls, "_name",
+                       cls.__name__.replace("Formatter", "").lower())
+
+    def formats(self, matches, colored=False, **kwargs):
+        """
+        :param matches: A list of :class:`ansiblelint.Match` objects or []
+        :param colored: Colored output will be returned if True
+        :return: Formatted string for matches
+        """
+        return os.linesep.join(self.format(m, colored=colored, **kwargs) for m
+                               in matches)
+
+    def format(self, match, colored=False, **kwargs):
+        """
+        :param match: :class:`ansiblelint.Match` object
+        :param colored: Colored output will be returned if True
+        :return: Formatted string for match
+        """
+        return ""

--- a/test/TestFormatter.py
+++ b/test/TestFormatter.py
@@ -43,3 +43,9 @@ class TestFormatter(unittest.TestCase):
     def test_dict_format_line(self):
         match = Match(1, {'hello': 'world'}, "filename.yml", self.rule, "xyz")
         result = self.formatter.format(match, True)
+
+    def test_formats(self):
+        matches = (Match(1, "hello", "filename.yml", self.rule, "message"),
+                   Match(1, "hello", "filename.yml", self.rule, u'\U0001f427'),
+                   Match(1, {'hello': 'world'}, "filename.yml", self.rule, "xyz"))
+        result = self.formatter.formats(matches, colored=True)

--- a/test/TestRunner.py
+++ b/test/TestRunner.py
@@ -70,6 +70,13 @@ class TestRule(unittest.TestCase):
         formatter = ansiblelint.formatters.Formatter()
         formatter.format(matches[0], colored=True)
 
+    def test_unicode_json_formats(self):
+        filename = 'test/unicode.yml'
+        runner = Runner(self.rules, filename, [], [], [])
+        matches = runner.run()
+        formatter = ansiblelint.formatters.JsonFormatter()
+        assert formatter.formats(matches, colored=True)
+
     def test_runner_excludes_paths(self):
         filename = 'examples/lots_of_warnings.yml'
         excludes = ['examples/lots_of_warnings.yml']


### PR DESCRIPTION
This PR adds a feature to support JSON formatted output and -F/--format option to chose output format along with misc. changes and refactorings to ansible-lint.

Here is an example session log w/ this changes:
```
ssato@localhost% PYTHONPATH=./lib python3 bin/ansible-lint -vv test/always-run-failure.yml
Examining test/always-run-failure.yml of type playbook
[101] Deprecated always_run
test/always-run-failure.yml:4
Task/Handler: always_run is deprecated

ssato@localhost% PYTHONPATH=./lib python3 bin/ansible-lint -vv -q test/always-run-failure.yml
Examining test/always-run-failure.yml of type playbook
[101] test/always-run-failure.yml:4
ssato@localhost% PYTHONPATH=./lib python3 bin/ansible-lint -vv -p test/always-run-failure.yml
Examining test/always-run-failure.yml of type playbook
test/always-run-failure.yml:4: [E101] Deprecated always_run
ssato@localhost% for f in default quiet parseable json; do
for> PYTHONPATH=./lib python3 bin/ansible-lint -vv -F $f test/always-run-failure.yml
for> done
Examining test/always-run-failure.yml of type playbook
[101] Deprecated always_run
test/always-run-failure.yml:4
Task/Handler: always_run is deprecated

Examining test/always-run-failure.yml of type playbook
[101] test/always-run-failure.yml:4
Examining test/always-run-failure.yml of type playbook
test/always-run-failure.yml:4: [E101] Deprecated always_run
Examining test/always-run-failure.yml of type playbook
[
  {
    "rule_id": "101",
    "message": "Deprecated always_run",
    "filename": "test/always-run-failure.yml",
    "linenumber": 4,
    "line": "Task/Handler: always_run is deprecated"
  }
]
ssato@localhost%
```

P.S. I made the commits separated into primitive ones as much as I could and it should be easy to cherry-pick some of the changes in this PR if entire changes are not accepted, or if some additional works are needed to merge them, please let me know.