### PR TITLE
Move repo to github.com/ansible

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -17,6 +17,8 @@ ansible-lint --version
 Please give some details of the feature being requested
 or what should happen if providing a bug report
 
+Possible security bugs should be reported via email to `security@ansible.com`
+
 # Actual Behaviour (Bug report only)
 
 Please give some details of what is actually happening.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,25 +3,29 @@ Contributing to Ansible-lint
 
 To contribute to ansible-lint, please use pull requests on a branch of your own fork.
 
-After creating your fork on github, you can do:
+After [creating your fork on GitHub](https://guides.github.com/activities/forking/), you can do:
+
 ```
 git clone git@github.com:yourname/ansible-lint
 cd ansible-lint
 git checkout -b your-branch-name
 DO SOME CODING HERE
 git add your new files
-git commit
+git commit --signoff
 git push origin your-branch-name
 ```
-You will then be able to create a pull request from your commit. 
+
+Contributors to ansible-lint must agree to [DCO 1.1](./DCO_1_1.md)
+
+You will then be able to create a pull request from your commit.
 
 All fixes to core functionality (i.e. anything except rules or examples) should
-be accompanied by tests that fail prior to your change and succeed afterwards. 
+be accompanied by tests that fail prior to your change and succeed afterwards.
 
 Feel free to raise issues in the repo if you don't feel able to contribute a code fix.
 
 Standards
-=========
+---------
 
 ansible-lint is flake8 compliant with `max-line-length` set to 100
 (see [setup.cfg](setup.cfg)).
@@ -32,3 +36,18 @@ with both.
 
 Automated tests will be run against all PRs for flake8 compliance and Ansible
 compatibility - to check before pushing commits, just use `tox`.
+
+Talk to us
+----------
+
+Discussion around ansible-lint happens in `#ansible-galaxy` IRC channel on Freenode and the [Ansible Development List](https://groups.google.com/forum/#!forum/ansible-devel)
+
+For the full list of Ansible IRC and Mailing list, please see the [Ansible Communication](https://docs.ansible.com/ansible/latest/community/communication.html) page
+Release announcements will be made to the [Ansible Announce](https://groups.google.com/forum/#!forum/ansible-announce) list.
+
+Possible security bugs should be reported via email to `security@ansible.com`
+
+Code of Conduct
+---------------
+
+As with all Ansible projects, we have a [Code of Conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html)

--- a/DCO_1_1.md
+++ b/DCO_1_1.md
@@ -1,0 +1,45 @@
+DCO
+===
+
+All contributors must use `git commit --signoff` for any
+commit to be merged, and agree that usage of --signoff constitutes
+agreement with the terms of DCO 1.1, which appears below:
+
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,6 @@
-Copyright (c) 2013-2014 Will Thames <will@thames.id.au>
+Copyright (c) 2013-2018 Will Thames <will@thames.id.au>
+Copyright (c) 2018 Ansible by Red Hat
+
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -271,8 +271,7 @@ ansible-lint containing `hooks.yaml`.
 Contributing
 ------------
 
-Please read
-[CONTRIBUTING.md](https://github.com/ansible/ansible-lint/blob/master/CONTRIBUTING.md) if you wish to contribute.
+Please read [CONTRIBUTING.md](https://github.com/ansible/ansible-lint/blob/master/CONTRIBUTING.md) if you wish to contribute.
 
 Authors
 -------

--- a/README.md
+++ b/README.md
@@ -5,19 +5,21 @@ ansible-lint checks playbooks for practices and behaviour that could
 potentially be improved
 
 [![PyPI version](https://img.shields.io/pypi/v/ansible-lint.svg)](https://pypi.org/project/ansible-lint/)
-[![Build Status](https://travis-ci.org/willthames/ansible-lint.svg?branch=master)](https://travis-ci.org/willthames/ansible-lint)
+[![Build Status](https://travis-ci.org/ansible/ansible-lint.svg?branch=master)](https://travis-ci.org/ansible/ansible-lint)
 
 Setup
 -----
 
 Using pip:
+
 ```
 pip2 install ansible-lint
 ```
 
 From source:
+
 ```
-git clone https://github.com/willthames/ansible-lint
+git clone https://github.com/ansible/ansible-lint
 export PYTHONPATH=$PYTHONPATH:`pwd`/ansible-lint/lib
 export PATH=$PATH:`pwd`/ansible-lint/bin
 ```
@@ -56,7 +58,7 @@ Options:
 ```
 
 False positives
-===============
+---------------
 
 Some rules are a bit of a rule of thumb. Advanced git, yum or apt usage,
 for example, is typically difficult to achieve through the modules. In
@@ -83,18 +85,19 @@ at this time! (patches welcome)
     warn: False
 
 - name: this would typically fire GitHasVersionRule
-  git: src=/path/to/git/repo dest=checkout 
+  git: src=/path/to/git/repo dest=checkout
   tags:
   - skip_ansible_lint
 ```
 
 Rules
-=====
+-----
 
 Rules are described using a class file per rule.
 Default rules are named `DeprecatedVariableRule.py`, etc.
 
 Each rule definition should have the following:
+
 * ID: A unique identifier
 * Short description: Brief description of the rule
 * Description: Behaviour the rule is looking for
@@ -109,7 +112,6 @@ Each rule definition should have the following:
       `module_arguments` key. Other common task modifiers such as
       `when`, `with_items` etc. are also available as keys if present
       in the task.
-
 
 An example rule using `match` is:
 
@@ -189,11 +191,11 @@ Task/Handler: using git module
 
 [ANSIBLE0002] Trailing whitespace
 examples/example.yml:13
-    action: do nothing   
+    action: do nothing
 
 [ANSIBLE0002] Trailing whitespace
 examples/example.yml:35
-    with_items: 
+    with_items:
 
 [ANSIBLE0006] git used in place of git module
 examples/example.yml:24
@@ -218,12 +220,11 @@ $ bin/ansible-lint examples/include.yml
 action: git a=b c=d
 ```
 
-As of version 2.4.0, ansible-lint now works just on roles (this is useful 
+As of version 2.4.0, ansible-lint now works just on roles (this is useful
 for CI of roles)
 
-
 Configuration File
-==================
+------------------
 
 Ansible-lint supports local configuration via a `.ansible-lint` configuration file.  Ansible-lint checks the working directory for the presence of this file and applies any configuration found there.  The configuration file location can also be overridden via the `-c path/to/file` CLI flag.
 
@@ -251,26 +252,29 @@ use_default_rules: true
 verbosity: 1
 ```
 
-
 Pre-commit
-==========
+----------
 
-To use ansible-lint with [pre-commit](http://pre-commit.com/), just 
-add the following to your local repo's `.pre-commit-config.yaml` file. 
-Make sure to change `sha:` to be either a git commit sha or tag of 
+To use ansible-lint with [pre-commit](http://pre-commit.com/), just
+add the following to your local repo's `.pre-commit-config.yaml` file.
+Make sure to change `sha:` to be either a git commit sha or tag of
 ansible-lint containing `hooks.yaml`.
 
 ```yaml
-- repo: https://github.com/willthames/ansible-lint.git
+- repo: https://github.com/ansible/ansible-lint.git
   sha: v3.3.1
   hooks:
     - id: ansible-lint
       files: \.(yaml|yml)$
 ```
 
-
 Contributing
-============
+------------
 
 Please read
-[CONTRIBUTING.md](https://github.com/willthames/ansible-lint/blob/master/CONTRIBUTING.md) if you wish to contribute.
+[CONTRIBUTING.md](https://github.com/ansible/ansible-lint/blob/master/CONTRIBUTING.md) if you wish to contribute.
+
+Authors
+-------
+
+ansible-lint was created by [Will Thames](https://github.com/willthames) and is not maintained as part of the [Ansible](https://ansible.com) project.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ ansible-lint checks playbooks for practices and behaviour that could
 potentially be improved
 
 [![PyPI version](https://img.shields.io/pypi/v/ansible-lint.svg)](https://pypi.org/project/ansible-lint/)
-[![Build Status](https://travis-ci.org/ansible/ansible-lint.svg?branch=master)](https://travis-ci.org/ansible/ansible-lint)
+[![Build Status](https://travis-ci.com/ansible/ansible-lint.svg?branch=master)](https://travis-ci.com/ansible/ansible-lint)
 
 Setup
 -----
@@ -191,11 +191,11 @@ Task/Handler: using git module
 
 [ANSIBLE0002] Trailing whitespace
 examples/example.yml:13
-    action: do nothing
+    action: do nothing   
 
 [ANSIBLE0002] Trailing whitespace
 examples/example.yml:35
-    with_items:
+    with_items: 
 
 [ANSIBLE0006] git used in place of git module
 examples/example.yml:24
@@ -276,4 +276,4 @@ Please read [CONTRIBUTING.md](https://github.com/ansible/ansible-lint/blob/maste
 Authors
 -------
 
-ansible-lint was created by [Will Thames](https://github.com/willthames) and is now maintained as part of the [Ansible](https://ansible.com) project.
+ansible-lint was created by [Will Thames](https://github.com/willthames) and is now maintained as part of the [Ansible](https://ansible.com) by Red Hat project.

--- a/README.md
+++ b/README.md
@@ -277,4 +277,4 @@ Please read
 Authors
 -------
 
-ansible-lint was created by [Will Thames](https://github.com/willthames) and is not maintained as part of the [Ansible](https://ansible.com) project.
+ansible-lint was created by [Will Thames](https://github.com/willthames) and is now maintained as part of the [Ansible](https://ansible.com) project.

--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -433,7 +433,7 @@ def normalize_task_v1(task):
                     else:
                         # Tasks that include playbooks (rather than task files)
                         # can get here
-                        # https://github.com/willthames/ansible-lint/issues/138
+                        # https://github.com/ansible/ansible-lint/issues/138
                         raise RuntimeError("Was not expecting value %s of type %s for key %s\n"
                                            "Task: %s. Check the syntax of your playbook using "
                                            "ansible-playbook --syntax-check" %

--- a/setup.py
+++ b/setup.py
@@ -13,16 +13,16 @@ setup(
     version=__version__,
     description=('checks playbooks for practices and behaviour that could potentially be improved'),
     keywords='ansible, lint',
-    author='Will Thames',
-    author_email='will@thames.id.au',
-    url='https://github.com/willthames/ansible-lint',
+    author='Ansible by Red Hat',
+    author_email='info@ansible.com',
+    url='https://github.com/ansible/ansible-lint',
     package_dir={'': 'lib'},
     packages=find_packages('lib'),
     zip_safe=False,
     install_requires=['ansible', 'pyyaml', 'six'],
     entry_points={
         'console_scripts': [
-             'ansible-lint = ansiblelint.__main__:main'
+            'ansible-lint = ansiblelint.__main__:main'
         ]
     },
     license='MIT',

--- a/setup.py
+++ b/setup.py
@@ -11,10 +11,10 @@ exec(open('lib/ansiblelint/version.py').read())
 setup(
     name='ansible-lint',
     version=__version__,
-    description=('checks playbooks for practices and behaviour that could potentially be improved'),
+    description='checks playbooks for practices and behaviour that could potentially be improved',
     keywords='ansible, lint',
-    author='Ansible by Red Hat',
-    author_email='info@ansible.com',
+    maintainer='Ansible by Red Hat',
+    maintainer_email='info@ansible.com',
     url='https://github.com/ansible/ansible-lint',
     package_dir={'': 'lib'},
     packages=find_packages('lib'),


### PR DESCRIPTION
Prepare for repo move
Red Hat are now the maintainers
Bulk update to follow Ansible project guidelines

* Thank willthames for his work
* Detail DCO requirement
* Link to IRC/Mailing lists
* Tidy up markdown files
* `ISSUE_TEMPLATE` into `.github` as it's not for people viewing the repo


Background see https://groups.google.com/forum/#!topic/ansible-devel/U8_Lxg7wAHA

Part of https://github.com/ansible/community/issues/366