### PR TITLE
Fix running with role path containing single or multiple dirs

### DIFF
--- a/lib/ansiblelint/__init__.py
+++ b/lib/ansiblelint/__init__.py
@@ -185,13 +185,7 @@ class Runner(object):
         self.playbooks = set()
         # assume role if directory
         if os.path.isdir(playbook):
-            # only have trailing slash when path has multiple dirs
-            playbook = os.path.normpath(playbook)
-            if '/' in playbook.lstrip('/'):
-                self.playbooks.add((os.path.join(playbook, ''), 'role'))
-            else:
-                self.playbooks.add((playbook, 'role'))
-
+            self.playbooks.add((os.path.join(playbook, ''), 'role'))
             self.playbook_dir = playbook
         else:
             self.playbooks.add((playbook, 'playbook'))

--- a/lib/ansiblelint/__init__.py
+++ b/lib/ansiblelint/__init__.py
@@ -185,7 +185,13 @@ class Runner(object):
         self.playbooks = set()
         # assume role if directory
         if os.path.isdir(playbook):
-            self.playbooks.add((os.path.join(playbook, ''), 'role'))
+            # only have trailing slash when path has multiple dirs
+            playbook = os.path.normpath(playbook)
+            if '/' in playbook.lstrip('/'):
+                self.playbooks.add((os.path.join(playbook, ''), 'role'))
+            else:
+                self.playbooks.add((playbook, 'role'))
+
             self.playbook_dir = playbook
         else:
             self.playbooks.add((playbook, 'playbook'))

--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -307,7 +307,8 @@ def _rolepath(basedir, role):
         path_dwim(
             basedir, os.path.join('..', '..', '..', 'roles', role)
         ),
-        path_dwim(basedir, os.path.join('..', '..', role))
+        path_dwim(basedir, os.path.join('..', '..', role)),
+        path_dwim(basedir, ''),
     ]
 
     if constants.DEFAULT_ROLES_PATH:

--- a/test/TestCliRolePaths.py
+++ b/test/TestCliRolePaths.py
@@ -1,0 +1,69 @@
+import unittest
+import subprocess
+import os
+
+
+class TestCliRolePaths(unittest.TestCase):
+    def setUp(self):
+        self.local_test_dir = os.path.dirname(os.path.realpath(__file__))
+
+    def run_ansible_lint(self, cwd, bin, role_path):
+        command = '{} {}'.format(bin, role_path)
+
+        result, err = subprocess.Popen(
+            [command],
+            cwd=cwd,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            shell=True
+        ).communicate()
+
+        self.assertFalse(err, 'Expected no error but was ' + str(err))
+
+        return result
+
+    def test_run_single_role_path_no_trailing_slash(self):
+        cwd = self.local_test_dir
+        bin = '../bin/ansible-lint'
+        role_path = 'test-role'
+
+        result = self.run_ansible_lint(cwd=cwd, bin=bin, role_path=role_path)
+        self.assertIn('Use shell only when shell functionality is required',
+                      str(result))
+
+    def test_run_single_role_path_with_trailing_slash(self):
+        cwd = self.local_test_dir
+        bin = '../bin/ansible-lint'
+        role_path = 'test-role/'
+
+        result = self.run_ansible_lint(cwd=cwd, bin=bin, role_path=role_path)
+        self.assertIn('Use shell only when shell functionality is required',
+                      str(result))
+
+    def test_run_multiple_role_path_no_trailing_slash(self):
+        cwd = self.local_test_dir
+        bin = '../bin/ansible-lint'
+        role_path = 'roles/test-role'
+
+        result = self.run_ansible_lint(cwd=cwd, bin=bin, role_path=role_path)
+        self.assertIn('Use shell only when shell functionality is required',
+                      str(result))
+
+    def test_run_multiple_role_path_with_trailing_slash(self):
+        cwd = self.local_test_dir
+        bin = '../bin/ansible-lint'
+        role_path = 'roles/test-role/'
+
+        result = self.run_ansible_lint(cwd=cwd, bin=bin, role_path=role_path)
+        self.assertIn('Use shell only when shell functionality is required',
+                      str(result))
+
+    def test_run_inside_role_dir(self):
+        cwd = os.path.join(self.local_test_dir, 'test-role/')
+        bin = '../../bin/ansible-lint'
+        role_path = '.'
+
+        result = self.run_ansible_lint(cwd=cwd, bin=bin, role_path=role_path)
+        self.assertIn('Use shell only when shell functionality is required',
+                      str(result))

--- a/test/TestCliRolePaths.py
+++ b/test/TestCliRolePaths.py
@@ -67,3 +67,12 @@ class TestCliRolePaths(unittest.TestCase):
         result = self.run_ansible_lint(cwd=cwd, bin=bin, role_path=role_path)
         self.assertIn('Use shell only when shell functionality is required',
                       str(result))
+
+    def test_run_role_three_dir_deep(self):
+        cwd = self.local_test_dir
+        bin = '../bin/ansible-lint'
+        role_path = 'roles/roles/test-role'
+
+        result = self.run_ansible_lint(cwd=cwd, bin=bin, role_path=role_path)
+        self.assertIn('Use shell only when shell functionality is required',
+                      str(result))

--- a/test/roles/roles/test-role/tasks/main.yml
+++ b/test/roles/roles/test-role/tasks/main.yml
@@ -1,0 +1,2 @@
+- name: shell instead of command
+  shell: echo hello world

--- a/test/roles/test-role/tasks/main.yml
+++ b/test/roles/test-role/tasks/main.yml
@@ -1,0 +1,2 @@
+- name: shell instead of command
+  shell: echo hello world


### PR DESCRIPTION
Fixes #210 - this PR only adds the trailing slash when multiple dirs are in the role path, and allows these 5 role path scenarios to function:

`code$ ansible-lint -p my_role/`  3.5.1 no output, 3.4.23 no output
`code$ ansible-lint -p my_role`   3.5.1 no output
`~$ ansible-lint -p code/my_role/`
`~$ ansible-lint -p code/my_role`    3.4.23 no output
`my_role$ ansible-lint -p .`

Test cases were added for each scenario.