### PR TITLE
Without this ansible-lint will fail if meta/main.yml has dependent ro…

### DIFF
--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -299,6 +299,9 @@ def _load_library_if_exists(path):
 def _rolepath(basedir, role):
     role_path = None
 
+    if role is None:
+        raise SystemExit('role name cannot be empty')
+
     possible_paths = [
         # if included from a playbook
         path_dwim(basedir, os.path.join('roles', role)),


### PR DESCRIPTION
…le without name. The approach is probable incorrect, but if you'll give me a hint I can fix it properly.