### PR TITLE
Deduplicate texts: reuse chunks from README in Sphinx docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -239,14 +239,16 @@ are also handled:
 As of version 2.4.0, ansible-lint now works just on roles (this is useful
 for CI of roles)
 
+.. config-file-docs-inclusion-marker-do-not-remove
+
 Configuration File
-------------------
+==================
 
 Ansible-lint supports local configuration via a ``.ansible-lint`` configuration file.  Ansible-lint checks the working directory for the presence of this file and applies any configuration found there.  The configuration file location can also be overridden via the ``-c path/to/file`` CLI flag.
 
 The following values are supported and function identically to their CLI counterparts.
 
-If a value is provided on both the command line and via a config file, the values will be merged (if a list like ``exclude_paths``), or the "True" value will be preferred, in the case of something like ``quiet``.
+If a value is provided on both the command line and via a config file, the values will be merged (if a list like **exclude_paths**), or the **True** value will be preferred, in the case of something like **quiet**.
 
 .. code:: yaml
 
@@ -267,6 +269,8 @@ If a value is provided on both the command line and via a config file, the value
       - run_this_tag
     use_default_rules: true
     verbosity: 1
+
+.. config-file-docs-inclusion-marker-end-do-not-remove
 
 .. pre-commit-docs-inclusion-marker-do-not-remove
 

--- a/README.rst
+++ b/README.rst
@@ -268,8 +268,10 @@ If a value is provided on both the command line and via a config file, the value
     use_default_rules: true
     verbosity: 1
 
+.. pre-commit-docs-inclusion-marker-do-not-remove
+
 Pre-commit
-----------
+==========
 
 To use ansible-lint with pre-commit_, just
 add the following to your local repo's ``.pre-commit-config.yaml`` file.
@@ -282,6 +284,8 @@ ansible-lint containing ``hooks.yaml``.
       sha: v3.3.1
       hooks:
         - id: ansible-lint
+
+.. pre-commit-docs-inclusion-marker-end-do-not-remove
 
 Contributing
 ------------

--- a/docs/docsite/rst/configuring/configuring.rst
+++ b/docs/docsite/rst/configuring/configuring.rst
@@ -9,34 +9,10 @@ Configuring
 
 This topic describes how to configure Ansible Lint
 
-Configuration File
-==================
 
-Ansible-lint supports local configuration via a ``.ansible-lint`` configuration file. Ansible-lint checks the working directory for the presence of this file and applies any configuration found there. The configuration file location can also be overridden via the ``-c path/to/file`` CLI flag.
-
-If a value is provided on both the command line and via a config file, the values will be merged (if a list like **exclude_paths**), or the **True** value will be preferred, in the case of something like **quiet**.
-
-The following values are supported, and function identically to their CLI counterparts:
-
-.. code-block:: yaml
-
-    exclude_paths:
-      - ./my/excluded/directory/
-      - ./my/other/excluded/directory/
-      - ./last/excluded/directory/
-    parseable: true
-    quiet: true
-    rulesdir:
-      - ./rule/directory/
-    skip_list:
-      - skip_this_tag
-      - and_this_one_too
-      - skip_this_id
-      - '401'
-    tags:
-      - run_this_tag
-    use_default_rules: true
-    verbosity: 1
+.. include:: ../../../../README.rst
+   :start-after: config-file-docs-inclusion-marker-do-not-remove
+   :end-before: config-file-docs-inclusion-marker-end-do-not-remove
 
 
 .. include:: ../../../../README.rst

--- a/docs/docsite/rst/configuring/configuring.rst
+++ b/docs/docsite/rst/configuring/configuring.rst
@@ -39,15 +39,6 @@ The following values are supported, and function identically to their CLI counte
     verbosity: 1
 
 
-Pre-commit
-==========
-
-To use ansible-lint with `pre-commit <http://pre-commit.com>`_, just add the following to your local repo's ``.pre-commit-config.yaml`` file. Make sure to change **sha:** to be either a git commit sha or tag of ansible-lint containing ``hooks.yaml``.
-
-.. code-block:: yaml
-
-    - repo: https://github.com/ansible/ansible-lint.git
-      sha: v3.3.1
-      hooks:
-        - id: ansible-lint
-          files: \.(yaml|yml)$
+.. include:: ../../../../README.rst
+   :start-after: pre-commit-docs-inclusion-marker-do-not-remove
+   :end-before: pre-commit-docs-inclusion-marker-end-do-not-remove


### PR DESCRIPTION
This is a demo of how to stop maintaining multiple copies of the same content having to remember to synchronize all of them. This PR only touches one docs page, but there's much more things which don't match repo README file, which is also visible through multiple places on the Internet (repo view in github, PyPI etc.)