### PR TITLE
Exclude packages that have `state` set to `absent`.

### DIFF
--- a/lib/ansiblelint/rules/PackageHasRetryRule.py
+++ b/lib/ansiblelint/rules/PackageHasRetryRule.py
@@ -18,7 +18,7 @@ class PackageHasRetryRule(AnsibleLintRule):
     #   | sort | awk -F '/' \
     #   '/__|dpkg|_repo|_facts|_sub|_chan/{next} {split($NF, words, ".");
     #   print "\""words[1]"\","}'
-    package_modules = [
+    _package_modules = [
         "apk",
         "apt_key",
         "apt",
@@ -67,6 +67,16 @@ class PackageHasRetryRule(AnsibleLintRule):
         "zypper",
     ]
 
+    _module_ignore_states = [
+        "absent",
+    ]
+
     def matchtask(self, file, task):
-        return (task['action']['__ansible_module__'] in self.package_modules
-                and 'until' not in task)
+        module = task["action"]["__ansible_module__"]
+        if module in self._package_modules:
+            if 'until' not in task:
+                # Exclude tasks where state is `absent`.
+                if task['action'].get('state') not in self._module_ignore_states:
+                    message = '{0} {1}'
+                    return message.format(self.shortdesc, module)
+                return False

--- a/test/TestPackageHasRetry.py
+++ b/test/TestPackageHasRetry.py
@@ -13,6 +13,11 @@ SUCCESS = '''
         pkg: foo
       register: result
       until: result|success
+
+    - name: remove software
+      package:
+        name: some_package
+        state: absent
 '''
 
 FAILURE = '''


### PR DESCRIPTION
Signed-off-by: Robert de Bock <robert@meinit.nl>

This PR solved #405 by excluding tasks that have `state` set to `absent`. Tests are included in pass locally using `tox`.