### PR TITLE
Add a severity property to the default rules

### DIFF
--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -65,6 +65,10 @@ def main():
                       default=False,
                       action='store_true',
                       help="parseable output in the format of pep8")
+    parser.add_option('--parseable-severity', dest='parseable_severity',
+                      default=False,
+                      action='store_true',
+                      help="parseable output including severity of rule")
     parser.add_option('-r', action='append', dest='rulesdir',
                       default=[], type='str',
                       help="specify one or more rules directories using "
@@ -113,6 +117,10 @@ def main():
         if 'parseable' in config:
             options.parseable = options.parseable or config['parseable']
 
+        if 'parseable_severity' in config:
+            options.parseable_severity = options.parseable_severity or \
+                                         config['parseable_severity']
+
         if 'use_default_rules' in config:
             options.use_default_rules = options.use_default_rules or config['use_default_rules']
 
@@ -136,6 +144,9 @@ def main():
 
     if options.parseable:
         formatter = formatters.ParseableFormatter()
+
+    if options.parseable_severity:
+        formatter = formatters.ParseableSeverityFormatter()
 
     if len(args) == 0 and not (options.listrules or options.listtags):
         parser.print_help(file=sys.stderr)

--- a/lib/ansiblelint/formatters/__init__.py
+++ b/lib/ansiblelint/formatters/__init__.py
@@ -52,3 +52,31 @@ class ParseableFormatter(object):
                                     match.linenumber,
                                     "E" + match.rule.id,
                                     match.message)
+
+
+class ParseableSeverityFormatter(object):
+
+    def format(self, match, colored=False):
+        formatstr = u"{0}:{1}: [{2}] [{3}] {4}"
+
+        filename = match.filename
+        linenumber = str(match.linenumber)
+        rule_id = u"E{0}".format(match.rule.id)
+        severity = match.rule.severity
+        message = str(match.message)
+
+        if colored:
+            color.ANSIBLE_COLOR = True
+            filename = color.stringc(filename, 'blue')
+            linenumber = color.stringc(linenumber, 'cyan')
+            rule_id = color.stringc(rule_id, 'bright red')
+            severity = color.stringc(severity, 'bright red')
+            message = color.stringc(message, 'red')
+
+        return formatstr.format(
+            filename,
+            linenumber,
+            rule_id,
+            severity,
+            message,
+        )

--- a/lib/ansiblelint/rules/AlwaysRunRule.py
+++ b/lib/ansiblelint/rules/AlwaysRunRule.py
@@ -25,6 +25,7 @@ class AlwaysRunRule(AnsibleLintRule):
     id = '101'
     shortdesc = 'Deprecated always_run'
     description = 'Instead of ``always_run``, use ``check_mode``'
+    severity = 'MEDIUM'
     tags = ['deprecated', 'ANSIBLE0018']
     version_added = 'historic'
 

--- a/lib/ansiblelint/rules/BecomeUserWithoutBecomeRule.py
+++ b/lib/ansiblelint/rules/BecomeUserWithoutBecomeRule.py
@@ -29,6 +29,7 @@ class BecomeUserWithoutBecomeRule(AnsibleLintRule):
     id = '501'
     shortdesc = 'become_user requires become to work as expected'
     description = '``become_user`` without ``become`` will not actually change user'
+    severity = 'VERY_HIGH'
     tags = ['task', 'oddity', 'ANSIBLE0017']
     version_added = 'historic'
 

--- a/lib/ansiblelint/rules/CommandHasChangesCheckRule.py
+++ b/lib/ansiblelint/rules/CommandHasChangesCheckRule.py
@@ -30,6 +30,7 @@ class CommandHasChangesCheckRule(AnsibleLintRule):
         'done (using creates/removes) or only do it if another '
         'check has a particular result (``when``)'
     )
+    severity = 'HIGH'
     tags = ['command-shell', 'idempotency', 'ANSIBLE0012']
     version_added = 'historic'
 

--- a/lib/ansiblelint/rules/CommandsInsteadOfArgumentsRule.py
+++ b/lib/ansiblelint/rules/CommandsInsteadOfArgumentsRule.py
@@ -41,6 +41,7 @@ class CommandsInsteadOfArgumentsRule(AnsibleLintRule):
         'Executing a command when there are arguments to modules '
         'is generally a bad idea'
     )
+    severity = 'VERY_HIGH'
     tags = ['command-shell', 'resources', 'ANSIBLE0007']
     version_added = 'historic'
 

--- a/lib/ansiblelint/rules/CommandsInsteadOfModulesRule.py
+++ b/lib/ansiblelint/rules/CommandsInsteadOfModulesRule.py
@@ -41,6 +41,7 @@ class CommandsInsteadOfModulesRule(AnsibleLintRule):
         'Executing a command when there is an Ansible module '
         'is generally a bad idea'
     )
+    severity = 'HIGH'
     tags = ['command-shell', 'resources', 'ANSIBLE0006']
     version_added = 'historic'
 

--- a/lib/ansiblelint/rules/ComparisonToEmptyStringRule.py
+++ b/lib/ansiblelint/rules/ComparisonToEmptyStringRule.py
@@ -12,6 +12,7 @@ class ComparisonToEmptyStringRule(AnsibleLintRule):
         'Use ``when: var`` rather than ``when: var != ""`` (or '
         'conversely ``when: not var`` rather than ``when: var == ""``)'
     )
+    severity = 'HIGH'
     tags = ['idiom']
     version_added = 'v4.0.0'
 

--- a/lib/ansiblelint/rules/ComparisonToLiteralBoolRule.py
+++ b/lib/ansiblelint/rules/ComparisonToLiteralBoolRule.py
@@ -12,6 +12,7 @@ class ComparisonToLiteralBoolRule(AnsibleLintRule):
         'Use ``when: var`` rather than ``when: var == True`` '
         '(or conversely ``when: not var``)'
     )
+    severity = 'HIGH'
     tags = ['idiom']
     version_added = 'v4.0.0'
 

--- a/lib/ansiblelint/rules/DeprecatedModuleRule.py
+++ b/lib/ansiblelint/rules/DeprecatedModuleRule.py
@@ -12,7 +12,7 @@ class DeprecatedModuleRule(AnsibleLintRule):
         'For more details see: '
         'https://docs.ansible.com/ansible/latest/modules/list_of_all_modules.html'
     )
-
+    severity = 'HIGH'
     tags = ['deprecated']
     version_added = 'v4.0.0'
 

--- a/lib/ansiblelint/rules/EnvVarsInCommandRule.py
+++ b/lib/ansiblelint/rules/EnvVarsInCommandRule.py
@@ -29,6 +29,7 @@ class EnvVarsInCommandRule(AnsibleLintRule):
         'Environment variables should be passed to ``shell`` or ``command`` '
         'through environment argument'
     )
+    severity = 'VERY_HIGH'
     tags = ['command-shell', 'bug', 'ANSIBLE0014']
     version_added = 'historic'
 

--- a/lib/ansiblelint/rules/GitHasVersionRule.py
+++ b/lib/ansiblelint/rules/GitHasVersionRule.py
@@ -28,6 +28,7 @@ class GitHasVersionRule(AnsibleLintRule):
         'All version control checkouts must point to '
         'an explicit commit or tag, not just ``latest``'
     )
+    severity = 'MEDIUM'
     tags = ['module', 'repeatability', 'ANSIBLE0004']
     version_added = 'historic'
 

--- a/lib/ansiblelint/rules/LineTooLongRule.py
+++ b/lib/ansiblelint/rules/LineTooLongRule.py
@@ -11,6 +11,7 @@ class LineTooLongRule(AnsibleLintRule):
         'Long lines make code harder to read and '
         'code review more difficult'
     )
+    severity = 'VERY_LOW'
     tags = ['formatting']
     version_added = 'v4.0.0'
 

--- a/lib/ansiblelint/rules/MercurialHasRevisionRule.py
+++ b/lib/ansiblelint/rules/MercurialHasRevisionRule.py
@@ -28,6 +28,7 @@ class MercurialHasRevisionRule(AnsibleLintRule):
         'All version control checkouts must point to '
         'an explicit commit or tag, not just ``latest``'
     )
+    severity = 'MEDIUM'
     tags = ['module', 'repeatability', 'ANSIBLE0005']
     version_added = 'historic'
 

--- a/lib/ansiblelint/rules/MetaChangeFromDefaultRule.py
+++ b/lib/ansiblelint/rules/MetaChangeFromDefaultRule.py
@@ -17,6 +17,7 @@ class MetaChangeFromDefaultRule(AnsibleLintRule):
             ', '.join([f[0] for f in field_defaults])
         )
     )
+    severity = 'HIGH'
     tags = ['metadata']
     version_added = 'v4.0.0'
 

--- a/lib/ansiblelint/rules/MetaMainHasInfoRule.py
+++ b/lib/ansiblelint/rules/MetaMainHasInfoRule.py
@@ -17,6 +17,7 @@ class MetaMainHasInfoRule(AnsibleLintRule):
     description = (
         'meta/main.yml should contain: ``{}``'.format(', '.join(info))
     )
+    severity = 'HIGH'
     tags = ['metadata']
     version_added = 'v4.0.0'
 

--- a/lib/ansiblelint/rules/MetaTagValidRule.py
+++ b/lib/ansiblelint/rules/MetaTagValidRule.py
@@ -11,6 +11,7 @@ class MetaTagValidRule(AnsibleLintRule):
         'Tags must contain lowercase letters and digits only, '
         'and ``galaxy_tags`` is expected to be a list'
     )
+    severity = 'HIGH'
     tags = ['metadata']
     version_added = 'v4.0.0'
 

--- a/lib/ansiblelint/rules/MetaVideoLinksRule.py
+++ b/lib/ansiblelint/rules/MetaVideoLinksRule.py
@@ -13,6 +13,7 @@ class MetaVideoLinksRule(AnsibleLintRule):
         'dictionaries, and contain only keys ``url`` and ``title``, '
         'and have a shared link from a supported provider'
     )
+    severity = 'LOW'
     tags = ['metadata']
     version_added = 'v4.0.0'
 

--- a/lib/ansiblelint/rules/NoFormattingInWhenRule.py
+++ b/lib/ansiblelint/rules/NoFormattingInWhenRule.py
@@ -10,6 +10,7 @@ class NoFormattingInWhenRule(AnsibleLintRule):
     id = '102'
     shortdesc = 'No Jinja2 in when'
     description = '``when`` lines should not include Jinja2 variables'
+    severity = 'HIGH'
     tags = ['deprecated', 'ANSIBLE0019']
     version_added = 'historic'
 

--- a/lib/ansiblelint/rules/NoTabsRule.py
+++ b/lib/ansiblelint/rules/NoTabsRule.py
@@ -8,6 +8,7 @@ class NoTabsRule(AnsibleLintRule):
     id = '203'
     shortdesc = 'Most files should not contain tabs'
     description = 'Tabs can cause unexpected display issues, use spaces'
+    severity = 'LOW'
     tags = ['formatting']
     version_added = 'v4.0.0'
 

--- a/lib/ansiblelint/rules/OctalPermissionsRule.py
+++ b/lib/ansiblelint/rules/OctalPermissionsRule.py
@@ -31,6 +31,7 @@ class OctalPermissionsRule(AnsibleLintRule):
         'in unexpected ways. See '
         'http://docs.ansible.com/ansible/file_module.html'
     )
+    severity = 'VERY_HIGH'
     tags = ['formatting', 'ANSIBLE0009']
     version_added = 'historic'
 

--- a/lib/ansiblelint/rules/PackageHasRetryRule.py
+++ b/lib/ansiblelint/rules/PackageHasRetryRule.py
@@ -14,6 +14,7 @@ class PackageHasRetryRule(AnsibleLintRule):
         'should be used via '
         '``register: my_result`` and ``until: my_result | success``'
     )
+    severity = 'LOW'
     tags = ['module', 'reliability']
     version_added = 'v4.0.0'
 

--- a/lib/ansiblelint/rules/PackageIsNotLatestRule.py
+++ b/lib/ansiblelint/rules/PackageIsNotLatestRule.py
@@ -28,6 +28,7 @@ class PackageIsNotLatestRule(AnsibleLintRule):
         'Package installs should use ``state=present`` '
         'with or without a version'
     )
+    severity = 'VERY_LOW'
     tags = ['module', 'repeatability', 'ANSIBLE0010']
     version_added = 'historic'
 

--- a/lib/ansiblelint/rules/PlaybookExtension.py
+++ b/lib/ansiblelint/rules/PlaybookExtension.py
@@ -10,6 +10,7 @@ class PlaybookExtension(AnsibleLintRule):
     id = '205'
     shortdesc = 'Use ".yml" or ".yaml" playbook extension'
     description = 'Playbooks should have the ".yml" or ".yaml" extension'
+    severity = 'MEDIUM'
     tags = ['formatting']
     done = []  # already noticed path list
     version_added = 'v4.0.0'

--- a/lib/ansiblelint/rules/RoleRelativePath.py
+++ b/lib/ansiblelint/rules/RoleRelativePath.py
@@ -11,6 +11,7 @@ class RoleRelativePath(AnsibleLintRule):
     id = '404'
     shortdesc = "Doesn't need a relative path in role"
     description = '``copy`` and ``template`` do not need to use relative path for ``src``'
+    severity = 'HIGH'
     tags = ['module']
     version_added = 'v4.0.0'
 

--- a/lib/ansiblelint/rules/SudoRule.py
+++ b/lib/ansiblelint/rules/SudoRule.py
@@ -5,6 +5,7 @@ class SudoRule(AnsibleLintRule):
     id = '103'
     shortdesc = 'Deprecated sudo'
     description = 'Instead of ``sudo``/``sudo_user``, use ``become``/``become_user``.'
+    severity = 'VERY_HIGH'
     tags = ['deprecated', 'ANSIBLE0008']
     version_added = 'historic'
 

--- a/lib/ansiblelint/rules/TaskHasNameRule.py
+++ b/lib/ansiblelint/rules/TaskHasNameRule.py
@@ -28,6 +28,7 @@ class TaskHasNameRule(AnsibleLintRule):
         'All tasks should have a distinct name for readability '
         'and for ``--start-at-task`` to work'
     )
+    severity = 'MEDIUM'
     tags = ['task', 'readability', 'ANSIBLE0011']
     version_added = 'historic'
 

--- a/lib/ansiblelint/rules/TaskNoLocalAction.py
+++ b/lib/ansiblelint/rules/TaskNoLocalAction.py
@@ -8,6 +8,7 @@ class TaskNoLocalAction(AnsibleLintRule):
     id = '504'
     shortdesc = "Do not use 'local_action', use 'delegate_to: localhost'"
     description = 'Do not use ``local_action``, use ``delegate_to: localhost``'
+    severity = 'MEDIUM'
     tags = ['task']
     version_added = 'v4.0.0'
 

--- a/lib/ansiblelint/rules/TrailingWhitespaceRule.py
+++ b/lib/ansiblelint/rules/TrailingWhitespaceRule.py
@@ -25,6 +25,7 @@ class TrailingWhitespaceRule(AnsibleLintRule):
     id = '201'
     shortdesc = 'Trailing whitespace'
     description = 'There should not be any trailing whitespace'
+    severity = 'INFO'
     tags = ['formatting', 'ANSIBLE0002']
     version_added = 'historic'
 

--- a/lib/ansiblelint/rules/UseCommandInsteadOfShellRule.py
+++ b/lib/ansiblelint/rules/UseCommandInsteadOfShellRule.py
@@ -34,6 +34,7 @@ class UseCommandInsteadOfShellRule(AnsibleLintRule):
         'or chaining commands (and Ansible would be preferred '
         'for some of those!)'
     )
+    severity = 'HIGH'
     tags = ['command-shell', 'safety', 'ANSIBLE0013']
     version_added = 'historic'
 

--- a/lib/ansiblelint/rules/UseHandlerRatherThanWhenChangedRule.py
+++ b/lib/ansiblelint/rules/UseHandlerRatherThanWhenChangedRule.py
@@ -35,6 +35,7 @@ class UseHandlerRatherThanWhenChangedRule(AnsibleLintRule):
         'If a task has a ``when: result.changed`` setting, it is effectively '
         'acting as a handler'
     )
+    severity = 'MEDIUM'
     tags = ['task', 'behaviour', 'ANSIBLE0016']
     version_added = 'historic'
 

--- a/lib/ansiblelint/rules/UsingBareVariablesIsDeprecatedRule.py
+++ b/lib/ansiblelint/rules/UsingBareVariablesIsDeprecatedRule.py
@@ -31,6 +31,7 @@ class UsingBareVariablesIsDeprecatedRule(AnsibleLintRule):
         'playbooks so that the environment value uses the full variable '
         'syntax ``{{ your_variable }}``'
     )
+    severity = 'VERY_HIGH'
     tags = ['deprecated', 'formatting', 'ANSIBLE0015']
     version_added = 'historic'
 

--- a/lib/ansiblelint/rules/VariableHasSpacesRule.py
+++ b/lib/ansiblelint/rules/VariableHasSpacesRule.py
@@ -9,6 +9,7 @@ class VariableHasSpacesRule(AnsibleLintRule):
     id = '206'
     shortdesc = 'Variables should have spaces before and after: {{ var_name }}'
     description = 'Variables should have spaces before and after: ``{{ var_name }}``'
+    severity = 'LOW'
     tags = ['formatting']
     version_added = 'v4.0.0'
 

--- a/test/TestRuleProperties.py
+++ b/test/TestRuleProperties.py
@@ -1,0 +1,24 @@
+import unittest
+
+from ansiblelint import RulesCollection, default_rulesdir
+
+
+class TestAlwaysRun(unittest.TestCase):
+    collection = RulesCollection()
+
+    def setUp(self):
+        self.collection.extend(
+            RulesCollection.create_from_directory(default_rulesdir)
+        )
+
+    def test_serverity_valid(self):
+        valid_severity_values = [
+            'VERY_HIGH',
+            'HIGH',
+            'MEDIUM',
+            'LOW',
+            'VERY_LOW',
+            'INFO',
+        ]
+        for rule in self.collection:
+            self.assertIn(rule.severity, valid_severity_values)


### PR DESCRIPTION
Closes #379

The `-p` option remains unchanged:
```
awc:code$ ansible-lint test1 -p
test1/handlers/main.yml:4: [E401] Git checkouts must contain explicit version
test1/meta/main.yml:1: [E701] Role info should contain author
test1/meta/main.yml:1: [E702] Tags must contain lowercase letters and digits only, invalid: 'my SQL'
test1/meta/main.yml:1: [E703] Should change default metadata: license
test1/tasks/main.yml:4: [E103] deprecated sudo feature
```

The `--parseable-severity` option was added:
```
awc:code$ ansible-lint test1 --parseable-severity
test1/handlers/main.yml:4: [E401] [MEDIUM] Git checkouts must contain explicit version
test1/meta/main.yml:1: [E701] [HIGH] Role info should contain author
test1/meta/main.yml:1: [E702] [HIGH] Tags must contain lowercase letters and digits only, invalid: 'my SQL'
test1/meta/main.yml:1: [E703] [HIGH] Should change default metadata: license
test1/tasks/main.yml:4: [E103] [VERY_HIGH] deprecated sudo feature
```