### PR TITLE
Fixing remediation message since the filtered success syntax is depre…

### DIFF
--- a/lib/ansiblelint/rules/PackageHasRetryRule.py
+++ b/lib/ansiblelint/rules/PackageHasRetryRule.py
@@ -12,7 +12,7 @@ class PackageHasRetryRule(AnsibleLintRule):
         'network communication and the availability of remote '
         'servers. To mitigate the potential problems, retries '
         'should be used via '
-        '``register: my_result`` and ``until: my_result | success``'
+        '``register: my_result`` and ``until: my_result is succeeded``'
     )
     severity = 'LOW'
     tags = ['module', 'reliability']


### PR DESCRIPTION
…cated in Ansible 2.9

Full Ansible warning message if using `my_result | success` is as follows:
`[DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of using `result|success` use `result is success`. This feature will be 
removed in version 2.9. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.`
