### PR TITLE
Rule 405 now ignore case of 'yum: list=package'

### DIFF
--- a/lib/ansiblelint/rules/PackageHasRetryRule.py
+++ b/lib/ansiblelint/rules/PackageHasRetryRule.py
@@ -76,9 +76,14 @@ class PackageHasRetryRule(AnsibleLintRule):
         "absent",
     ]
 
-    _module_ignore_parameters = [
-        "data",
-    ]
+    _module_ignore_parameters = {
+        "apt_key": [
+            "data",
+        ],
+        "yum": [
+            "list",
+        ]
+    }
 
     _package_name_keys = [
         "name",
@@ -111,7 +116,7 @@ class PackageHasRetryRule(AnsibleLintRule):
             return False
 
         has_whitelisted_parameter = (
-            set(self._module_ignore_parameters).intersection(set(task['action']))
+            set(self._module_ignore_parameters.get(module, [])).intersection(set(task['action']))
         )
         if has_whitelisted_parameter:
             return False

--- a/test/TestPackageHasRetry.py
+++ b/test/TestPackageHasRetry.py
@@ -39,6 +39,10 @@ SUCCESS = '''
         data: "{{ lookup('file', release_key) }}"
         id: "{{ release_key_id }}"
         state: present
+
+    - name: list packages
+      yum:
+        list: some_package
 '''
 
 FAILURE = '''


### PR DESCRIPTION
https://docs.ansible.com/ansible/latest/modules/yum_module.html
`list` is for retrieving available packages, not sure it needs the `until` loop.