### PR TITLE
Ignore comments for line-based rules

### DIFF
--- a/lib/ansiblelint/__init__.py
+++ b/lib/ansiblelint/__init__.py
@@ -50,6 +50,8 @@ class AnsibleLintRule(object):
         # arrays are 0-based, line numbers are 1-based
         # so use prev_line_no as the counter
         for (prev_line_no, line) in enumerate(text.split("\n")):
+            if line.lstrip().startswith('#'):
+                continue
             result = self.match(file, line)
             if result:
                 message = None


### PR DESCRIPTION
Currently ansible-lint task-based rules ignore comments since the comments don’t get parsed but ansible-lint line-based rules do not ignore comments.

This PR make it so ansible-lint line-based rules will ignore full-line comments.

Signed-off-by: Andrew Crosby <acrosby@redhat.com>