### PR TITLE
Allow config skip_list to have rule number id not in quotes

### DIFF
--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -174,7 +174,7 @@ def main():
 
     skip = set()
     for s in options.skip_list:
-        skip.update(s.split(','))
+        skip.update(str(s).split(','))
     options.skip_list = frozenset(skip)
 
     playbooks = set(args)


### PR DESCRIPTION
Signed-off-by: Andrew Crosby <acrosby@redhat.com>