### PR TITLE
Lint all yaml in tasks/ and handlers/ regardless of import or include (fix PR#462)

### DIFF
--- a/lib/ansiblelint/__init__.py
+++ b/lib/ansiblelint/__init__.py
@@ -234,6 +234,10 @@ class Runner(object):
                 visited.add(arg)
 
         matches = list()
+
+        # remove duplicates from files list
+        files = [value for n,value in enumerate(files) if value not in files[:n]]
+
         # remove files that have already been checked
         files = [x for x in files if x['path'] not in self.checked_files]
         for file in files:

--- a/lib/ansiblelint/__init__.py
+++ b/lib/ansiblelint/__init__.py
@@ -236,7 +236,7 @@ class Runner(object):
         matches = list()
 
         # remove duplicates from files list
-        files = [value for n,value in enumerate(files) if value not in files[:n]]
+        files = [value for n, value in enumerate(files) if value not in files[:n]]
 
         # remove files that have already been checked
         files = [x for x in files if x['path'] not in self.checked_files]

--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -338,7 +338,7 @@ def _look_for_role_files(basedir, role, main='main'):
     results = []
 
     for th in ['tasks', 'handlers', 'meta']:
-        current_path=os.path.join(role_path, th)
+        current_path = os.path.join(role_path, th)
         for dir, subdirs, files in os.walk(current_path):
             for file in files:
                 if file.endswith('.yml' or '.yaml'):

--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -342,7 +342,7 @@ def _look_for_role_files(basedir, role, main='main'):
         for dir, subdirs, files in os.walk(current_path):
             for file in files:
                 file_ignorecase = file.lower()
-                if file_ignorecase.endswith('.yml' or '.yaml'):
+                if file_ignorecase.endswith(('.yml', '.yaml')):
                     thpath = os.path.join(dir, file)
                     results.append({'path': thpath, 'type': th})
 

--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -341,7 +341,8 @@ def _look_for_role_files(basedir, role, main='main'):
         current_path = os.path.join(role_path, th)
         for dir, subdirs, files in os.walk(current_path):
             for file in files:
-                if file.endswith('.yml' or '.yaml'):
+                file_ignorecase = file.lower()
+                if file_ignorecase.endswith('.yml' or '.yaml'):
                     thpath = os.path.join(dir, file)
                     results.append({'path': thpath, 'type': th})
 

--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -338,11 +338,13 @@ def _look_for_role_files(basedir, role, main='main'):
     results = []
 
     for th in ['tasks', 'handlers', 'meta']:
-        for ext in ('.yml', '.yaml'):
-            thpath = os.path.join(role_path, th, main + ext)
-            if os.path.exists(thpath):
-                results.append({'path': thpath, 'type': th})
-                break
+        current_path=os.path.join(role_path, th)
+        for dir, subdirs, files in os.walk(current_path):
+            for file in files:
+                if file.endswith('.yml' or '.yaml'):
+                    thpath = os.path.join(dir, file)
+                    results.append({'path': thpath, 'type': th})
+
     return results
 
 


### PR DESCRIPTION
Fix syntax in PR#462
Related to [#373](https://github.com/ansible/ansible-lint/issues/373)
