### PR TITLE
Don't crash on empty roles.

### DIFF
--- a/lib/ansiblelint/rules/NoFormattingInWhenRule.py
+++ b/lib/ansiblelint/rules/NoFormattingInWhenRule.py
@@ -22,7 +22,7 @@ class NoFormattingInWhenRule(AnsibleLintRule):
     def matchplay(self, file, play):
         errors = []
         if isinstance(play, dict):
-            if 'roles' not in play:
+            if 'roles' not in play or play['roles'] is None:
                 return errors
             for role in play['roles']:
                 if self.matchtask(file, role):


### PR DESCRIPTION
Rule NoFormattingInWhen is crashing when rules is empty, which is
common in developing playbooks. 

Signed-off-by: Daniel Ehlers <sargon@toppoint.de>

This solves #487 but without the suggested warning.