### PR TITLE
Syntax proposed by 104 should not fail 206

### DIFF
--- a/lib/ansiblelint/rules/UsingBareVariablesIsDeprecatedRule.py
+++ b/lib/ansiblelint/rules/UsingBareVariablesIsDeprecatedRule.py
@@ -66,5 +66,5 @@ class UsingBareVariablesIsDeprecatedRule(AnsibleLintRule):
             if loop_type != 'with_fileglob' or not (self._jinja.search(varstring) or
                                                     self._glob.search(varstring)):
                 message = "Found a bare variable '{0}' used in a '{1}' loop." + \
-                          " You should use the full variable syntax ('{{{{{0}}}}}')"
+                          " You should use the full variable syntax ('{{{{ {0} }}}}')"
                 return message.format(task[loop_type], loop_type)


### PR DESCRIPTION
Introduce additional spaces in the UsingBareVariablesIsDeprecatedRule
proposal output, so it's not failing VariableHasSpacesRule.

Signed-off-by: Sebastian Meyer <meyer@b1-systems.de>