### PR TITLE
📌 Set min supported Ansible version @ dist meta

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -80,7 +80,7 @@ setup_requires =
 
 # These are required in actual runtime:
 install_requires =
-    ansible
+    ansible >= 2.5
     pyyaml
     six
     ruamel.yaml


### PR DESCRIPTION
I just realized that there's literally no place specifying that we don't support EOL versions of Ansible.

This should be set in the package distribution metadata, at least.