### PR TITLE
🚑 Drop WWW/HTTP trove classifier from dist meta

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -51,11 +51,6 @@ classifiers =
     Programming Language :: Python :: Implementation :: Jython
     Programming Language :: Python :: Implementation :: PyPy
 
-    Topic :: Internet :: WWW/HTTP
-    Topic :: Internet :: WWW/HTTP :: HTTP Servers
-    Topic :: Internet :: WWW/HTTP :: WSGI
-    Topic :: Internet :: WWW/HTTP :: WSGI :: Server
-
     Topic :: Software Development :: Bug Tracking
     Topic :: Software Development :: Quality Assurance
     Topic :: Software Development :: Testing


### PR DESCRIPTION
I think it's a result of accidental copy-paste...