### PR TITLE
Allow exceptions in CommandsInsteadOfModules

### DIFF
--- a/lib/ansiblelint/rules/CommandsInsteadOfModulesRule.py
+++ b/lib/ansiblelint/rules/CommandsInsteadOfModulesRule.py
@@ -68,6 +68,7 @@ class CommandsInsteadOfModulesRule(AnsibleLintRule):
         'wget': 'get_url or uri',
         'yum': 'yum',
     }
+    _exceptions = ['versionlock']
 
     def matchtask(self, file, task):
         if task['action']['__ansible_module__'] not in self._commands:
@@ -79,6 +80,7 @@ class CommandsInsteadOfModulesRule(AnsibleLintRule):
 
         executable = os.path.basename(first_cmd_arg)
         if executable in self._modules and \
-                boolean(task['action'].get('warn', True)):
+                boolean(task['action'].get('warn', True)) and not\
+                any(i in self._exceptions for i in task['action']['__ansible_arguments__']):
             message = '{0} used in place of {1} module'
             return message.format(executable, self._modules[executable])


### PR DESCRIPTION
As there's multiple subcommands of yum that doesn't have an equivialent function there's a need to have exceptions available to don't hit the rule when for example versionlock is used in a command or shell.

At this time it doesn't seam like versionlock will be added to the yum module.

https://github.com/ansible/ansible/issues/13086