### PR TITLE
fix skipping when using import_playbook

### DIFF
--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -613,8 +613,8 @@ def append_skipped_rules(pyyaml_data, file_text, file_type):
             ruamel_tasks = []
             pyyaml_tasks = []
             for ruamel_play, pyyaml_play in zip(ruamel_data, pyyaml_data):
-                ruamel_tasks.extend(ruamel_play.get('tasks'))
-                pyyaml_tasks.extend(pyyaml_play.get('tasks'))
+                ruamel_tasks.extend(ruamel_play.get('tasks', []))
+                pyyaml_tasks.extend(pyyaml_play.get('tasks', []))
         except (AttributeError, TypeError):
             return pyyaml_data
     elif file_type == 'meta':

--- a/test/TestSkipImportPlaybook.py
+++ b/test/TestSkipImportPlaybook.py
@@ -1,0 +1,49 @@
+import os
+import unittest
+import tempfile
+import shutil
+
+from ansiblelint import Runner, RulesCollection
+
+IMPORTED_PLAYBOOK = '''
+- hosts: all
+  tasks:
+    - name: success
+      fail: msg="fail"
+      when: False
+'''
+
+MAIN_PLAYBOOK = '''
+- hosts: all
+
+  tasks:
+    - name: should be shell  # noqa 305 301
+      shell: echo lol
+
+- import_playbook: imported_playbook.yml
+'''
+
+
+class TestSkipBeforeImport(unittest.TestCase):
+    def setUp(self):
+        rulesdir = os.path.join('lib', 'ansiblelint', 'rules')
+        self.rules = RulesCollection.create_from_directory(rulesdir)
+
+        # make dir and write role tasks to import or include
+        self.play_root = tempfile.mkdtemp()
+        with open(os.path.join(self.play_root, 'imported_playbook.yml'), 'w') as f_main:
+            f_main.write(IMPORTED_PLAYBOOK)
+
+    def tearDown(self):
+        shutil.rmtree(self.play_root)
+
+    def _get_play_file(self, playbook_text):
+        with open(os.path.join(self.play_root, 'playbook.yml'), 'w') as f_play:
+            f_play.write(playbook_text)
+        return f_play
+
+    def test_skip_import_playbook(self):
+        fh = self._get_play_file(MAIN_PLAYBOOK)
+        runner = Runner(self.rules, fh.name, [], [], [])
+        results = runner.run()
+        self.assertEqual(0, len(results))


### PR DESCRIPTION
The `import_playbook` item doesn't have the `tasks` property, so an exception is raised in utils.py line 669 (in `append_skipped_rules`). Although the exception is caught and ignored the side effect is that the rest of the method doesn't finish it's work, so the line based `noqa XXX` statements are ignored.

For example, the following playbook should pass by default:

```yaml
- hosts: all

  tasks:
    - name: should be shell  # noqa 305 301
      shell: echo lol

- import_playbook: imported_playbook.yml
```

Instead, the following two errors are raised:

```
ansible/playbooks/test3.yml:4: [E301] Commands should not change things if nothing needs doing
ansible/playbooks/test3.yml:4: [E305] Use shell only when shell functionality is required
```

To fix this, I added the empty list as a default value in the calls to `.get('tasks')`.

Signed-off-by: Konstantinos Koukopoulos <koukopoulos@gmail.com>