### PR TITLE
Support to_nice_yaml filter

### DIFF
--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -32,6 +32,7 @@ import subprocess
 import six
 import yaml
 from yaml.composer import Composer
+from yaml.representer import RepresenterError
 import ruamel.yaml
 
 from ansible import constants
@@ -184,7 +185,7 @@ def template(basedir, value, vars, fail_on_undefined=False, **kwargs):
                                  **dict(kwargs, fail_on_undefined=fail_on_undefined))
         # Hack to skip the following exception when using to_json filter on a variable.
         # I guess the filter doesn't like empty vars...
-    except (AnsibleError, ValueError):
+    except (AnsibleError, ValueError, RepresenterError):
         # templating failed, so just keep value as is.
         pass
     return value

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -141,6 +141,11 @@ class TestUtils(unittest.TestCase):
         result = utils.template('/a/b/c', v, dict(playbook_dir='/a/b/c'))
         self.assertEqual(result, "{{ hello | to_json }}")
 
+    def test_existing_filter_yaml_on_unknown_var(self):
+        v = "{{ hello | to_nice_yaml }}"
+        result = utils.template('/a/b/c', v, dict(playbook_dir='/a/b/c'))
+        self.assertEqual(result, "{{ hello | to_nice_yaml }}")
+
     def test_task_to_str_unicode(self):
         task = dict(fail=dict(msg=u"unicode é ô à"))
         result = utils.task_to_str(utils.normalize_task(task, 'filename.yml'))


### PR DESCRIPTION
`ansiblelint.utils.template` can't handle the `to_nice_yaml` filter, so we should add the `RepresenterError` to the ignored exception list.

Example task:
```yaml
- name: output some nice yaml
  debug: msg="{{ some_var | to_nice_yaml }}"
```
Causes this error:

```python-traceback
  File "/root/.cache/pre-commit/repogevfadgi/py_env-python3.6/lib/python3.6/site-packages/ansiblelint/utils.py", line 224, in play_children
    fail_on_undefined=False)
  File "/root/.cache/pre-commit/repogevfadgi/py_env-python3.6/lib/python3.6/site-packages/ansiblelint/utils.py", line 191, in template
    **dict(kwargs, fail_on_undefined=fail_on_undefined))
  File "/root/.cache/pre-commit/repogevfadgi/py_env-python3.6/lib/python3.6/site-packages/ansiblelint/utils.py", line 78, in ansible_template
    return templar.template(varname, **kwargs)
  File "/root/.cache/pre-commit/repogevfadgi/py_env-python3.6/lib/python3.6/site-packages/ansible/template/__init__.py", line 572, in template
    ) for v in variable]
  File "/root/.cache/pre-commit/repogevfadgi/py_env-python3.6/lib/python3.6/site-packages/ansible/template/__init__.py", line 572, in <listcomp>
    ) for v in variable]
  File "/root/.cache/pre-commit/repogevfadgi/py_env-python3.6/lib/python3.6/site-packages/ansible/template/__init__.py", line 584, in template
    disable_lookups=disable_lookups,
  File "/root/.cache/pre-commit/repogevfadgi/py_env-python3.6/lib/python3.6/site-packages/ansible/template/__init__.py", line 584, in template
    disable_lookups=disable_lookups,
  File "/root/.cache/pre-commit/repogevfadgi/py_env-python3.6/lib/python3.6/site-packages/ansible/template/__init__.py", line 539, in template
    disable_lookups=disable_lookups,
  File "/root/.cache/pre-commit/repogevfadgi/py_env-python3.6/lib/python3.6/site-packages/ansible/template/__init__.py", line 804, in do_template
    res = j2_concat(rf)
  File "<template>", line 12, in root
  File "/root/.cache/pre-commit/repogevfadgi/py_env-python3.6/lib/python3.6/site-packages/ansible/plugins/filter/core.py", line 71, in to_nice_yaml
    transformed = yaml.dump(a, Dumper=AnsibleDumper, indent=indent, allow_unicode=True, default_flow_style=False, **kw)
  File "/root/.cache/pre-commit/repogevfadgi/py_env-python3.6/lib/python3.6/site-packages/yaml/__init__.py", line 290, in dump
    return dump_all([data], stream, Dumper=Dumper, **kwds)
  File "/root/.cache/pre-commit/repogevfadgi/py_env-python3.6/lib/python3.6/site-packages/yaml/__init__.py", line 278, in dump_all
    dumper.represent(data)
  File "/root/.cache/pre-commit/repogevfadgi/py_env-python3.6/lib/python3.6/site-packages/yaml/representer.py", line 27, in represent
    node = self.represent_data(data)
  File "/root/.cache/pre-commit/repogevfadgi/py_env-python3.6/lib/python3.6/site-packages/yaml/representer.py", line 58, in represent_data
    node = self.yaml_representers[None](self, data)
  File "/root/.cache/pre-commit/repogevfadgi/py_env-python3.6/lib/python3.6/site-packages/yaml/representer.py", line 231, in represent_undefined
    raise RepresenterError("cannot represent an object", data)
yaml.representer.RepresenterError: ('cannot represent an object', AnsibleUndefined)
```