### PR TITLE
Dependency updates - drop support for ansible 2.5, add 2.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,24 @@ jobs:
 
   - python: "3.7"
     env:
+      ANSIBLE_VERSION: "28"
+
+  - python: "3.6"
+    <<: *if-cron-or-manual-run-or-tagged
+    env:
+      ANSIBLE_VERSION: "28"
+
+  - python: "3.5"
+    <<: *if-cron-or-manual-run-or-tagged
+    env:
+      ANSIBLE_VERSION: "28"
+
+  - python: "2.7"
+    env:
+      ANSIBLE_VERSION: "28"
+
+  - python: "3.7"
+    env:
       ANSIBLE_VERSION: "27"
 
   - python: "3.6"
@@ -70,24 +88,6 @@ jobs:
   - python: "2.7"
     env:
       ANSIBLE_VERSION: "26"
-
-  - python: "3.7"
-    env:
-      ANSIBLE_VERSION: "25"
-
-  - python: "3.6"
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      ANSIBLE_VERSION: "25"
-
-  - python: "3.5"
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      ANSIBLE_VERSION: "25"
-
-  - python: "2.7"
-    env:
-      ANSIBLE_VERSION: "25"
 
   - python: "3.7"
     <<: *if-cron-or-manual-run-or-tagged

--- a/setup.cfg
+++ b/setup.cfg
@@ -75,7 +75,7 @@ setup_requires =
 
 # These are required in actual runtime:
 install_requires =
-    ansible >= 2.5
+    ansible >= 2.6
     pyyaml
     six
     ruamel.yaml >= 0.15.34,<1

--- a/setup.cfg
+++ b/setup.cfg
@@ -78,7 +78,8 @@ install_requires =
     ansible >= 2.5
     pyyaml
     six
-    ruamel.yaml
+    ruamel.yaml >= 0.15.34,<1
+    # NOTE: per issue #509 0.15.34 included in debian backports
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -78,7 +78,8 @@ install_requires =
     ansible >= 2.6
     pyyaml
     six
-    ruamel.yaml >= 0.15.34,<1
+    ruamel.yaml >= 0.15.34,<1; python_version < "3.7"
+    ruamel.yaml >= 0.15.37,<1; python_version >= "3.7"
     # NOTE: per issue #509 0.15.34 included in debian backports
 
 [options.entry_points]

--- a/test-deps.txt
+++ b/test-deps.txt
@@ -1,5 +1,0 @@
-flake8
-nose
-pep8-naming
-wheel
-ruamel.yaml

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,11 @@ deps =
   ansible26: ansible>=2.6,<2.7
   ansible27: ansible>=2.7,<2.8
   ansibledevel: git+https://github.com/ansible/ansible.git
-  -rtest-deps.txt
+  ruamel.yaml
+  flake8
+  nose
+  pep8-naming
+  wheel
 commands = nosetests []
 passenv = HOME
 # recreate = True

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,13 @@
 [tox]
 minversion = 3.5.3
-envlist = flake8,py{37,36,35,27}-ansible{27,26,25,devel}
+envlist = flake8,py{37,36,35,27}-ansible{28,27,26,devel}
 skip_missing_interpreters = True
 
 [testenv]
 deps =
-  ansible25: ansible>=2.5,<2.6
   ansible26: ansible>=2.6,<2.7
   ansible27: ansible>=2.7,<2.8
+  ansible28: ansible>=2.8,<2.9
   ansibledevel: git+https://github.com/ansible/ansible.git
   ruamel.yaml==0.15.37  # NOTE: 0.15.34 has issues with py37
   flake8

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
   ansible26: ansible>=2.6,<2.7
   ansible27: ansible>=2.7,<2.8
   ansibledevel: git+https://github.com/ansible/ansible.git
-  ruamel.yaml
+  ruamel.yaml==0.15.37  # NOTE: 0.15.34 has issues with py37
   flake8
   nose
   pep8-naming


### PR DESCRIPTION
* drop support for ansible 2.5, add 2.8
* add a dependency range for ruamel.yaml which closes #509, and ensure we are testing with as minimal version as we can for our CI config
* removed `test-deps.txt` and added those deps to `tox.ini`