### PR TITLE
Ensure files are checked only once.

### DIFF
--- a/lib/ansiblelint/__init__.py
+++ b/lib/ansiblelint/__init__.py
@@ -221,9 +221,9 @@ class Runner(object):
         # assume role if directory
         if os.path.isdir(playbook):
             self.playbooks.add((os.path.join(playbook, ''), 'role'))
-            self.playbook_dir = playbook
+            self.playbook_dir = os.path.abspath(playbook)
         else:
-            self.playbooks.add((playbook, 'playbook'))
+            self.playbooks.add((os.path.abspath(playbook), 'playbook'))
             self.playbook_dir = os.path.dirname(playbook)
         self.tags = tags
         self.skip_list = skip_list

--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -157,7 +157,7 @@ def find_children(playbook, playbook_dir):
         except AnsibleError as e:
             raise SystemExit(str(e))
     results = []
-    basedir = os.path.dirname(playbook[0])
+    basedir = os.path.abspath(os.path.dirname(playbook[0]))
     items = _playbook_items(playbook_ds)
     for item in items:
         for child in play_children(basedir, item, playbook[1], playbook_dir):


### PR DESCRIPTION
Ansible Lint has a mecanism to avoid checking
a file several times. Though file path not
being properly normalized, it is not effective.

This commit fixes that and adds a mean to still
keep the output of ansible short by remove the
files common path prefix (helps with cut pasting
path from several env., e.g. from your CI to
your local shell).

This should fix #560 .

There would be a few tests to perform implement though. In particular I have an exclude list, with relative path in it. They are indeed still ignored but I didn't check why yet). The config used is the following:
```yaml
exclude_paths:
  # Ignore third party roles
  - ./tests/roles/
```