### PR TITLE
WIP: fix: Expand paths correctly from basepath

### DIFF
--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -240,7 +240,10 @@ def _include_children(basedir, k, v, parent_type):
 
     result = path_dwim(basedir, args[0])
     if not os.path.exists(result) and not basedir.endswith('tasks'):
-        result = path_dwim(os.path.join(basedir, '..', 'tasks'), v)
+        tasks_path = basedir.rsplit('tasks/')[0] + 'tasks/'
+        result = path_dwim(tasks_path, args[0])
+        if not os.path.exists(result):
+            result = path_dwim(os.path.join(basedir, '..', 'tasks'), v)
     return [{'path': result, 'type': parent_type}]
 
 

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -157,6 +157,18 @@ def test_expand_paths_vars(monkeypatch):
     assert utils.expand_paths_vars(['~']) == [os.path.expanduser('~')]
     assert utils.expand_paths_vars(['$TEST_PATH']) == [test_path]
 
+@unittest.mock.patch('os.path.exists')
+def test_include_children_relative_from_root(self, mock_exists):
+    # Mock that the file exists relative from root
+    mock_exists.return_value = True
+
+    result = utils._include_children(
+        basedir='/role/tasks/subdir',
+        k='include_tasks',
+        v='includes/main.yml',
+        parent_type='tasks'
+    )
+    self.assertEqual(result, '/role/tasks/includes/main.yml')
 
 @pytest.mark.parametrize(
     ('reset_env_var', 'message_prefix'),


### PR DESCRIPTION
Fixes: #569 

Ansible supports relative includes from the tasks folder. Check the demo here:
https://github.com/wilmardo/ansible-lint-issue-demo.git

Ansible lint assumed that the tasks dir is just one directory up but it could be more then one. My solutions split the basedir on the lasts tasks/ in the path and looks there for the include.
If that does not exists it falls back on the previous behavior (which in my opinion is better to remove but might break some existing scenarios).

If someone has a better solution please share! This solution assumes there is no nested tasks folder in the role (like `role/tasks/linux/tasks/main.yml`)
 
How Ansible handles relative imports/includes can be found here, which my be hard to reproduce since there is no reference to a previous include:

https://github.com/ansible/ansible/blob/7346b699eec99d7279da4175b99f07e08f0de283/lib/ansible/playbook/included_file.py#L117