### PR TITLE
Fix EnvVarsInCommandRule with Ansible 2.8

### DIFF
--- a/lib/ansiblelint/rules/EnvVarsInCommandRule.py
+++ b/lib/ansiblelint/rules/EnvVarsInCommandRule.py
@@ -34,6 +34,7 @@ class EnvVarsInCommandRule(AnsibleLintRule):
     version_added = 'historic'
 
     expected_args = ['chdir', 'creates', 'executable', 'removes', 'stdin', 'warn',
+                     'stdin_add_newline', 'strip_empty_ends',
                      'cmd', '__ansible_module__', '__ansible_arguments__',
                      LINE_NUMBER_KEY, FILENAME_KEY]
 

--- a/test/TestEnvVarsInCommand.py
+++ b/test/TestEnvVarsInCommand.py
@@ -49,6 +49,17 @@ SUCCESS_PLAY_TASKS = '''
 
   - name: environment variable with shell
     shell: HELLO=hello echo $HELLO
+
+  - name: command with stdin_add_newline (ansible > 2.8)
+    command: /bin/cat
+    args:
+      stdin: "Hello, world!"
+      stdin_add_newline: false
+
+  - name: command with strip_empty_ends (ansible > 2.8)
+    command: echo
+    args:
+      strip_empty_ends: false
 '''
 
 FAIL_PLAY_TASKS = '''


### PR DESCRIPTION
The `stdin_add_newline` and `strip_empty_ends` parameters were added in
Ansible 2.8, creating false positives.