### PR TITLE
Check at file level

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -415,6 +415,7 @@ Each rule definition should have the following:
 
   * ``match`` that takes a line and returns None or False, if the line doesn't match the test, and True or a custom message, when it does. (This allows one rule to test multiple behaviours - see e.g. the *CommandsInsteadOfModulesRule*.)
   * ``matchtask`` that operates on a single task or handler, such that tasks get standardized to always contain a *module* key and *module_arguments* key. Other common task modifiers, such as *when*, *with_items*, etc., are also available as keys, if present in the task.
+  * ``matchfile`` that operates on a file as a list of lines and returns either None if there is no match, either the line number of the match.
 
 An example rule using ``match`` is:
 

--- a/lib/ansiblelint/__init__.py
+++ b/lib/ansiblelint/__init__.py
@@ -43,6 +43,7 @@ class AnsibleLintRule(object):
     match = None
     matchtask = None
     matchplay = None
+    matchfile = None
 
     @staticmethod
     def unjinja(text):
@@ -137,6 +138,21 @@ class AnsibleLintRule(object):
                                      section, file['path'], self, message))
         return matches
 
+    def matchfiles(self, file, text):
+        matches = []
+        if not self.matchfile:
+            return matches
+
+        split_text = text.splitlines()
+        line = self.matchfile(file, split_text)
+        if line is None or not isinstance(line, six.integer_types):
+            return matches
+
+        message = None
+        matches.append(Match(line, split_text[line-1],
+                           file['path'], self, message))
+        return matches
+
 
 class RulesCollection(object):
 
@@ -176,6 +192,7 @@ class RulesCollection(object):
                     matches.extend(rule.matchlines(playbookfile, text))
                     matches.extend(rule.matchtasks(playbookfile, text))
                     matches.extend(rule.matchyaml(playbookfile, text))
+                    matches.extend(rule.matchfiles(playbookfile, text))
 
         return matches
 

--- a/lib/ansiblelint/__init__.py
+++ b/lib/ansiblelint/__init__.py
@@ -150,7 +150,7 @@ class AnsibleLintRule(object):
 
         message = None
         matches.append(Match(line, split_text[line-1],
-                           file['path'], self, message))
+                             file['path'], self, message))
         return matches
 
 


### PR DESCRIPTION
Add an ansible-lint hook (matchfile) to check at file level (e.g. header or footer of the file)