### PR TITLE
with_filetree loop: reduce false positive

### DIFF
--- a/test/TestUsingBareVariablesIsDeprecated.py
+++ b/test/TestUsingBareVariablesIsDeprecated.py
@@ -18,4 +18,4 @@ class TestUsingBareVariablesIsDeprecated(unittest.TestCase):
         failure = 'test/using-bare-variables-failure.yml'
         bad_runner = Runner(self.collection, failure, [], [], [])
         errs = bad_runner.run()
-        self.assertEqual(13, len(errs))
+        self.assertEqual(14, len(errs))

--- a/test/using-bare-variables-failure.yml
+++ b/test/using-bare-variables-failure.yml
@@ -61,6 +61,11 @@
         msg: "{{ item }}"
       with_fileglob: my_list
 
+    - name: with_filetree loop using bare variable
+      debug:
+        msg: "{{ item }}"
+      with_filetree: my_list
+
     - name: with_together loop using bare variable
       debug:
         msg: "{{ item.0 }} {{ item.1 }}"

--- a/test/using-bare-variables-success.yml
+++ b/test/using-bare-variables-success.yml
@@ -107,6 +107,26 @@
         msg: "{{ item }}"
       with_fileglob: 'foo{{glob}}'
 
+    ### Testing with_filetree
+    - name: with_filetree loop using list of path
+      debug:
+        msg: "{{ item }}"
+      with_filetree:
+        - path/to/dir1/
+        - path/to/dir2/
+
+    ### Testing non-list form of with_filetree
+    - name: with_filetree loop using single path
+      debug:
+        msg: "{{ item }}"
+      with_filetree: path/to/dir/
+
+    ### Testing non-list form of with_filetree with trailing templated pattern
+    - name: with_filetree loop using templated pattern
+      debug:
+        msg: "{{ item }}"
+      with_filetree: 'path/to/{{ directory }}'
+
     ### Testing with_together
     - name: with_together loop using variable lists
       debug:


### PR DESCRIPTION
handle `with_filetree` loop:
- don't return an error when a string ending with a slash is used
- `with_filetree` loop accepts list too
- add tests
