### PR TITLE
Avoid installation failure with newer setuptools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ pip-log.txt
 # Coverage artifacts
 .coverage
 coverage.xml
+pip-wheel-metadata

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+  "setuptools == 41.0.0",  # See https://github.com/pypa/setuptools/issues/1869
+  "setuptools_scm >= 1.15.0",
+  "setuptools_scm_git_archive >= 1.0",
+  "wheel",
+]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Implement workaround for avoiding installation errors on system with newer setuptools
```
AttributeError: 'SpecifierSet' object has no attribute 'split'
```

Fixes: #590