### PR TITLE
tox: addex SSL proxy variables to passenv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,11 @@ deps =
   pep8-naming
   wheel
 commands = nosetests []
-passenv = HOME
+passenv =
+    CURL_CA_BUNDLE  # https proxies, https://github.com/tox-dev/tox/issues/1437
+    HOME
+    REQUESTS_CA_BUNDLE  # https proxies
+    SSL_CERT_FILE  # https proxies
 # recreate = True
 
 [testenv:flake8]


### PR DESCRIPTION
Fix tox execution failures from system that are using SSL based
http proxies.

Related: https://github.com/tox-dev/tox/issues/1437