### PR TITLE
packaging: fix minor on descrioption format

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ project_urls =
   Source Code = https://github.com/ansible/ansible-lint
 description = Checks playbooks for practices and behaviour that could potentially be improved
 long_description = file: README.rst
+long_description_content_type = text/x-rst
 author = Will Thames
 author_email = will@thames.id.au
 maintainer = Ansible by Red Hat


### PR DESCRIPTION
Avoids build time warning related to lack of format for README.rst