### PR TITLE
Fixed deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -116,7 +116,9 @@ jobs:
     if: repo == "ansible/ansible-lint" AND tag IS present
     python: "3.7"
     env: &deploy-env
-      TOXENV: metadata-validation
+      TOXENV: build-dists,metadata-validation
+    before_deploy:
+    - echo > setup.py
     deploy: &deploy-step
       provider: pypi
       user: ansible-lint

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,24 @@ passenv =
     SSL_CERT_FILE  # https proxies
 # recreate = True
 
+[testenv:build-dists]
+basepython = python3
+isolated_build = true
+# `usedevelop = true` overrides `skip_install` instruction, it's unwanted
+usedevelop = false
+skip_install = true
+deps =
+  pep517 >= 0.5.0
+commands =
+  rm -rfv {toxinidir}/dist/
+  {envpython} -m pep517.build \
+    --source \
+    --binary \
+    --out-dir {toxinidir}/dist/ \
+    {toxinidir}
+whitelist_externals =
+  rm
+
 [testenv:flake8]
 deps = flake8
 commands = flake8
@@ -35,10 +53,14 @@ usedevelop = True
 
 [testenv:metadata-validation]
 deps =
+  {[testenv:build-dists]deps}
   collective.checkdocs
   twine
 usedevelop = False
+skip_install = {[testenv:build-dists]skip_install}
 # Ref: https://twitter.com/di_codes/status/1044358639081975813
 commands =
-  python -m setup checkdocs check --metadata --restructuredtext --strict --verbose
-  twine check .tox/dist/*
+  {[testenv:build-dists]commands}
+  twine check {toxinidir}/dist/*
+whitelist_externals =
+  {[testenv:build-dists]whitelist_externals}


### PR DESCRIPTION
Replaces older metada-validation targer with the more coprehensive
build-dist which builds packages using pep517 and also verifies
their metadata by usin twine check (replacement for the older method).

This also fixed deploy on travis which is wrongly calls setup.py when
found.