### PR TITLE
Fixed pre-commit hooks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -6,6 +6,9 @@
 -   id: ansible-lint
     name: Ansible-lint
     description: This hook runs ansible-lint.
-    entry: ansible-lint
+    entry: ansible-lint --force-color .
     language: python
-    files: \.(yaml|yml)$
+    # do not pass files to ansible-lint, see:
+    # https://github.com/ansible/ansible-lint/issues/611
+    pass_filenames: false
+    always_run: true


### PR DESCRIPTION
Assures that when used as a pre-commit hook, ansible-lint is not
given each file as argument. This is needed because ansible-lint
needs to detect the code-base layout in order to figure-out which
YAML files are playbooks, tasks or vars files.

Previously the hook was passing all files that where matching its
filters and ansible-lint would assume they were playbooks. This made it
give false positives.

This change also adds the --force-color because without it ansible-lint
would fail to detect the TTY and avoid using colors.

Fixes: #611
Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>