### PR TITLE
Normalize displayed file paths

### DIFF
--- a/lib/ansiblelint/__init__.py
+++ b/lib/ansiblelint/__init__.py
@@ -260,7 +260,7 @@ class Runner(object):
                 continue
             if playbook[1] == 'role':
                 continue
-            files.append({'path': playbook[0], 'type': playbook[1]})
+            files.append({'path': ansiblelint.utils.normpath(playbook[0]), 'type': playbook[1]})
         visited = set()
         while (visited != self.playbooks):
             for arg in self.playbooks - visited:
@@ -280,7 +280,9 @@ class Runner(object):
         files = [x for x in files if x['path'] not in self.checked_files]
         for file in files:
             if self.verbosity > 0:
-                print("Examining %s of type %s" % (file['path'], file['type']))
+                print("Examining %s of type %s" % (
+                    ansiblelint.utils.normpath(file['path']),
+                    file['type']))
             matches.extend(self.rules.run(file, tags=set(self.tags),
                            skip_list=self.skip_list))
         # update list of checked files

--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -30,6 +30,7 @@ import ansiblelint.formatters as formatters
 import six
 from ansiblelint import default_rulesdir, RulesCollection, Runner
 from ansiblelint.version import __version__
+from ansiblelint.utils import normpath
 import yaml
 import os
 
@@ -176,7 +177,7 @@ def main():
         skip.update(str(s).split(','))
     options.skip_list = frozenset(skip)
 
-    playbooks = set(args)
+    playbooks = sorted(set(args))
     matches = list()
     checked_files = set()
     for playbook in playbooks:
@@ -185,7 +186,7 @@ def main():
                         options.verbosity, checked_files)
         matches.extend(runner.run())
 
-    matches.sort(key=lambda x: (x.filename, x.linenumber, x.rule.id))
+    matches.sort(key=lambda x: (normpath(x.filename), x.linenumber, x.rule.id))
 
     for match in matches:
         print(formatter.format(match, options.colored))

--- a/lib/ansiblelint/formatters/__init__.py
+++ b/lib/ansiblelint/formatters/__init__.py
@@ -2,6 +2,7 @@ try:
     from ansible import color
 except ImportError:
     from ansible.utils import color
+from ansiblelint.utils import normpath
 
 
 class Formatter(object):
@@ -12,7 +13,7 @@ class Formatter(object):
             color.ANSIBLE_COLOR = True
             return formatstr.format(color.stringc(u"[{0}]".format(match.rule.id), 'bright red'),
                                     color.stringc(match.message, 'red'),
-                                    color.stringc(match.filename, 'blue'),
+                                    color.stringc(normpath(match.filename), 'blue'),
                                     color.stringc(str(match.linenumber), 'cyan'),
                                     color.stringc(u"{0}".format(match.line), 'purple'))
         else:
@@ -30,10 +31,10 @@ class QuietFormatter(object):
         if colored:
             color.ANSIBLE_COLOR = True
             return formatstr.format(color.stringc(u"[{0}]".format(match.rule.id), 'bright red'),
-                                    color.stringc(match.filename, 'blue'),
+                                    color.stringc(normpath(match.filename), 'blue'),
                                     color.stringc(str(match.linenumber), 'cyan'))
         else:
-            return formatstr.format(match.rule.id, match.filename,
+            return formatstr.format(match.rule.id, normpath(match.filename),
                                     match.linenumber)
 
 
@@ -43,12 +44,12 @@ class ParseableFormatter(object):
         formatstr = u"{0}:{1}: [{2}] {3}"
         if colored:
             color.ANSIBLE_COLOR = True
-            return formatstr.format(color.stringc(match.filename, 'blue'),
+            return formatstr.format(color.stringc(normpath(match.filename), 'blue'),
                                     color.stringc(str(match.linenumber), 'cyan'),
                                     color.stringc(u"E{0}".format(match.rule.id), 'bright red'),
                                     color.stringc(u"{0}".format(match.message), 'red'))
         else:
-            return formatstr.format(match.filename,
+            return formatstr.format(normpath(match.filename),
                                     match.linenumber,
                                     "E" + match.rule.id,
                                     match.message)
@@ -59,7 +60,7 @@ class ParseableSeverityFormatter(object):
     def format(self, match, colored=False):
         formatstr = u"{0}:{1}: [{2}] [{3}] {4}"
 
-        filename = match.filename
+        filename = normpath(match.filename)
         linenumber = str(match.linenumber)
         rule_id = u"E{0}".format(match.rule.id)
         severity = match.rule.severity

--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -732,3 +732,13 @@ def get_rule_skips_from_line(line):
         noqa_text = line.split('# noqa')[1]
         rule_id_list = noqa_text.split()
     return rule_id_list
+
+
+def normpath(path):
+    """
+    Normalize a path in order to provide a more consistent output.
+
+    Currently it generates a relative path but in the future we may want to
+    make this user configurable.
+    """
+    return os.path.relpath(path)


### PR DESCRIPTION
Avoids displaying a mix of relative and absolute paths in tool output.

Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>