### PR TITLE
Enable flake-docstrings to check for pep257

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,3 +5,5 @@ repos:
   hooks:
   - id: flake8
     language_version: python3
+    additional_dependencies:
+    - flake8-docstrings

--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -238,5 +238,5 @@ html_static_path = ['_static']
 html_context = {
     'css_files': [
         '_static/theme_overrides.css',  # override wide tables in RTD theme
-        ],
-     }
+    ],
+}

--- a/lib/ansiblelint/__init__.py
+++ b/lib/ansiblelint/__init__.py
@@ -68,7 +68,7 @@ class AnsibleLintRule(object):
             message = None
             if isinstance(result, six.string_types):
                 message = result
-            matches.append(Match(prev_line_no+1, line,
+            matches.append(Match(prev_line_no + 1, line,
                            file['path'], self, message))
         return matches
 

--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -119,7 +119,7 @@ def main():
 
         if 'parseable_severity' in config:
             options.parseable_severity = options.parseable_severity or \
-                                         config['parseable_severity']
+                config['parseable_severity']
 
         if 'use_default_rules' in config:
             options.use_default_rules = options.use_default_rules or config['use_default_rules']

--- a/lib/ansiblelint/formatters/__init__.py
+++ b/lib/ansiblelint/formatters/__init__.py
@@ -1,3 +1,4 @@
+"""Output formatters."""
 try:
     from ansible import color
 except ImportError:

--- a/lib/ansiblelint/generate_docs.py
+++ b/lib/ansiblelint/generate_docs.py
@@ -1,4 +1,4 @@
-'''Script to generate rule table .rst documentation.'''
+"""Script to generate rule table .rst documentation."""
 
 import os
 import importlib
@@ -80,21 +80,21 @@ def get_serialized_rules():
 
 
 def make_table(grid):
-    cell_width = 2 + max(reduce(lambda x, y: x+y,
+    cell_width = 2 + max(reduce(lambda x, y: x + y,
                                 [[len(item) for item in row] for row in grid], []))
     num_cols = len(grid[0])
     block = DOC_HEADER
     header = True
     for row in grid:
         if header:
-            block = block + num_cols*((cell_width)*'=' + ' ') + '\n'
+            block = block + num_cols * ((cell_width) * '=' + ' ') + '\n'
 
-        block = block + ''.join([normalize_cell(x, cell_width+1)
+        block = block + ''.join([normalize_cell(x, cell_width + 1)
                                  for x in row]) + '\n'
         if header:
-            block = block + num_cols*((cell_width)*'=' + ' ') + '\n'
+            block = block + num_cols * ((cell_width) * '=' + ' ') + '\n'
         header = False
-    block = block + num_cols*((cell_width)*'=' + ' ') + '\n'
+    block = block + num_cols * ((cell_width) * '=' + ' ') + '\n'
     return block
 
 

--- a/lib/ansiblelint/rules/__init__.py
+++ b/lib/ansiblelint/rules/__init__.py
@@ -1,0 +1,1 @@
+"""All internal ansible-lint rules."""

--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -349,7 +349,7 @@ def rolename(filepath):
     idx = filepath.find('roles/')
     if idx < 0:
         return ''
-    role = filepath[idx+6:]
+    role = filepath[idx + 6:]
     role = role[:role.find('/')]
     return role
 
@@ -360,8 +360,7 @@ def _kv_to_dict(v):
 
 
 def normalize_task_v2(task):
-    '''Ensures tasks have an action key and strings are converted to python objects'''
-
+    """Ensure tasks have an action key and strings are converted to python objects."""
     result = dict()
     mod_arg_parser = ModuleArgsParser(task)
     try:
@@ -535,11 +534,10 @@ def get_normalized_tasks(yaml, file):
 
 
 def parse_yaml_linenumbers(data, filename):
-    """Parses yaml as ansible.utils.parse_yaml but with linenumbers.
+    """Parse yaml as ansible.utils.parse_yaml but with linenumbers.
 
     The line numbers are stored in each node's LINE_NUMBER_KEY key.
     """
-
     def compose_node(parent, index):
         # the line number where the previous token has ended (plus empty lines)
         line = loader.line
@@ -594,7 +592,6 @@ def append_skipped_rules(pyyaml_data, file_text, file_type):
     :returns: original pyyaml_data altered with a 'skipped_rules' list added
     to individual tasks, or added to the single metadata block.
     """
-
     try:
         yaml_skip = _append_skipped_rules(pyyaml_data, file_text, file_type)
     except RuntimeError as exc:
@@ -759,8 +756,8 @@ def is_playbook(filename):
             % (filename, e))
     else:
         if (
-            isinstance(f, AnsibleSequence)
-            and playbooks_keys.intersection(next(iter(f), {}).keys())
+            isinstance(f, AnsibleSequence) and
+            playbooks_keys.intersection(next(iter(f), {}).keys())
         ):
             return True
     return False
@@ -796,8 +793,8 @@ def get_playbooks_and_roles(options=None):
 
         if any(str(p).startswith(file_path) for file_path in options.exclude_paths):
             continue
-        elif (next((i for i in p.parts if i.endswith('playbooks')), None)
-                or 'playbook' in p.parts[-1]):
+        elif (next((i for i in p.parts if i.endswith('playbooks')), None) or
+                'playbook' in p.parts[-1]):
             playbooks.append(normpath(p))
             continue
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,17 @@ universal = 1
 [flake8]
 max-line-length = 100
 exclude = .git,.hg,.svn,__pycache__,.tox,.eggs,env
+ignore =
+  # TODO(ssbarnea): gradually address exceptions below:
+  D100  # D100 Missing docstring in public module
+  D101  # D101 Missing docstring in public class
+  D102  # D102 Missing docstring in public method
+  D103  # D103 Missing docstring in public function
+  D104  # D104 Missing docstring in public package
+  D105  # D105 Missing docstring in magic method
+  D107  # D107 Missing docstring in __init__
+  # W503 is incompatible with W504
+  W504  # W504 line break after binary operator
 
 [metadata]
 name = ansible-lint

--- a/test/TestCliRolePaths.py
+++ b/test/TestCliRolePaths.py
@@ -79,7 +79,7 @@ class TestCliRolePaths(unittest.TestCase):
                       str(result))
 
     def test_run_playbook(self):
-        '''Call ansible-lint the way molecule does'''
+        """Call ansible-lint the way molecule does."""
         top_src_dir = os.path.dirname(self.local_test_dir)
         cwd = os.path.join(top_src_dir, 'test/roles/test-role')
         bin = top_src_dir + '/bin/ansible-lint'

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -111,10 +111,10 @@ class TestUtils(unittest.TestCase):
 
     def test_extract_from_list(self):
         block = {
-                'block': [{'tasks': {'name': 'hello', 'command': 'whoami'}}],
-                'test_none': None,
-                'test_string': 'foo'
-                }
+            'block': [{'tasks': {'name': 'hello', 'command': 'whoami'}}],
+            'test_none': None,
+            'test_string': 'foo',
+        }
         blocks = [block]
 
         test_list = utils.extract_from_list(blocks, ['block'])


### PR DESCRIPTION
Enables checking of docstrings in order to assure compliance with
PEP257.

Because the codebase was never checked for this we are forced to disable
some of the rules and address them in follow-ups. This will ease code
reviews and avoid having too wide changes.

Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>