### PR TITLE
Drop code related to Ansible version before 2.4

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,9 +30,9 @@ Standards
 ansible-lint is flake8 compliant with `max-line-length` set to 100
 (see [setup.cfg](setup.cfg)).
 
-ansible-lint works with both Ansible 1.9 and Ansible 2.0 onwards. This will be
-the case for the foreseeable future, so please ensure all contributions work
-with both.
+ansible-lint works only with [supported Ansible versions](
+https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html#release-status
+) at the time it was released.
 
 Automated tests will be run against all PRs for flake8 compliance and Ansible
 compatibility - to check before pushing commits, just use `tox`.

--- a/test/TestRunner.py
+++ b/test/TestRunner.py
@@ -92,15 +92,9 @@ class TestRule(unittest.TestCase):
         assert (len(runner.run()) == 0)
 
     def test_runner_encrypted_secrets(self):
-        from pkg_resources import parse_version
-        import ansible
-        # Only run this test for ansible 2.3+
-        # It checks ansible-lint's parsing of yaml files that contain
-        # encrypted secrets.
-        if parse_version(ansible.__version__) >= parse_version('2.3'):
-            filename = 'test/contains_secrets.yml'
-            runner = Runner(self.rules, filename, [], [], [])
-            assert (len(runner.run()) == 0)
+        filename = 'test/contains_secrets.yml'
+        runner = Runner(self.rules, filename, [], [], [])
+        assert (len(runner.run()) == 0)
 
     def test_dir_with_trailing_slash(self):
         filename = 'test/'

--- a/test/TestTaskIncludes.py
+++ b/test/TestTaskIncludes.py
@@ -1,9 +1,7 @@
 import os
 import unittest
-import ansible
 
 from ansiblelint import Runner, RulesCollection
-from pkg_resources import parse_version
 
 
 class TestTaskIncludes(unittest.TestCase):
@@ -30,16 +28,12 @@ class TestTaskIncludes(unittest.TestCase):
         runner.run()
         self.assertEqual(len(runner.playbooks), 4)
 
-    @unittest.skipIf(parse_version(ansible.__version__) < parse_version('2.4'),
-                     "not supported with ansible < 2.4")
     def test_include_tasks_2_4_style(self):
         filename = 'test/taskincludes_2_4_style.yml'
         runner = Runner(self.rules, filename, [], [], [])
         runner.run()
         self.assertEqual(len(runner.playbooks), 4)
 
-    @unittest.skipIf(parse_version(ansible.__version__) < parse_version('2.4'),
-                     "not supported with ansible < 2.4")
     def test_import_tasks_2_4_style(self):
         filename = 'test/taskimports.yml'
         runner = Runner(self.rules, filename, [], [], [])
@@ -52,8 +46,6 @@ class TestTaskIncludes(unittest.TestCase):
         runner.run()
         self.assertEqual(len(runner.playbooks), 3)
 
-    @unittest.skipIf(parse_version(ansible.__version__) < parse_version('2.4'),
-                     "not supported with ansible < 2.4")
     def test_include_tasks_in_role(self):
         filename = 'test/include-import-tasks-in-role.yml'
         runner = Runner(self.rules, filename, [], [], [])


### PR DESCRIPTION
Remove any code related to very old versions of Ansible.

This should make code easier to maintain, test and refactor.

Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>