### PR TITLE
Fix normpath method under python2.7

### DIFF
--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -749,7 +749,9 @@ def normpath(path):
     Currently it generates a relative path but in the future we may want to
     make this user configurable.
     """
-    return os.path.relpath(path)
+    # convertion to string in order to allow receiving non string objects as
+    # arguments which would have failed under python2
+    return os.path.relpath(str(path))
 
 
 def is_playbook(filename):

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -21,6 +21,10 @@
 # THE SOFTWARE.
 
 import unittest
+try:
+    from pathlib import Path
+except ImportError:
+    from pathlib2 import Path
 
 import ansiblelint.utils as utils
 
@@ -140,3 +144,13 @@ class TestUtils(unittest.TestCase):
         task = dict(fail=dict(msg=u"unicode é ô à"))
         result = utils.task_to_str(utils.normalize_task(task, 'filename.yml'))
         self.assertEqual(result, u"fail msg=unicode é ô à")
+
+    def test_normpath_with_path_object(self):
+        self.assertEqual(
+            utils.normpath(Path("a/b/../")),
+            "a")
+
+    def test_normpath_with_string(self):
+        self.assertEqual(
+            utils.normpath("a/b/../"),
+            "a")


### PR DESCRIPTION
Avoids exception: AttributeError: 'PosixPath' object has no attribute 'startswith'

```
  File "/home/zuul/.cache/pre-commit/repokg740X/py_env-python2.7/bin/ansible-lint", line 8, in 
    sys.exit(main())
  File "/home/zuul/.cache/pre-commit/repokg740X/py_env-python2.7/lib/python2.7/site-packages/ansiblelint/__main__.py", line 153, in main
    args = get_playbooks_and_roles(options=options)
  File "/home/zuul/.cache/pre-commit/repokg740X/py_env-python2.7/lib/python2.7/site-packages/ansiblelint/utils.py", line 847, in get_playbooks_and_roles
    playbooks.append(normpath(p))
  File "/home/zuul/.cache/pre-commit/repokg740X/py_env-python2.7/lib/python2.7/site-packages/ansiblelint/utils.py", line 752, in normpath
    return os.path.relpath(path)
  File "/home/zuul/.cache/pre-commit/repokg740X/py_env-python2.7/lib64/python2.7/posixpath.py", line 423, in relpath
    path_list = [x for x in abspath(path).split(sep) if x]
  File "/home/zuul/.cache/pre-commit/repokg740X/py_env-python2.7/lib64/python2.7/posixpath.py", line 352, in abspath
    if not isabs(path):
  File "/home/zuul/.cache/pre-commit/repokg740X/py_env-python2.7/lib64/python2.7/posixpath.py", line 61, in isabs
    return s.startswith('/')
AttributeError: 'PosixPath' object has no attribute 'startswith'
```
Seen on http://logs.rdoproject.org/91/23591/6/check/tox-linters/861d3a1/job-output.txt