### PR TITLE
DNM: used to test CI status

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@
 Ansible-lint
 ============
 
-``ansible-lint`` checks playbooks for practices and behaviour that could
+``ansible-lint`` checks playbooks and roles for practices and behaviour that could
 potentially be improved.
 
 `Visit the Ansible Lint docs site <https://docs.ansible.com/ansible-lint/>`_


### PR DESCRIPTION
Ignore this PR, we should used it to test if CI tests are working well on master.