### PR TITLE
Disable docs build on macos with py38

### DIFF
--- a/.github/workflows/tox-linters.yml
+++ b/.github/workflows/tox-linters.yml
@@ -41,6 +41,11 @@ jobs:
         # - TOXENV: pre-commit-ci
         # - TOXENV: check-docs
         # - TOXENV: build-docs
+        exclude:
+        # Excluded until sphinx bug is fixed
+        # https://github.com/sphinx-doc/sphinx/issues/6803
+        - os: macOS-10.14
+          python-version: 3.8
 
     steps:
     - uses: actions/checkout@master


### PR DESCRIPTION
We avoid broken Sphinx on specific platform until upstream bug is fixed.

CI was broken by enablement of broken job via a merge that ignored CI
result.

Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>