### PR TITLE
Fix pre_tasks include playbook error

### DIFF
--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -614,7 +614,7 @@ def _append_skipped_rules(pyyaml_data, file_text, file_type):
     if file_type in ('tasks', 'handlers'):
         ruamel_task_blocks = ruamel_data
         pyyaml_task_blocks = pyyaml_data
-    elif file_type == 'playbook':
+    elif file_type in ('playbook', 'pre_tasks', 'post_tasks'):
         try:
             pyyaml_task_blocks = _get_task_blocks_from_playbook(pyyaml_data)
             ruamel_task_blocks = _get_task_blocks_from_playbook(ruamel_data)

--- a/test/TestPretaskIncludePlaybook.py
+++ b/test/TestPretaskIncludePlaybook.py
@@ -1,0 +1,35 @@
+import os
+import unittest
+
+from ansiblelint import Runner, RulesCollection
+
+
+class TestTaskIncludes(unittest.TestCase):
+
+    def setUp(self):
+        rulesdir = os.path.join('lib', 'ansiblelint', 'rules')
+        self.rules = RulesCollection.create_from_directory(rulesdir)
+
+    def test_pre_task_include_playbook(self):
+        filename = 'test/playbook-include/playbook_pre.yml'
+        runner = Runner(self.rules, filename, [], [], [])
+        results = runner.run()
+
+        self.assertEqual(len(runner.playbooks), 2)
+        self.assertEqual(len(results), 3)
+        self.assertIn('Commands should not change things', str(results))
+
+        self.assertNotIn('502', str(results))
+        self.assertNotIn('All tasks should be named', str(results))
+
+    def test_post_task_include_playbook(self):
+        filename = 'test/playbook-include/playbook_post.yml'
+        runner = Runner(self.rules, filename, [], [], [])
+        results = runner.run()
+
+        self.assertEqual(len(runner.playbooks), 2)
+        self.assertEqual(len(results), 3)
+        self.assertIn('Commands should not change things', str(results))
+
+        self.assertNotIn('502', str(results))
+        self.assertNotIn('All tasks should be named', str(results))

--- a/test/playbook-include/playbook_included.yml
+++ b/test/playbook-include/playbook_included.yml
@@ -1,0 +1,9 @@
+---
+- hosts: localhost
+  connection: local
+  gather_facts: no
+  tasks:
+  - command: echo "no name"  # noqa 502
+  - name: Another task
+    debug:
+      msg: debug message

--- a/test/playbook-include/playbook_post.yml
+++ b/test/playbook-include/playbook_post.yml
@@ -1,0 +1,8 @@
+---
+- hosts: localhost
+  tasks:
+  - command: echo "no name"  # noqa 502
+  post_tasks:
+    - command: echo "no name"  # noqa 502
+    - name: Including another playbook
+      include: playbook_included.yml

--- a/test/playbook-include/playbook_pre.yml
+++ b/test/playbook-include/playbook_pre.yml
@@ -1,0 +1,8 @@
+---
+- hosts: localhost
+  tasks:
+  - command: echo "no name"  # noqa 502
+  pre_tasks:
+    - command: echo "no name"  # noqa 502
+    - name: Including another playbook
+      include: playbook_included.yml


### PR DESCRIPTION
Fixes #640: error when playbook `pre_tasks` or `post_tasks` uses `include:` for another playbook file.