### PR TITLE
[WIP] Support tasks using modules from collections

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,16 +12,16 @@ strategy:
   matrix:
     Python27:
       python.version: '2.7'
-      TOXENV: ansible{29,28,27,devel}
+      TOXENV: ansible{29,28,27}
     Python35:
       python.version: '3.5'
-      TOXENV: ansible{29,28,27,devel}
+      TOXENV: ansible{29,28,27}
     Python36:
       python.version: '3.6'
-      TOXENV: ansible{29,28,27,devel}
+      TOXENV: ansible{29,28,27}
     Python37:
       python.version: '3.7'
-      TOXENV: ansible{29,28,27,devel}
+      TOXENV: ansible{29,28,27}
 
 steps:
 - task: UsePythonVersion@0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ requires = [
   "ansible",
   "pathlib2; python_version < '3.2'",
   "ruamel.yaml",
+  "semver",
   "six",
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -93,6 +93,7 @@ setup_requires =
 install_requires =
   ansible >= 2.7
   pyyaml
+  semver
   six
   pathlib2; python_version < "3.2"
   ruamel.yaml >= 0.15.34,<1; python_version < "3.7"

--- a/test/TestAlwaysRunRule.py
+++ b/test/TestAlwaysRunRule.py
@@ -1,6 +1,9 @@
 import unittest
+
+from ansible import __version__ as ANSIBLE_VERSION
 from ansiblelint import RulesCollection, Runner
 from ansiblelint.rules.AlwaysRunRule import AlwaysRunRule
+import semver
 
 
 class TestAlwaysRun(unittest.TestCase):
@@ -9,11 +12,15 @@ class TestAlwaysRun(unittest.TestCase):
     def setUp(self):
         self.collection.register(AlwaysRunRule())
 
+    @unittest.skipIf(semver.match(ANSIBLE_VERSION, '>=2.7.0'),
+                     "'always_run' not supported in this ansible version range")
     def test_file_positive(self):
         success = 'test/always-run-success.yml'
         good_runner = Runner(self.collection, success, [], [], [])
         self.assertEqual([], good_runner.run())
 
+    @unittest.skipIf(semver.match(ANSIBLE_VERSION, '>=2.7.0'),
+                     "'always_run' not supported in this ansible version range")
     def test_file_negative(self):
         failure = 'test/always-run-failure.yml'
         bad_runner = Runner(self.collection, failure, [], [], [])

--- a/test/TestSudoRule.py
+++ b/test/TestSudoRule.py
@@ -1,7 +1,9 @@
 import unittest
 
+from ansible import __version__ as ANSIBLE_VERSION
 from ansiblelint import RulesCollection
 from ansiblelint.rules.SudoRule import SudoRule
+import semver
 from test import RunFromText
 
 ROLE_2_ERRORS = '''
@@ -49,18 +51,26 @@ class TestSudoRule(unittest.TestCase):
     def setUp(self):
         self.runner = RunFromText(self.collection)
 
+    @unittest.skipIf(semver.match(ANSIBLE_VERSION, '>=2.9.0'),
+                     "'sudo' not supported in this ansible version range")
     def test_run_role_fail(self):
         results = self.runner.run_role_tasks_main(ROLE_2_ERRORS)
         self.assertEqual(2, len(results))
 
+    @unittest.skipIf(semver.match(ANSIBLE_VERSION, '>=2.9.0'),
+                     "'sudo' not supported in this ansible version range")
     def test_run_role_pass(self):
         results = self.runner.run_role_tasks_main(ROLE_0_ERRORS)
         self.assertEqual(0, len(results))
 
+    @unittest.skipIf(semver.match(ANSIBLE_VERSION, '>=2.9.0'),
+                     "'sudo' not supported in this ansible version range")
     def test_play_root_and_task_fail(self):
         results = self.runner.run_playbook(PLAY_4_ERRORS)
         self.assertEqual(4, len(results))
 
+    @unittest.skipIf(semver.match(ANSIBLE_VERSION, '>=2.9.0'),
+                     "'sudo' not supported in this ansible version range")
     def test_play_task_fail(self):
         results = self.runner.run_playbook(PLAY_1_ERROR)
         self.assertEqual(1, len(results))

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.5.3
-envlist = lint,py{38,37,36,35,27}-ansible{29,28,27,devel}
+envlist = lint,py{38,37,36,35,27}-ansible{29,28,27}
 isolated_build = true
 requires =
   setuptools >= 41.4.0
@@ -14,13 +14,13 @@ deps =
   ansible27: ansible>=2.7,<2.8
   ansible28: ansible>=2.8,<2.9
   ansible29: ansible>=2.9,<2.10
-  ansibledevel: git+https://github.com/ansible/ansible.git
   ruamel.yaml==0.16.5  # NOTE: 0.15.34 has issues with py37
   flake8
   pep8-naming
   pytest
   pytest-cov
   pytest-xdist
+  semver
   # Needed to avoid DeprecationWarning errors in pytest:
   setuptools >= 40.4.3
   wheel


### PR DESCRIPTION
With this PR ansible-lint with ansible 2.9 uses updated ansible parser logic to determine the module action even though the collection is not installed (which it is not assumed to be during linting). So this allows linting of tasks using a collection module. This PR resolves #538, and resolves #372 (errors using local modules)

Notes:
- TestAlwaysRunRule.py can be removed since it is skipped for 2.7+ and ansible-lint requires 2.7+
- This PR skips testing against ansible devel since https://github.com/ansible/ansible/blob/devel/lib/ansible/release.py#L22 dev version is not semver compliant, this would work if it were `2.10.0-dev0` or `2.10.0+dev0`
