### PR TITLE
Added note regarding pip requirements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,8 @@ Using Pip
 From Source
 -----------
 
+**Note**: pip 19.0+ is required for installation.
+
 .. code-block:: bash
 
     pip install git+https://github.com/ansible/ansible-lint.git

--- a/README.rst
+++ b/README.rst
@@ -44,11 +44,14 @@ Using Pip
 From Source
 -----------
 
-**Note**: pip 19.0+ is required for installation.
+**Note**: pip 19.0+ is required for installation. Please consult with the `PyPA User Guide`_
+to learn more about managing Pip versions.
 
 .. code-block:: bash
 
     pip install git+https://github.com/ansible/ansible-lint.git
+
+.. _PyPA User Guide: https://packaging.python.org/tutorials/installing-packages/#ensure-pip-setuptools-and-wheel-are-up-to-date
 
 .. installing-docs-inclusion-marker-end-do-not-remove
 


### PR DESCRIPTION
Since the project switched to PEP517 installation
only, it is required to have pip 19.0+ installed.
Earlier versions of pip don't support PEP517 style
installation.

Added note to README to inform about this

Relates to #643