### PR TITLE
Update readme to include new usage options.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,7 +90,7 @@ The following is the output from ``ansible-lint --help``, providing an overview 
                             path to directories or files to skip. This option is
                             repeatable.
       -c /path/to/file      Specify configuration file to use.  Defaults to
-                            ".ansible-lint"
+                              ".ansible-lint"
 
 
 

--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ The following is the output from ``ansible-lint --help``, providing an overview 
 
 .. code-block:: bash
 
-    Usage: ansible-lint [options] [playbook.yml [playbook2 ...]]
+    Usage: ansible-lint [options] [playbook.yml [playbook2 ...]]|roledirectory
 
     Options:
       --version             show program's version number and exit
@@ -89,7 +89,7 @@ The following is the output from ``ansible-lint --help``, providing an overview 
       --exclude=EXCLUDE_PATHS
                             path to directories or files to skip. This option is
                             repeatable.
-      -c C                  Specify configuration file to use.  Defaults to
+      -c /path/to/file      Specify configuration file to use.  Defaults to
                             ".ansible-lint"
 
 

--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ The following is the output from ``ansible-lint --help``, providing an overview 
 
 .. code-block:: bash
 
-    Usage: ansible-lint playbook.yml|roledirectory ...
+    Usage: ansible-lint [options] [playbook.yml [playbook2 ...]]
 
     Options:
       --version             show program's version number and exit
@@ -70,6 +70,7 @@ The following is the output from ``ansible-lint --help``, providing an overview 
       -L                    list all the rules
       -q                    quieter, although not silent output
       -p                    parseable output in the format of pep8
+      --parseable-severity  parseable output including severity of rule
       -r RULESDIR           specify one or more rules directories using one or
                             more -r arguments. Any -r flags override the default
                             rules in ['/path/to/ansible-
@@ -80,15 +81,16 @@ The following is the output from ``ansible-lint --help``, providing an overview 
                             to specify this if no -r flags are used
       -t TAGS               only check rules whose id/tags match these values
       -T                    list all the tags
+      -v                    Increase verbosity level
       -x SKIP_LIST          only check rules whose id/tags do not match these
                             values
+      --nocolor             disable colored output
+      --force-color         Try force colored output (relying on ansible's code)
       --exclude=EXCLUDE_PATHS
                             path to directories or files to skip. This option is
                             repeatable.
-      --force-color         Try force colored output (relying on ansible's code)
-      --nocolor             disable colored output
-      -c /path/to/file      Specify configuration file to use.  Defaults to
-                              ".ansible-lint"
+      -c C                  Specify configuration file to use.  Defaults to
+                            ".ansible-lint"
 
 
 


### PR DESCRIPTION
parseable-severity and extra verbosity are missing on the readme as usage options