### PR TITLE
Make ansible-lint installable in editable mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -158,3 +158,4 @@ install:
 
 script:
 - tox -v
+- pip install -e .  # Validates that project can install in editable mode

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,10 @@
+#! /usr/bin/env python
+"""ansible-lint distribution package setuptools installer."""
+
+import setuptools
+
+
+if __name__ == "__main__":
+    setuptools.setup(
+        use_scm_version=True, setup_requires=["setuptools_scm"],
+    )


### PR DESCRIPTION
The change is also adding a regression protection in CI jobs by testing that editable installation is possible after it runs the normal tox environments.

Considering the CI determines what is supported or not I see no reason for not fixing this issue. 
When most (in not all) python development tools like tox, pytest, flake8, pre-commit, black are installable in editable mode, I am confident to challenge the reasons for preventing ansible-lint from doing the same.

Fixes: #653
Fixes: #716