### PR TITLE
Avoid error when include_role uses role instead of name

### DIFF
--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -237,13 +237,17 @@ def _taskshandlers_children(basedir, k, v, parent_type):
             append_children(th['import_playbook'], basedir, k, parent_type, results)
         elif 'import_tasks' in th:
             append_children(th['import_tasks'], basedir, k, parent_type, results)
-        elif 'import_role' in th:
+        elif 'include_role' in th or 'import_role' in th:
             th = normalize_task_v2(th)
-            results.extend(_roles_children(basedir, k, [th['action'].get('name')], parent_type,
-                                           main=th['action'].get('tasks_from', 'main')))
-        elif 'include_role' in th:
-            th = normalize_task_v2(th)
-            results.extend(_roles_children(basedir, k, [th['action'].get('name')],
+            module = th['action']['__ansible_module__']
+            if "name" not in th['action']:
+                raise RuntimeError(
+                    "Failed to find required 'name' key in %s" % module)
+            if not isinstance(th['action']["name"], six.string_types):
+                raise RuntimeError(
+                    "Value assigned to 'name' key on '%s' is not a string." %
+                    module)
+            results.extend(_roles_children(basedir, k, [th['action'].get("name")],
                                            parent_type,
                                            main=th['action'].get('tasks_from', 'main')))
         elif 'block' in th:

--- a/test/TestImportIncludeRole.py
+++ b/test/TestImportIncludeRole.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 import unittest
 import tempfile
 import shutil
@@ -20,6 +21,14 @@ PLAY_IMPORT_ROLE = '''
   tasks:
     - import_role:
         name: test-role
+'''
+
+PLAY_IMPORT_ROLE_INCOMPLETE = '''
+- hosts: all
+
+  tasks:
+    - import_role:
+        foo: bar
 '''
 
 PLAY_IMPORT_ROLE_INLINE = '''
@@ -93,3 +102,9 @@ class TestImportIncludeRole(unittest.TestCase):
         results = runner.run()
         assert 'only when shell functionality is required' in str(results)
         assert 'All tasks should be named' in str(results)
+
+    def test_invalid_import_role(self):
+        fh = self._get_play_file(PLAY_IMPORT_ROLE_INCOMPLETE)
+        runner = Runner(self.rules, fh.name, [], [], [])
+        with pytest.raises(RuntimeError, match="Failed to find required 'name' key in import_role"):
+            runner.run()


### PR DESCRIPTION
While Ansible documents only `name` as accepted for `include_role` and `import_role` it does silently accept `role` alias.

We match Ansible behaviour instead of crashing during parsing.

Fixes: #652