### PR TITLE
Enable Zuul CI Jobs

### DIFF
--- a/tools/test-setup.sh
+++ b/tools/test-setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euxo pipefail
+set -Eeuxo pipefail
 # Used by Zuul CI to perform extra bootstrapping
 
 # Bumping system tox because version from CentOS 7 is too old

--- a/tools/test-setup.sh
+++ b/tools/test-setup.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euxo pipefail
+# Used by Zuul CI to perform extra bootstrapping
+
+# Bumping system tox because version from CentOS 7 is too old
+# We are not using pip --user due to few bugs in tox role which does not allow
+# us to override how is called. Once these are addressed we will switch back
+# non-sudo mode.
+PYTHON=$(command -v python3 python | head -n1)
+
+sudo "$PYTHON" -m pip install -U tox "zipp<0.6.0;python_version=='2.7'"

--- a/zuul.d/layout.yaml
+++ b/zuul.d/layout.yaml
@@ -1,0 +1,40 @@
+---
+# zuul.d/layout.yaml
+- job:
+    name: tox-py27-ansible28
+    parent: ansible-tox-py27
+    vars:
+      tox_envlist: py27-ansible28
+
+- job:
+    name: tox-py37-ansible28
+    parent: ansible-tox-py37
+    vars:
+      tox_envlist: py37-ansible28
+
+- project:
+    check:
+      jobs: &defaults
+        - tox-linters:
+            vars:
+              tox_envlist: lint
+        - tox-docs
+        - tox-py27:
+            vars:
+              tox_envlist: py27-ansible29
+        - tox-py27-ansible28
+        - tox-py35:
+            vars:
+              tox_envlist: py35-ansible29
+        - tox-py36:
+            vars:
+              tox_envlist: py36-ansible29
+        - tox-py37:
+            vars:
+              tox_envlist: py37-ansible29
+        - tox-py37-ansible28
+        - tox-py38:
+            vars:
+              tox_envlist: py38-ansible29
+    gate:
+      jobs: *defaults


### PR DESCRIPTION
@gundalow Please activate https://github.com/apps/ansible-zuul for this repo so we can test it, activating it does not mean it will act as required.

## 2020-02-27 Update
As all molecule* projects where already succesfully migrated to Zuul CI, during the last months, we can say that now it should be the right time to enable it on ansible-lint too, but only as a 3rd party CI, without replacing the dual-CI config already configured by @webknjaz 

Recent bugs regarding failure to install as a pre-commit hook under centos-7, created more pressure for setting CI that runs on our platforms. Once we enable Zuul, we will be able to add extra coverage for bugs like that.

With @pabelanger help I can take care of configuring zuul project and the jobs running on it.