### PR TITLE
var-space-rule: Fix nested JSON obj false positive

### DIFF
--- a/lib/ansiblelint/rules/VariableHasSpacesRule.py
+++ b/lib/ansiblelint/rules/VariableHasSpacesRule.py
@@ -19,4 +19,5 @@ class VariableHasSpacesRule(AnsibleLintRule):
     def match(self, file, line):
         if not self.variable_syntax.search(line):
             return
-        return self.bracket_regex.search(line)
+        line_exclude_json = re.sub(r"[^{]{'\w+': ?[^{]{.*?}}", "", line)
+        return self.bracket_regex.search(line_exclude_json)


### PR DESCRIPTION
When using compact form nested JSON object within a
Jinja2 context as shown in the following example:
  set_fact:"{{ {'test': {'subtest': variable}} }}"

'variable}}' will raise a false positive [206] error.

This commit adds an intermediate step within 206
(VariableHasSpacesRule.py) rule to exclude nested
JSON object before matching for an actual error.

Fixes: #665 

Signed-off-by: Simon Kheng <simon.kheng1337@gmail.com>