### PR TITLE
Expand environment vars and ~

### DIFF
--- a/lib/ansiblelint/__init__.py
+++ b/lib/ansiblelint/__init__.py
@@ -196,7 +196,7 @@ class RulesCollection(object):
     @classmethod
     def create_from_directory(cls, rulesdir):
         result = cls()
-        result.rules = ansiblelint.utils.load_plugins(os.path.expanduser(rulesdir))
+        result.rules = ansiblelint.utils.load_plugins(rulesdir)
         return result
 
 

--- a/lib/ansiblelint/__init__.py
+++ b/lib/ansiblelint/__init__.py
@@ -196,6 +196,8 @@ class RulesCollection(object):
     @classmethod
     def create_from_directory(cls, rulesdir):
         result = cls()
+        rulesdir = os.path.expanduser(rulesdir)
+        rulesdir = os.path.expanduser(rulesdir)
         result.rules = ansiblelint.utils.load_plugins(rulesdir)
         return result
 

--- a/lib/ansiblelint/__init__.py
+++ b/lib/ansiblelint/__init__.py
@@ -140,10 +140,13 @@ class AnsibleLintRule(object):
 
 class RulesCollection(object):
 
-    def __init__(self, rulesdirs=[]):
-        self._update_rulesdirs(rulesdirs)
+    def __init__(self, rulesdirs=None):
+        if rulesdirs is None:
+            rulesdirs = []
+        self.rulesdirs = ansiblelint.utils.expand_paths_vars(rulesdirs)
         self.rules = []
-        self._update_rules(self.rulesdirs)
+        for rulesdir in self.rulesdirs:
+            self.extend(ansiblelint.utils.load_plugins(rulesdir))
 
     def register(self, obj):
         self.rules.append(obj)
@@ -153,14 +156,6 @@ class RulesCollection(object):
 
     def __len__(self):
         return len(self.rules)
-
-    def _update_rulesdirs(self, rulesdirs):
-        rulesdirs = ansiblelint.utils.expand_paths_vars(rulesdirs)
-        self.rulesdirs = rulesdirs
-
-    def _update_rules(self, rulesdirs):
-        for rulesdir in rulesdirs:
-            self.extend(ansiblelint.utils.load_plugins(rulesdir))
 
     def extend(self, more):
         self.rules.extend(more)

--- a/lib/ansiblelint/__init__.py
+++ b/lib/ansiblelint/__init__.py
@@ -198,14 +198,6 @@ class RulesCollection(object):
             results.append("{0} {1}".format(tag, tags[tag]))
         return "\n".join(results)
 
-    @classmethod
-    def create_from_directory(cls, rulesdir):
-        result = cls()
-        rulesdir = os.path.expanduser(rulesdir)
-        rulesdir = os.path.expandvars(rulesdir)
-        result.rules = ansiblelint.utils.load_plugins(rulesdir)
-        return result
-
 
 class Match(object):
 

--- a/lib/ansiblelint/__init__.py
+++ b/lib/ansiblelint/__init__.py
@@ -155,8 +155,7 @@ class RulesCollection(object):
         return len(self.rules)
 
     def _update_rulesdirs(self, rulesdirs):
-        rulesdirs = [os.path.expanduser(p) for p in rulesdirs]
-        rulesdirs = [os.path.expandvars(p) for p in rulesdirs]
+        rulesdirs = ansiblelint.utils.expand_paths_vars(rulesdirs)
         self.rulesdirs = rulesdirs
 
     def _update_rules(self, rulesdirs):
@@ -252,10 +251,7 @@ class Runner(object):
     def _update_exclude_paths(self, exclude_paths):
         if exclude_paths:
             # These will be (potentially) relative paths
-            paths = [s.strip() for s in exclude_paths]
-            # Expand ~ and other environment vars such as $HOME
-            paths = [os.path.expanduser(s) for s in paths]
-            paths = [os.path.expandvars(s) for s in paths]
+            paths = ansiblelint.utils.expand_paths_vars(exclude_paths)
             # Since ansiblelint.utils.find_children returns absolute paths,
             # and the list of files we create in `Runner.run` can contain both
             # relative and absolute paths, we need to cover both bases.

--- a/lib/ansiblelint/__init__.py
+++ b/lib/ansiblelint/__init__.py
@@ -197,7 +197,7 @@ class RulesCollection(object):
     def create_from_directory(cls, rulesdir):
         result = cls()
         rulesdir = os.path.expanduser(rulesdir)
-        rulesdir = os.path.expanduser(rulesdir)
+        rulesdir = os.path.expandvars(rulesdir)
         result.rules = ansiblelint.utils.load_plugins(rulesdir)
         return result
 

--- a/lib/ansiblelint/__init__.py
+++ b/lib/ansiblelint/__init__.py
@@ -240,6 +240,9 @@ class Runner(object):
         if exclude_paths:
             # These will be (potentially) relative paths
             paths = [s.strip() for s in exclude_paths]
+            # Expand ~ and other environment vars such as $HOME
+            paths = [os.path.expanduser(s) for s in paths]
+            paths = [os.path.expandvars(s) for s in paths]
             # Since ansiblelint.utils.find_children returns absolute paths,
             # and the list of files we create in `Runner.run` can contain both
             # relative and absolute paths, we need to cover both bases.

--- a/lib/ansiblelint/__init__.py
+++ b/lib/ansiblelint/__init__.py
@@ -140,8 +140,10 @@ class AnsibleLintRule(object):
 
 class RulesCollection(object):
 
-    def __init__(self):
+    def __init__(self, rulesdirs=[]):
+        self._update_rulesdirs(rulesdirs)
         self.rules = []
+        self._update_rules(self.rulesdirs)
 
     def register(self, obj):
         self.rules.append(obj)
@@ -151,6 +153,15 @@ class RulesCollection(object):
 
     def __len__(self):
         return len(self.rules)
+
+    def _update_rulesdirs(self, rulesdirs):
+        rulesdirs = [os.path.expanduser(p) for p in rulesdirs]
+        rulesdirs = [os.path.expandvars(p) for p in rulesdirs]
+        self.rulesdirs = rulesdirs
+
+    def _update_rules(self, rulesdirs):
+        for rulesdir in rulesdirs:
+            self.extend(ansiblelint.utils.load_plugins(rulesdir))
 
     def extend(self, more):
         self.rules.extend(more)

--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -159,6 +159,8 @@ def main():
         rulesdirs = options.rulesdir or [default_rulesdir]
 
     rules = RulesCollection()
+    rulesdirs = [os.path.expanduser(s) for s in rulesdirs]
+    rulesdirs = [os.path.expandvars(s) for s in rulesdirs]
     for rulesdir in rulesdirs:
         rules.extend(RulesCollection.create_from_directory(rulesdir))
 

--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -159,8 +159,6 @@ def main():
         rulesdirs = options.rulesdir or [default_rulesdir]
 
     rules = RulesCollection()
-    rulesdirs = [os.path.expanduser(s) for s in rulesdirs]
-    rulesdirs = [os.path.expandvars(s) for s in rulesdirs]
     for rulesdir in rulesdirs:
         rules.extend(RulesCollection.create_from_directory(rulesdir))
 

--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -157,10 +157,7 @@ def main():
         rulesdirs = options.rulesdir + [default_rulesdir]
     else:
         rulesdirs = options.rulesdir or [default_rulesdir]
-
-    rules = RulesCollection()
-    for rulesdir in rulesdirs:
-        rules.extend(RulesCollection.create_from_directory(rulesdir))
+    rules = RulesCollection(rulesdirs)
 
     if options.listrules:
         print(rules)

--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -861,3 +861,17 @@ def get_playbooks_and_roles(options=None):
         print('Found playbooks: ' + ' '.join(playbooks))
 
     return role_dirs + playbooks
+
+
+def expand_path_vars(path):
+    """Expand the environment or ~ variables in a path string."""
+    path = path.strip()
+    path = os.path.expanduser(path)
+    path = os.path.expandvars(path)
+    return path
+
+
+def expand_paths_vars(paths):
+    """Expand the environment or ~ variables in a list."""
+    paths = [expand_path_vars(p) for p in paths]
+    return paths

--- a/test/TestDependenciesInMeta.py
+++ b/test/TestDependenciesInMeta.py
@@ -8,7 +8,7 @@ class TestDependenciesInMeta(unittest.TestCase):
 
     def setUp(self):
         rulesdir = os.path.join('lib', 'ansiblelint', 'rules')
-        self.rules = RulesCollection.create_from_directory(rulesdir)
+        self.rules = RulesCollection([rulesdir])
 
     def test_bitbucket_in_meta_dependency_is_ok(self):
         filename = 'test/dependency-in-meta/bitbucket.yml'

--- a/test/TestImportIncludeRole.py
+++ b/test/TestImportIncludeRole.py
@@ -49,7 +49,7 @@ PLAY_INCLUDE_ROLE_INLINE = '''
 class TestImportIncludeRole(unittest.TestCase):
     def setUp(self):
         rulesdir = os.path.join('lib', 'ansiblelint', 'rules')
-        self.rules = RulesCollection.create_from_directory(rulesdir)
+        self.rules = RulesCollection([rulesdir])
 
         # make dir and write role tasks to import or include
         self.play_root = tempfile.mkdtemp()

--- a/test/TestPretaskIncludePlaybook.py
+++ b/test/TestPretaskIncludePlaybook.py
@@ -8,7 +8,7 @@ class TestTaskIncludes(unittest.TestCase):
 
     def setUp(self):
         rulesdir = os.path.join('lib', 'ansiblelint', 'rules')
-        self.rules = RulesCollection.create_from_directory(rulesdir)
+        self.rules = RulesCollection([rulesdir])
 
     def test_pre_task_include_playbook(self):
         filename = 'test/playbook-include/playbook_pre.yml'

--- a/test/TestRuleProperties.py
+++ b/test/TestRuleProperties.py
@@ -8,7 +8,7 @@ class TestAlwaysRun(unittest.TestCase):
 
     def setUp(self):
         self.collection.extend(
-            RulesCollection.create_from_directory(default_rulesdir)
+            RulesCollection([default_rulesdir])
         )
 
     def test_serverity_valid(self):

--- a/test/TestRulesCollection.py
+++ b/test/TestRulesCollection.py
@@ -75,18 +75,20 @@ class TestRulesCollection(unittest.TestCase):
         matches = self.rules.run(self.ematchtestfile, skip_list=['DOESNOTEXIST'])
         self.assertEqual(len(matches), 3)
 
-    def test_rulesdir_var_expansion(self):
-        test_path = '/test/path'
-        os.environ['TEST_PATH'] = test_path
-        test_rulesdirs = ['$TEST_PATH']
-        expansion_rules = RulesCollection(test_rulesdirs)
-        self.assertIn(test_path, expansion_rules.rulesdirs)
-
-    def test_rulesdir_user_expansion(self):
-        expansion_rules = RulesCollection(['~'])
-        self.assertIn(os.path.expanduser('~'), expansion_rules.rulesdirs)
-
     def test_no_duplicate_rule_ids(self):
         real_rules = RulesCollection(['./lib/ansiblelint/rules'])
         rule_ids = [rule.id for rule in real_rules]
         self.assertEqual([x for x, y in collections.Counter(rule_ids).items() if y > 1], [])
+
+
+def test_rulesdir_var_expansion(monkeypatch):
+    test_path = '/test/path'
+    monkeypatch.setenv('TEST_PATH', test_path)
+    test_rulesdirs = ['$TEST_PATH']
+    expansion_rules = RulesCollection(test_rulesdirs)
+    assert test_path in expansion_rules.rulesdirs
+
+
+def test_rulesdir_user_expansion():
+    expansion_rules = RulesCollection(['~'])
+    assert os.path.expanduser('~') in expansion_rules.rulesdirs

--- a/test/TestRunner.py
+++ b/test/TestRunner.py
@@ -30,7 +30,7 @@ class TestRule(unittest.TestCase):
 
     def setUp(self):
         rulesdir = os.path.join('lib', 'ansiblelint', 'rules')
-        self.rules = RulesCollection.create_from_directory(rulesdir)
+        self.rules = RulesCollection([rulesdir])
 
     def test_runner_count(self):
         filename = 'test/nomatchestest.yml'

--- a/test/TestRunner.py
+++ b/test/TestRunner.py
@@ -22,7 +22,7 @@ import os
 import unittest
 
 import ansiblelint
-from ansiblelint import Runner, RulesCollection
+from ansiblelint import default_rulesdir, Runner, RulesCollection
 import ansiblelint.formatters
 
 
@@ -69,19 +69,6 @@ class TestRule(unittest.TestCase):
         matches = runner.run()
         formatter = ansiblelint.formatters.Formatter()
         formatter.format(matches[0], colored=True)
-
-    def test_runner_exclude_var_expansion(self):
-        filename = 'example/lots_of_warnings.yml'
-        os.environ['EXCLUDE_PATH'] = filename
-        excludes = ['$EXCLUDE_PATH']
-        runner = Runner(self.rules, filename, [], [], excludes)
-        assert filename in runner.exclude_paths
-
-    def test_runner_exclude_user_expansion(self):
-        filename = 'example/lots_of_warnings.yml'
-        excludes = ['~']
-        runner = Runner(self.rules, filename, [], [], excludes)
-        assert os.path.expanduser('~') in runner.exclude_paths
 
     def test_runner_excludes_paths(self):
         filename = 'examples/lots_of_warnings.yml'
@@ -131,3 +118,20 @@ class TestRule(unittest.TestCase):
         run2 = runner.run()
 
         assert ((len(run1) + len(run2)) == 1)
+
+
+def test_runner_exclude_var_expansion(monkeypatch):
+    rules = RulesCollection([default_rulesdir])
+    filename = 'example/lots_of_warnings.yml'
+    monkeypatch.setenv('EXCLUDE_PATH', filename)
+    excludes = ['$EXCLUDE_PATH']
+    runner = Runner(rules, filename, [], [], excludes)
+    assert filename in runner.exclude_paths
+
+
+def test_runner_exclude_user_expansion():
+    rules = RulesCollection([default_rulesdir])
+    filename = 'example/lots_of_warnings.yml'
+    excludes = ['~']
+    runner = Runner(rules, filename, [], [], excludes)
+    assert os.path.expanduser('~') in runner.exclude_paths

--- a/test/TestRunner.py
+++ b/test/TestRunner.py
@@ -70,6 +70,19 @@ class TestRule(unittest.TestCase):
         formatter = ansiblelint.formatters.Formatter()
         formatter.format(matches[0], colored=True)
 
+    def test_runner_exclude_var_expansion(self):
+        filename = 'example/lots_of_warnings.yml'
+        os.environ['EXCLUDE_PATH'] = filename
+        excludes = ['$EXCLUDE_PATH']
+        runner = Runner(self.rules, filename, [], [], excludes)
+        assert filename in runner.exclude_paths
+
+    def test_runner_exclude_user_expansion(self):
+        filename = 'example/lots_of_warnings.yml'
+        excludes = ['~']
+        runner = Runner(self.rules, filename, [], [], excludes)
+        assert os.path.expanduser('~') in runner.exclude_paths
+
     def test_runner_excludes_paths(self):
         filename = 'examples/lots_of_warnings.yml'
         excludes = ['examples/lots_of_warnings.yml']

--- a/test/TestSkipImportPlaybook.py
+++ b/test/TestSkipImportPlaybook.py
@@ -27,7 +27,7 @@ MAIN_PLAYBOOK = '''
 class TestSkipBeforeImport(unittest.TestCase):
     def setUp(self):
         rulesdir = os.path.join('lib', 'ansiblelint', 'rules')
-        self.rules = RulesCollection.create_from_directory(rulesdir)
+        self.rules = RulesCollection([rulesdir])
 
         # make dir and write role tasks to import or include
         self.play_root = tempfile.mkdtemp()

--- a/test/TestSkipInsideYaml.py
+++ b/test/TestSkipInsideYaml.py
@@ -90,7 +90,7 @@ galaxy_info:  # noqa 701
 
 class TestSkipInsideYaml(unittest.TestCase):
     rulesdir = os.path.join('lib', 'ansiblelint', 'rules')
-    collection = RulesCollection.create_from_directory(rulesdir)
+    collection = RulesCollection([rulesdir])
 
     def setUp(self):
         self.runner = RunFromText(self.collection)

--- a/test/TestSkipPlaybookItems.py
+++ b/test/TestSkipPlaybookItems.py
@@ -91,7 +91,7 @@ PLAYBOOK_WITH_BLOCK = '''
 
 class TestSkipPlaybookItems(unittest.TestCase):
     rulesdir = os.path.join('lib', 'ansiblelint', 'rules')
-    collection = RulesCollection.create_from_directory(rulesdir)
+    collection = RulesCollection([rulesdir])
 
     def setUp(self):
         self.runner = RunFromText(self.collection)

--- a/test/TestTaskIncludes.py
+++ b/test/TestTaskIncludes.py
@@ -8,7 +8,7 @@ class TestTaskIncludes(unittest.TestCase):
 
     def setUp(self):
         rulesdir = os.path.join('lib', 'ansiblelint', 'rules')
-        self.rules = RulesCollection.create_from_directory(rulesdir)
+        self.rules = RulesCollection([rulesdir])
 
     def test_block_included_tasks(self):
         filename = 'test/blockincludes.yml'

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -21,6 +21,7 @@
 # THE SOFTWARE.
 
 import unittest
+import os
 try:
     from pathlib import Path
 except ImportError:
@@ -154,3 +155,15 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(
             utils.normpath("a/b/../"),
             "a")
+
+    def test_expand_path_vars(self):
+        test_path = '/test/path'
+        os.environ['TEST_PATH'] = test_path
+        self.assertEqual(utils.expand_path_vars('~'), os.path.expanduser('~'))
+        self.assertEqual(utils.expand_path_vars('$TEST_PATH'), test_path)
+
+    def test_expand_paths_vars(self):
+        test_path = '/test/path'
+        os.environ['TEST_PATH'] = test_path
+        self.assertEqual(utils.expand_paths_vars(['~']), [os.path.expanduser('~')])
+        self.assertEqual(utils.expand_paths_vars(['$TEST_PATH']), [test_path])

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -156,14 +156,16 @@ class TestUtils(unittest.TestCase):
             utils.normpath("a/b/../"),
             "a")
 
-    def test_expand_path_vars(self):
-        test_path = '/test/path'
-        os.environ['TEST_PATH'] = test_path
-        self.assertEqual(utils.expand_path_vars('~'), os.path.expanduser('~'))
-        self.assertEqual(utils.expand_path_vars('$TEST_PATH'), test_path)
 
-    def test_expand_paths_vars(self):
-        test_path = '/test/path'
-        os.environ['TEST_PATH'] = test_path
-        self.assertEqual(utils.expand_paths_vars(['~']), [os.path.expanduser('~')])
-        self.assertEqual(utils.expand_paths_vars(['$TEST_PATH']), [test_path])
+def test_expand_path_vars(monkeypatch):
+    test_path = '/test/path'
+    monkeypatch.setenv('TEST_PATH', test_path)
+    assert utils.expand_path_vars('~') == os.path.expanduser('~')
+    assert utils.expand_path_vars('$TEST_PATH') == test_path
+
+
+def test_expand_paths_vars(monkeypatch):
+    test_path = '/test/path'
+    monkeypatch.setenv('TEST_PATH', test_path)
+    assert utils.expand_paths_vars(['~']) == [os.path.expanduser('~')]
+    assert utils.expand_paths_vars(['$TEST_PATH']) == [test_path]


### PR DESCRIPTION
Signed-off-by: Dan Mills <evilhamsterman@gmail.com>

Simply adds the ability to expand environment vars and ~ in the exclude and rulesdirs config. This could close #541 by allowing you to easily exclude the traditional galaxy roles directory with the following 

```YAML
exclude_paths:
    - ~/.ansible/roles
```