### PR TITLE
Added support for ANSIBLE_PLAYBOOK_DIR environment variable.

### DIFF
--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -52,6 +52,8 @@ from ansible.template import Templar
 # successfully.
 DEFAULT_VAULT_PASSWORD = 'x'
 
+PLAYBOOK_DIR = os.environ.get('ANSIBLE_PLAYBOOK_DIR', None)
+
 
 def parse_yaml_from_file(filepath):
     dl = DataLoader()
@@ -210,7 +212,7 @@ def play_children(basedir, item, parent_type, playbook_dir):
         if v:
             v = template(os.path.abspath(basedir),
                          v,
-                         dict(playbook_dir=os.path.abspath(basedir)),
+                         dict(playbook_dir=PLAYBOOK_DIR or os.path.abspath(basedir)),
                          fail_on_undefined=False)
             return delegate_map[k](basedir, k, v, parent_type)
     return []


### PR DESCRIPTION
Signed-off-by: Aleksandr Komlev <aleksandr.komlev@gmail.com>

------------

`ansible-lint` should take into account environment variable `ANSIBLE_PLAYBOOK_DIR` while resolves `playbook_dir` variable.

https://docs.ansible.com/ansible/latest/reference_appendices/config.html#envvar-ANSIBLE_PLAYBOOK_DIR

------------

Fixes #569
Fixes #160