### PR TITLE
Enforce use of python3 with pre-commit

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,7 +7,7 @@
     name: Ansible-lint
     description: This hook runs ansible-lint.
     entry: ansible-lint --force-color .
-    language: python
+    language: python3
     # do not pass files to ansible-lint, see:
     # https://github.com/ansible/ansible-lint/issues/611
     pass_filenames: false


### PR DESCRIPTION
Avoids installation errors with py27 with pre-commit, as we
do not have control over the build tools version.