### PR TITLE
Add a new rule for detecting nested jinja mustache syntax

### DIFF
--- a/docs/docsite/rst/rules/default_rules.rst
+++ b/docs/docsite/rst/rules/default_rules.rst
@@ -101,6 +101,13 @@ Playbooks should have the ".yml" or ".yaml" extension
 
 Variables should have spaces before and after: ``{{ var_name }}``
 
+.. _207:
+
+207: Nested jinja pattern
+*************************
+
+There should not be any nested jinja pattern. Example (bad): ``{{ list_one + {{ list_two | max }} }}``, example (good): ``{{ list_one + max(list_two) }}``
+
 Command-Shell Rules (3xx)
 -------------------------
 

--- a/lib/ansiblelint/rules/NestedJinjaRule.py
+++ b/lib/ansiblelint/rules/NestedJinjaRule.py
@@ -32,7 +32,7 @@ class NestedJinjaRule(AnsibleLintRule):
     )
     severity = 'VERY_HIGH'
     tags = ['formatting']
-    version_added = 'v4.2.1'
+    version_added = 'v4.3.0'
 
     nested_jinja_pattern = re.compile(r"{{(?:[^{}]*)?{{")
 

--- a/lib/ansiblelint/rules/NestedJinjaRule.py
+++ b/lib/ansiblelint/rules/NestedJinjaRule.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Author: Adrián Tóth <adtoth@redhat.com>
 #
 # Copyright (c) 2020, Red Hat, Inc.

--- a/lib/ansiblelint/rules/NestedJinjaRule.py
+++ b/lib/ansiblelint/rules/NestedJinjaRule.py
@@ -41,12 +41,12 @@ class NestedJinjaRule(AnsibleLintRule):
 
     def matchtask(self, file, task):
 
-        command = "".join([
+        command = "".join(
             str(value)
             # task properties are stored in the 'action' key
             for key, value in task['action'].items()
             # exclude useless values of '__file__', '__ansible_module__', '__*__', etc.
             if not key.startswith('__') and not key.endswith('__')
-        ])
+        )
 
         return bool(self.pattern.search(command))

--- a/lib/ansiblelint/rules/NestedJinjaRule.py
+++ b/lib/ansiblelint/rules/NestedJinjaRule.py
@@ -1,3 +1,5 @@
+# Author: Adrián Tóth <adtoth@redhat.com>
+#
 # Copyright (c) 2020, Red Hat, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/lib/ansiblelint/rules/NestedJinjaRule.py
+++ b/lib/ansiblelint/rules/NestedJinjaRule.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2020, Red Hat, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import re
+from ansiblelint import AnsibleLintRule
+
+
+class NestedJinjaRule(AnsibleLintRule):
+    id = '207'
+    shortdesc = 'Nested jinja pattern'
+    description = (
+        'There should not be any nested jinja pattern. '
+        'Example (bad): \'{{ list_one + {{ list_two | max }} }}\', '
+        'example (good): \'{{ list_one + max(list_two) }}\''
+    )
+    severity = 'VERY_HIGH'
+    tags = ['formatting']
+    version_added = 'v4.2.1'
+
+    nested_jinja_pattern = re.compile(r"{{(?:[^{}]*)?{{")
+
+    def matchtask(self, file, task):
+        strings = (
+            val for key, val in task['action'].items()
+            if isinstance(val, str) and not key.startswith('__')
+        )
+
+        return any(self.nested_jinja_pattern.search(item) for item in strings)

--- a/lib/ansiblelint/rules/NestedJinjaRule.py
+++ b/lib/ansiblelint/rules/NestedJinjaRule.py
@@ -26,9 +26,9 @@ class NestedJinjaRule(AnsibleLintRule):
     id = '207'
     shortdesc = 'Nested jinja pattern'
     description = (
-        'There should not be any nested jinja pattern. '
-        'Example (bad): \'{{ list_one + {{ list_two | max }} }}\', '
-        'example (good): \'{{ list_one + max(list_two) }}\''
+        "There should not be any nested jinja pattern. "
+        "Example (bad): '{{ list_one + {{ list_two | max }} }}', "
+        "example (good): '{{ list_one + max(list_two) }}'"
     )
     severity = 'VERY_HIGH'
     tags = ['formatting']

--- a/lib/ansiblelint/rules/NestedJinjaRule.py
+++ b/lib/ansiblelint/rules/NestedJinjaRule.py
@@ -22,7 +22,7 @@
 # THE SOFTWARE.
 
 import re
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 
 
 class NestedJinjaRule(AnsibleLintRule):

--- a/test/TestNestedJinjaRule.py
+++ b/test/TestNestedJinjaRule.py
@@ -25,7 +25,6 @@ from collections import namedtuple
 
 import pytest
 
-from ansiblelint.rules.NestedJinjaRule import NestedJinjaRule
 from ansiblelint.runner import Runner
 
 
@@ -186,7 +185,7 @@ def _playbook_file(tmp_path, request):
 @pytest.mark.usefixtures('_playbook_file')
 def test_including_wrong_nested_jinja(runner):
     rule_violations = runner.run()
-    assert type(rule_violations[0].rule) is NestedJinjaRule  # avoid matching subclasses
+    assert rule_violations[0].rule.id == '207'
 
 
 @pytest.mark.parametrize(

--- a/test/TestNestedJinjaRule.py
+++ b/test/TestNestedJinjaRule.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Author: Adrián Tóth <adtoth@redhat.com>
 #
 # Copyright (c) 2020, Red Hat, Inc.

--- a/test/TestNestedJinjaRule.py
+++ b/test/TestNestedJinjaRule.py
@@ -30,29 +30,77 @@ from test import RunFromText
 FAIL_TASKS = '''
 - name: one-level nesting
   set_fact:
-    variable_one: "2*(1+2) is {{ 2 * {{ 1 + 2 }} }}"
+    var_one: "2*(1+2) is {{ 2 * {{ 1 + 2 }} }}"
+
+- name: one-level multiline nesting
+  set_fact:
+    var_one_ml: >
+      2*(1+2) is {{ 2 *
+      {{ 1 + 2 }}
+      }}
 
 - name: two-level nesting
   set_fact:
-    variable_two: "2*(1+(3-1)) is {{ 2 * {{ 1 + {{ 3 - 1 }} }} }}"
+    var_two: "2*(1+(3-1)) is {{ 2 * {{ 1 + {{ 3 - 1 }} }} }}"
+
+- name: two-level multiline nesting
+  set_fact:
+    var_two_ml: >
+      2*(1+(3-1)) is {{ 2 *
+      {{ 1 +
+      {{ 3 - 1 }}
+      }} }}
 
 - name: five-level wild nesting
   set_fact:
-    variable_three: "{{ {{ {{ {{ {{ 234 }} }} }} }} }}"
+    var_three_wld: "{{ {{ {{ {{ {{ 234 }} }} }} }} }}"
+
+- name: five-level wild multiline nesting
+  set_fact:
+    var_three_wld_ml: >
+      {{
+      {{
+      {{
+      {{
+      {{ 234 }}
+      }}
+      }}
+      }}
+      }}
 '''
 
 SUCCESS_TASKS = '''
-- name: proper nesting
+- name: proper non-nested example
   set_fact:
-    variable_one: "number for 'one' is {{ 2 * 1 }}"
+    var_one: "number for 'one' is {{ 2 * 1 }}"
+
+- name: proper multiline non-nested example
+  set_fact:
+    var_one_ml: >
+      number for 'one' is {{
+      2 * 1 }}
 
 - name: proper nesting far from each other
   set_fact:
-    variable_two: "number for 'two' is {{ 2 * 1 }} and number for 'three' is {{ 4 - 1 }}"
+    var_two: "number for 'two' is {{ 2 * 1 }} and number for 'three' is {{ 4 - 1 }}"
+
+- name: proper multiline nesting far from each other
+  set_fact:
+    var_two_ml: >
+      number for 'two' is {{ 2 * 1
+      }} and number for 'three' is {{
+      4 - 1 }}
 
 - name: proper nesting close to each other
   set_fact:
-    variable_three: "number for 'ten' is {{ 2 - 1 }}{{ 3 - 3 }}"
+    var_three: "number for 'ten' is {{ 2 - 1 }}{{ 3 - 3 }}"
+
+- name: proper multiline nesting close to each other
+  set_fact:
+    var_three_ml: >
+      number for 'ten' is {{
+      2 - 1
+      }}{{ 3 - 3 }}
 '''
 
 
@@ -65,7 +113,7 @@ class TestNestedJinjaRule(unittest.TestCase):
 
     def test_fail(self):
         results = self.runner.run_role_tasks_main(FAIL_TASKS)
-        self.assertEqual(3, len(results))
+        self.assertEqual(6, len(results))
 
     def test_success(self):
         results = self.runner.run_role_tasks_main(SUCCESS_TASKS)

--- a/test/TestNestedJinjaRule.py
+++ b/test/TestNestedJinjaRule.py
@@ -25,6 +25,7 @@ from collections import namedtuple
 
 import pytest
 
+from ansiblelint.rules.NestedJinjaRule import NestedJinjaRule
 from ansiblelint.runner import Runner
 
 
@@ -185,7 +186,7 @@ def _playbook_file(tmp_path, request):
 @pytest.mark.usefixtures('_playbook_file')
 def test_including_wrong_nested_jinja(runner):
     rule_violations = runner.run()
-    assert rule_violations[0].rule.id == '207'
+    assert type(rule_violations[0].rule) is NestedJinjaRule  # avoid matching subclasses
 
 
 @pytest.mark.parametrize(

--- a/test/TestNestedJinjaRule.py
+++ b/test/TestNestedJinjaRule.py
@@ -1,0 +1,71 @@
+# Author: Adrián Tóth <adtoth@redhat.com>
+#
+# Copyright (c) 2020, Red Hat, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import unittest
+
+from ansiblelint import RulesCollection
+from ansiblelint.rules.NestedJinjaRule import NestedJinjaRule
+from test import RunFromText
+
+FAIL_TASKS = '''
+- name: one-level nesting
+  set_fact:
+    variable_one: "2*(1+2) is {{ 2 * {{ 1 + 2 }} }}"
+
+- name: two-level nesting
+  set_fact:
+    variable_two: "2*(1+(3-1)) is {{ 2 * {{ 1 + {{ 3 - 1 }} }} }}"
+
+- name: five-level wild nesting
+  set_fact:
+    variable_three: "{{ {{ {{ {{ {{ 234 }} }} }} }} }}"
+'''
+
+SUCCESS_TASKS = '''
+- name: proper nesting
+  set_fact:
+    variable_one: "number for 'one' is {{ 2 * 1 }}"
+
+- name: proper nesting far from each other
+  set_fact:
+    variable_two: "number for 'two' is {{ 2 * 1 }} and number for 'three' is {{ 4 - 1 }}"
+
+- name: proper nesting close to each other
+  set_fact:
+    variable_three: "number for 'ten' is {{ 2 - 1 }}{{ 3 - 3 }}"
+'''
+
+
+class TestNestedJinjaRule(unittest.TestCase):
+    collection = RulesCollection()
+    collection.register(NestedJinjaRule())
+
+    def setUp(self):
+        self.runner = RunFromText(self.collection)
+
+    def test_fail(self):
+        results = self.runner.run_role_tasks_main(FAIL_TASKS)
+        self.assertEqual(3, len(results))
+
+    def test_success(self):
+        results = self.runner.run_role_tasks_main(SUCCESS_TASKS)
+        self.assertEqual(0, len(results))


### PR DESCRIPTION
A new rule for ansible lint was added that provides nested jinja bracket pattern detection. Nesting jinja patterns can lead to failures and other problems.

\cc @amarza-rh
