### PR TITLE
Avoid exception from 505 rule

### DIFF
--- a/lib/ansiblelint/rules/IncludeMissingFileRule.py
+++ b/lib/ansiblelint/rules/IncludeMissingFileRule.py
@@ -46,7 +46,7 @@ class IncludeMissingFileRule(AnsibleLintRule):
                 if referenced_file:
                     break
 
-            if referenced_file is None:
+            if referenced_file is None or absolute_directory is None:
                 continue
 
             # make sure we have a absolute path here and check if it is a file


### PR DESCRIPTION
This should fix exception when absolute_directory is None, like I seen on current master branch:
```
Traceback (most recent call last):
  File "/Users/ssbarnea/.cache/pre-commit/repo71i9evtb/py_env-python3/bin/ansible-lint", line 8, in <module>
    sys.exit(main())
  File "/Users/ssbarnea/.cache/pre-commit/repo71i9evtb/py_env-python3/lib/python3.7/site-packages/ansiblelint/__main__.py", line 185, in main
    matches.extend(runner.run())
  File "/Users/ssbarnea/.cache/pre-commit/repo71i9evtb/py_env-python3/lib/python3.7/site-packages/ansiblelint/__init__.py", line 290, in run
    skip_list=self.skip_list))
  File "/Users/ssbarnea/.cache/pre-commit/repo71i9evtb/py_env-python3/lib/python3.7/site-packages/ansiblelint/__init__.py", line 183, in run
    matches.extend(rule.matchyaml(playbookfile, text))
  File "/Users/ssbarnea/.cache/pre-commit/repo71i9evtb/py_env-python3/lib/python3.7/site-packages/ansiblelint/__init__.py", line 125, in matchyaml
    result = self.matchplay(file, play)
  File "/Users/ssbarnea/.cache/pre-commit/repo71i9evtb/py_env-python3/lib/python3.7/site-packages/ansiblelint/rules/IncludeMissingFileRule.py", line 53, in matchplay
    referenced_file = os.path.join(absolute_directory, referenced_file)
  File "/Users/ssbarnea/.pyenv/versions/3.7.6/lib/python3.7/posixpath.py", line 80, in join
    a = os.fspath(a)
TypeError: expected str, bytes or os.PathLike object, not NoneType
```
