### PR TITLE
Un-xfail tests that hit moved out Ansible modules

### DIFF
--- a/test/TestPackageIsNotLatest.py
+++ b/test/TestPackageIsNotLatest.py
@@ -2,10 +2,6 @@ import unittest
 from ansiblelint import Runner, RulesCollection
 from ansiblelint.rules.PackageIsNotLatestRule import PackageIsNotLatestRule
 
-from importlib_metadata import version as get_dist_version
-from packaging.version import Version
-import pytest
-
 
 class TestPackageIsNotLatestRule(unittest.TestCase):
     collection = RulesCollection()
@@ -13,16 +9,6 @@ class TestPackageIsNotLatestRule(unittest.TestCase):
     def setUp(self):
         self.collection.register(PackageIsNotLatestRule())
 
-    @pytest.mark.xfail(
-        Version(get_dist_version('ansible')) >= Version('2.10.dev0') and
-        Version(get_dist_version('ansible-base')) >= Version('2.10.dev0'),
-        reason='Post-split Ansible Core Engine does not have '
-        'the module used in the test playbook.'
-        ' Ref: https://github.com/ansible/ansible-lint/issues/703.'
-        ' Ref: https://github.com/ansible/ansible/pull/68598.',
-        raises=SystemExit,
-        strict=True,
-    )
     def test_package_not_latest_positive(self):
         success = 'test/package-check-success.yml'
         good_runner = Runner(self.collection, success, [], [], [])

--- a/test/TestRoleRelativePath.py
+++ b/test/TestRoleRelativePath.py
@@ -4,11 +4,6 @@ from ansiblelint import RulesCollection
 from ansiblelint.rules.RoleRelativePath import RoleRelativePath
 from test import RunFromText
 
-from importlib_metadata import version as get_dist_version
-from packaging.version import Version
-import pytest
-
-
 FAIL_TASKS = '''
 - name: template example
   template:
@@ -47,30 +42,10 @@ class TestRoleRelativePath(unittest.TestCase):
     def setUp(self):
         self.runner = RunFromText(self.collection)
 
-    @pytest.mark.xfail(
-        Version(get_dist_version('ansible')) >= Version('2.10.dev0') and
-        Version(get_dist_version('ansible-base')) >= Version('2.10.dev0'),
-        reason='Post-split Ansible Core Engine does not have '
-        'the module used in the test playbook.'
-        ' Ref: https://github.com/ansible/ansible-lint/issues/703.'
-        ' Ref: https://github.com/ansible/ansible/pull/68598.',
-        raises=SystemExit,
-        strict=True,
-    )
     def test_fail(self):
         results = self.runner.run_role_tasks_main(FAIL_TASKS)
         self.assertEqual(4, len(results))
 
-    @pytest.mark.xfail(
-        Version(get_dist_version('ansible')) >= Version('2.10.dev0') and
-        Version(get_dist_version('ansible-base')) >= Version('2.10.dev0'),
-        reason='Post-split Ansible Core Engine does not have '
-        'the module used in the test playbook.'
-        ' Ref: https://github.com/ansible/ansible-lint/issues/703.'
-        ' Ref: https://github.com/ansible/ansible/pull/68598.',
-        raises=SystemExit,
-        strict=True,
-    )
     def test_success(self):
         results = self.runner.run_role_tasks_main(SUCCESS_TASKS)
         self.assertEqual(0, len(results))

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -26,8 +26,6 @@ from pathlib import Path
 import subprocess
 import sys
 
-from importlib_metadata import version as get_dist_version
-from packaging.version import Version
 import pytest
 
 import ansiblelint.utils as utils
@@ -75,16 +73,6 @@ def test_normalize(reference_form, alternate_forms):
         assert normal_form == utils.normalize_task(form, 'tasks.yml')
 
 
-@pytest.mark.xfail(
-    Version(get_dist_version('ansible')) >= Version('2.10.dev0') and
-    Version(get_dist_version('ansible-base')) >= Version('2.10.dev0'),
-    reason='Post-split Ansible Core Engine does not have '
-    'the module used in the test playbook.'
-    ' Ref: https://github.com/ansible/ansible-lint/issues/703.'
-    ' Ref: https://github.com/ansible/ansible/pull/68598.',
-    raises=SystemExit,
-    strict=True,
-)
 def test_normalize_complex_command():
     task1 = dict(name="hello", action={'module': 'ec2',
                                        'region': 'us-east1',

--- a/tox.ini
+++ b/tox.ini
@@ -22,8 +22,6 @@ deps =
   ansibledevel: ansible @ https://toshio.fedorapeople.org/ansible/acd/ansible/ansible-2.10.0.tar.gz
   ruamel.yaml==0.16.5  # NOTE: 0.15.34 has issues with py37
   flake8
-  importlib-metadata
-  packaging
   pep8-naming
   pytest
   pytest-cov


### PR DESCRIPTION
This reverts commit 1bdd563e4ca78a59b0c7891572eb2cecf4fe0515.
Fixes #703.

Depends on: https://github.com/ansible/ansible/pull/67684.