### PR TITLE
Remove six and pathlib2 dependencies

### DIFF
--- a/lib/ansiblelint/__init__.py
+++ b/lib/ansiblelint/__init__.py
@@ -24,8 +24,6 @@ import os
 import re
 import sys
 
-import six
-
 import ansiblelint.utils
 import codecs
 
@@ -66,7 +64,7 @@ class AnsibleLintRule(object):
             if not result:
                 continue
             message = None
-            if isinstance(result, six.string_types):
+            if isinstance(result, str):
                 message = result
             matches.append(Match(prev_line_no + 1, line,
                            file['path'], self, message))
@@ -97,7 +95,7 @@ class AnsibleLintRule(object):
                 continue
 
             message = None
-            if isinstance(result, six.string_types):
+            if isinstance(result, str):
                 message = result
             task_msg = "Task/Handler: " + ansiblelint.utils.task_to_str(task)
             matches.append(Match(task[ansiblelint.utils.LINE_NUMBER_KEY], task_msg,

--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -26,7 +26,6 @@ import errno
 import sys
 
 import ansiblelint.formatters as formatters
-import six
 from ansiblelint import cli, default_rulesdir, RulesCollection, Runner
 from ansiblelint.utils import normpath
 
@@ -64,7 +63,7 @@ def main():
         print(rules.listtags())
         return 0
 
-    if isinstance(options.tags, six.string_types):
+    if isinstance(options.tags, str):
         options.tags = options.tags.split(',')
 
     skip = set()

--- a/lib/ansiblelint/rules/MetaMainHasInfoRule.py
+++ b/lib/ansiblelint/rules/MetaMainHasInfoRule.py
@@ -1,8 +1,6 @@
 # Copyright (c) 2016, Will Thames and contributors
 # Copyright (c) 2018, Ansible Project
 
-import six
-
 from ansiblelint import AnsibleLintRule
 
 
@@ -41,7 +39,7 @@ class MetaMainHasInfoRule(AnsibleLintRule):
         for info in ['author', 'description']:
             if not galaxy_info.get(info):
                 continue
-            if not isinstance(galaxy_info.get(info), six.string_types):
+            if not isinstance(galaxy_info.get(info), str):
                 results.append(({'meta/main.yml': data},
                                 '%s should be a string' % info))
 

--- a/lib/ansiblelint/rules/MetaTagValidRule.py
+++ b/lib/ansiblelint/rules/MetaTagValidRule.py
@@ -2,8 +2,6 @@
 
 import re
 
-import six
-
 from ansiblelint import AnsibleLintRule
 
 
@@ -49,7 +47,7 @@ class MetaTagValidRule(AnsibleLintRule):
 
         for tag in tags:
             msg = self.shortdesc
-            if not isinstance(tag, six.string_types):
+            if not isinstance(tag, str):
                 results.append((
                     {'meta/main.yml': data},
                     "Tags must be strings: '{}'".format(tag)))

--- a/lib/ansiblelint/rules/MetaVideoLinksRule.py
+++ b/lib/ansiblelint/rules/MetaVideoLinksRule.py
@@ -2,7 +2,6 @@
 
 from ansiblelint import AnsibleLintRule
 import re
-import six
 
 
 class MetaVideoLinksRule(AnsibleLintRule):
@@ -53,7 +52,7 @@ class MetaVideoLinksRule(AnsibleLintRule):
                                 "only keys 'url' and 'title'"))
                 continue
 
-            for name, expr in six.iteritems(self.VIDEO_REGEXP):
+            for name, expr in self.VIDEO_REGEXP.items():
                 if expr.match(video['url']):
                     break
             else:

--- a/lib/ansiblelint/rules/OctalPermissionsRule.py
+++ b/lib/ansiblelint/rules/OctalPermissionsRule.py
@@ -19,7 +19,6 @@
 # THE SOFTWARE.
 
 from ansiblelint import AnsibleLintRule
-import six
 
 
 class OctalPermissionsRule(AnsibleLintRule):
@@ -67,7 +66,7 @@ class OctalPermissionsRule(AnsibleLintRule):
         if task["action"]["__ansible_module__"] in self._modules:
             mode = task['action'].get('mode', None)
 
-            if isinstance(mode, six.string_types):
+            if isinstance(mode, str):
                 return False
 
             if isinstance(mode, int):

--- a/lib/ansiblelint/rules/UseHandlerRatherThanWhenChangedRule.py
+++ b/lib/ansiblelint/rules/UseHandlerRatherThanWhenChangedRule.py
@@ -18,13 +18,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-import six
-
 from ansiblelint import AnsibleLintRule
 
 
 def _changed_in_when(item):
-    if not isinstance(item, six.string_types):
+    if not isinstance(item, str):
         return False
     return any(changed in item for changed in
                ['.changed', '|changed', '["changed"]', "['changed']"])

--- a/lib/ansiblelint/rules/UsingBareVariablesIsDeprecatedRule.py
+++ b/lib/ansiblelint/rules/UsingBareVariablesIsDeprecatedRule.py
@@ -20,7 +20,6 @@
 
 import os
 import re
-import six
 from ansiblelint import AnsibleLintRule
 
 
@@ -62,7 +61,7 @@ class UsingBareVariablesIsDeprecatedRule(AnsibleLintRule):
                 return self._matchvar(task[loop_type], task, loop_type)
 
     def _matchvar(self, varstring, task, loop_type):
-        if (isinstance(varstring, six.string_types) and
+        if (isinstance(varstring, str) and
                 not self._jinja.match(varstring)):
             valid = loop_type == 'with_fileglob' and bool(self._jinja.search(varstring) or
                                                           self._glob.search(varstring))

--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -23,13 +23,10 @@ import glob
 import imp
 from itertools import product
 import os
-try:
-    from pathlib import Path
-except ImportError:
-    from pathlib2 import Path
+from pathlib import Path
+
 import subprocess
 
-import six
 import yaml
 from yaml.composer import Composer
 from yaml.representer import RepresenterError
@@ -246,7 +243,7 @@ def _taskshandlers_children(basedir, k, v, parent_type):
             if "name" not in th['action']:
                 raise RuntimeError(
                     "Failed to find required 'name' key in %s" % module)
-            if not isinstance(th['action']["name"], six.string_types):
+            if not isinstance(th['action']["name"], str):
                 raise RuntimeError(
                     "Value assigned to 'name' key on '%s' is not a string." %
                     module)
@@ -314,7 +311,7 @@ def _rolepath(basedir, role):
 
     if constants.DEFAULT_ROLES_PATH:
         search_locations = constants.DEFAULT_ROLES_PATH
-        if isinstance(search_locations, six.string_types):
+        if isinstance(search_locations, str):
             search_locations = search_locations.split(os.pathsep)
         for loc in search_locations:
             loc = os.path.expanduser(loc)
@@ -428,7 +425,7 @@ def normalize_task_v1(task):
             else:
                 result[k] = v
         else:
-            if isinstance(v, six.string_types):
+            if isinstance(v, str):
                 v = _kv_to_dict(k + ' ' + v)
             elif not v:
                 v = dict(__ansible_module__=k)
@@ -752,7 +749,7 @@ def is_playbook(filename):
     }
 
     # makes it work with Path objects by converting them to strings
-    if not isinstance(filename, six.string_types):
+    if not isinstance(filename, str):
         filename = str(filename)
 
     try:

--- a/setup.cfg
+++ b/setup.cfg
@@ -90,8 +90,6 @@ setup_requires =
 install_requires =
   ansible >= 2.7
   pyyaml
-  six
-  pathlib2; python_version < "3.2"
   ruamel.yaml >= 0.15.34,<1; python_version < "3.7"
   ruamel.yaml >= 0.15.37,<1; python_version >= "3.7"
   # NOTE: per issue #509 0.15.34 included in debian backports

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -22,10 +22,7 @@
 
 import unittest
 import os
-try:
-    from pathlib import Path
-except ImportError:
-    from pathlib2 import Path
+from pathlib import Path
 
 import ansiblelint.utils as utils
 


### PR DESCRIPTION
As we removed support for py27, we can now drop two dependencies that where used in order to provide support for it.

Partial-Fix: #699