### PR TITLE
Remove obsolete py27 boilerplate

### DIFF
--- a/lib/ansiblelint/__init__.py
+++ b/lib/ansiblelint/__init__.py
@@ -18,7 +18,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from __future__ import print_function
 from collections import defaultdict
 import os
 import re

--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -20,8 +20,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from __future__ import print_function
-
 import errno
 import sys
 

--- a/lib/ansiblelint/rules/IncludeMissingFileRule.py
+++ b/lib/ansiblelint/rules/IncludeMissingFileRule.py
@@ -1,8 +1,6 @@
 # Copyright (c) 2020, Joachim Lusiardi
 # Copyright (c) 2020, Ansible Project
 
-from __future__ import print_function
-
 import os.path
 
 import ansible.parsing.yaml.objects

--- a/lib/ansiblelint/version.py
+++ b/lib/ansiblelint/version.py
@@ -1,8 +1,5 @@
 """Ansible-lint version information."""
 
-from __future__ import absolute_import, division, print_function
-__metaclass__ = type
-
 try:
     import pkg_resources
 except ImportError:


### PR DESCRIPTION
- from __future__ imports no longer needed
- remove __metaclass__ as python3 does not use it