### PR TITLE
Switch support to last two stable version of Ansible

### DIFF
--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -33,7 +33,6 @@ jobs:
         - devel
         - 29
         - 28
-        - 27
 
     env:
       TOX_PARALLEL_NO_SPINNER: 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,25 +74,6 @@ jobs:
       ANSIBLE_VERSION: "28"
 
   - python: "3.8"
-    env:
-      ANSIBLE_VERSION: "27"
-
-  - python: "3.7"
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      ANSIBLE_VERSION: "27"
-
-  - python: "3.6"
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      ANSIBLE_VERSION: "27"
-
-  - python: "3.5"
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      ANSIBLE_VERSION: "27"
-
-  - python: "3.8"
     <<: *if-cron-or-manual-run-or-tagged
     env:
       ANSIBLE_VERSION: devel

--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,8 @@ Ansible-lint
 ============
 
 ``ansible-lint`` checks playbooks for practices and behaviour that could
-potentially be improved.
+potentially be improved. As a community backed project ansible-lint supports
+only the last two major versions of Ansible.
 
 `Visit the Ansible Lint docs site <https://docs.ansible.com/ansible-lint/>`_
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,7 +37,6 @@ jobs:
     ansible_versions:
     - 29
     - 28
-    - 27
     - devel
     python_envs:
       38: [linux, macOs]

--- a/setup.cfg
+++ b/setup.cfg
@@ -88,7 +88,7 @@ setup_requires =
 
 # These are required in actual runtime:
 install_requires =
-  ansible >= 2.7
+  ansible >= 2.8
   pyyaml
   ruamel.yaml >= 0.15.34,<1; python_version < "3.7"
   ruamel.yaml >= 0.15.37,<1; python_version >= "3.7"

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.5.3
-envlist = lint,py{38,37,36,35}-ansible{29,28,27,devel}
+envlist = lint,py{38,37,36,35}-ansible{29,28,devel}
 isolated_build = true
 requires =
   setuptools >= 41.4.0
@@ -13,7 +13,6 @@ usedevelop = false
 description =
   Run the tests with pytest under {basepython}
 deps =
-  ansible27: ansible>=2.7,<2.8
   ansible28: ansible>=2.8,<2.9
   ansible29: ansible>=2.9,<2.10
   ansibledevel: ansible-base @ git+https://github.com/ansible/ansible.git@devel


### PR DESCRIPTION
Drops support for ansible 2.7 and documents the support matrix.

Fixes: #698