### PR TITLE
Make config loading failures visible

### DIFF
--- a/test/TestCommandLineInvocationSameAsConfig.py
+++ b/test/TestCommandLineInvocationSameAsConfig.py
@@ -74,3 +74,17 @@ def test_path_from_cli_depend_on_cwd(base_arguments, monkeypatch):  # Issue 572
 
     assert 'test/test' not in options1.exclude_paths[0]
     assert 'test/test' in options2.exclude_paths[0]
+
+
+@pytest.mark.parametrize(
+    "config_file",
+    [
+        pytest.param("test/fixtures/ansible-config-invalid.yml", id="invalid"),
+        pytest.param("/dev/null/ansible-config-missing.yml", id="missing")
+    ]
+)
+def test_config_failure(base_arguments, config_file):
+    """Ensures specific config files produce error code 2."""
+    with pytest.raises(SystemExit, match="^2$"):
+        cli.get_config(base_arguments +
+                       ["-c", config_file])

--- a/test/fixtures/ansible-config-invalid.yml
+++ b/test/fixtures/ansible-config-invalid.yml
@@ -1,0 +1,3 @@
+# invalid .ansible-lint config file
+- foo
+- bar


### PR DESCRIPTION
Corrects implementation of config file loading in order to return an error code in case of failure, with a meaningful error message.