### PR TITLE
ci: tox upgrade workaround for zuul

### DIFF
--- a/tools/test-setup.sh
+++ b/tools/test-setup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euxo pipefail
+# Used by Zuul CI to perform extra bootstrapping
+
+PYTHON=$(command -v python3 python | head -n1)
+
+sudo $PYTHON -m pip install -U tox


### PR DESCRIPTION
Upgrades tox on Zuul CI in order to avoid build failures due to a version that is unable to upgrade itself.