### PR TITLE
[WIP] Get rid of the imp module usage

### DIFF
--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -102,6 +102,7 @@ def load_plugins(directory):
     result = []
 
     for pluginfile in glob.glob(os.path.join(directory, '[A-Za-z]*.py')):
+
         pluginname = os.path.basename(pluginfile.replace('.py', ''))
         spec = importlib.util.spec_from_file_location(pluginname, pluginfile)
         module = importlib.util.module_from_spec(spec)

--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -20,7 +20,7 @@
 
 from collections import OrderedDict
 import glob
-import imp
+import importlib
 from itertools import product
 import os
 from pathlib import Path
@@ -100,19 +100,14 @@ BLOCK_NAME_TO_ACTION_TYPE_MAP = {
 
 def load_plugins(directory):
     result = []
-    fh = None
 
     for pluginfile in glob.glob(os.path.join(directory, '[A-Za-z]*.py')):
-
         pluginname = os.path.basename(pluginfile.replace('.py', ''))
-        try:
-            fh, filename, desc = imp.find_module(pluginname, [directory])
-            mod = imp.load_module(pluginname, fh, filename, desc)
-            obj = getattr(mod, pluginname)()
-            result.append(obj)
-        finally:
-            if fh:
-                fh.close()
+        spec = importlib.util.spec_from_file_location(pluginname, pluginfile)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        obj = getattr(module, pluginname)()
+        result.append(obj)
     return result
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -24,6 +24,9 @@ doctest_optionflags = ALLOW_UNICODE ELLIPSIS
 filterwarnings =
     error
 
+    # TODO: delete the following ignores once Ansible that we support gets rid of `imp`	
+    # Ref: https://github.com/ansible/ansible-lint/pull/734
+    ignore:the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses:DeprecationWarning:ansible.plugins.loader
     # TODO: delete the following ignores once we get rid of `inspect.getargspec()`
     # Ref: https://github.com/ansible/ansible-lint/issues/603
     ignore:inspect.getargspec\(\) is deprecated, use inspect.signature\(\) instead:DeprecationWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -24,11 +24,6 @@ doctest_optionflags = ALLOW_UNICODE ELLIPSIS
 filterwarnings =
     error
 
-    # TODO: delete the following ignores once we get rid of `imp`
-    # Ref: https://github.com/ansible/ansible-lint/issues/602
-    ignore:the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses:DeprecationWarning
-    ignore:the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses:PendingDeprecationWarning
-
     # TODO: delete the following ignores once we get rid of `inspect.getargspec()`
     # Ref: https://github.com/ansible/ansible-lint/issues/603
     ignore:inspect.getargspec\(\) is deprecated, use inspect.signature\(\) instead:DeprecationWarning


### PR DESCRIPTION
The imp library deprecated since python 3.3 so it was changed to importlib

Close: #602