### PR TITLE
Run linters job groups on a single platform

### DIFF
--- a/.github/workflows/tox-linters.yml
+++ b/.github/workflows/tox-linters.yml
@@ -19,13 +19,8 @@ jobs:
       matrix:
         python-version:
         - 3.8
-        - 3.7
-        - 3.6
-        - 3.5
         os:
         - ubuntu-latest
-        - macOS-latest
-        # - windows-latest
         env:
         - TOXENV: build-dists,metadata-validation
         - TOXENV: docs


### PR DESCRIPTION
Lower the CI footprint and chance of being affected by random failures. Non-core cannot ever retrigger CI without closing and reopening a PR.

Partial-Fix: #699