### PR TITLE
Gracefully process a missing git binary when falling-back to pure-python discovery

### DIFF
--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -778,6 +778,8 @@ def get_yaml_files(options):
             )
         )
 
+    out = None
+
     try:
         out = subprocess.check_output(
             git_command,
@@ -792,7 +794,15 @@ def get_yaml_files(options):
                     error_msg=exc.output.rstrip('\n')
                 )
             )
+    except FileNotFoundError as exc:
+        if options.verbosity:
+            print(
+                "Warning: Failed to locate command: {error_msg!s}".format(
+                    error_msg=exc
+                )
+            )
 
+    if out is None:
         out = [
             os.path.join(root, name)
             for root, dirs, files in os.walk('.')


### PR DESCRIPTION
This change fixes #735 by catching an extra corner case
exception `FileNotFoundError`.