### PR TITLE
Avoid printing coverage report on test failures

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -20,6 +20,7 @@ addopts =
     --cov=ansiblelint
     --cov-report term-missing:skip-covered
     --cov-report xml:.test-results/pytest/cov.xml
+    --no-cov-on-fail
 doctest_optionflags = ALLOW_UNICODE ELLIPSIS
 filterwarnings =
     error


### PR DESCRIPTION
Improves development experience by avoiding printing a coverage
report when tests are failing. This avoids forcing the user to
do additional scrolling in order to see the error.