### PR TITLE
Fix logging configuration

### DIFF
--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -21,6 +21,7 @@
 # THE SOFTWARE.
 
 import errno
+import logging
 import pathlib
 import sys
 
@@ -29,12 +30,16 @@ from ansiblelint import cli, default_rulesdir, RulesCollection, Runner
 from ansiblelint.utils import normpath, initialize_logger
 
 
+_logger = logging.getLogger(__name__)
+
+
 def main():
     cwd = pathlib.Path.cwd()
 
     options = cli.get_config(sys.argv[1:])
 
     initialize_logger(options.verbosity)
+    _logger.debug("Options: %s", options)
 
     formatter_factory = formatters.Formatter
     if options.quiet:

--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -68,9 +68,13 @@ def initialize_logger(level=0):
     handler = logging.StreamHandler()
     formatter = logging.Formatter('%(levelname)-8s %(message)s')
     handler.setFormatter(formatter)
-    _logger.addHandler(handler)
-    # unknown logging level is treated as DEBUG
-    _logger.setLevel(VERBOSITY_MAP.get(level, logging.DEBUG))
+    logger = logging.getLogger(__package__)
+    logger.addHandler(handler)
+    # Unknown logging level is treated as DEBUG
+    logging_level = VERBOSITY_MAP.get(level, logging.DEBUG)
+    logger.setLevel(logging_level)
+    # Use module-level _logger instance to validate it
+    _logger.debug("Logging initialized to level %s", logging_level)
 
 
 def parse_yaml_from_file(filepath):

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -219,3 +219,17 @@ def test_get_yaml_files_silent(is_in_git, monkeypatch, capsys):
             locals(),
         )
     )
+
+
+def test_logger_debug(
+    caplog
+):
+    options = cli.get_config(['-vv'])
+    utils.initialize_logger(options.verbosity)
+
+    expected_info = (
+        "ansiblelint.utils",
+        logging.DEBUG,
+        'Logging initialized to level 10')
+
+    assert expected_info in caplog.record_tuples


### PR DESCRIPTION
Assure logging is initialized in such way that all submodules use
the module settings.

Previously initialize_setup() did configure logging only for
`ansiblelint.utils`, which means that any other ansiblelint.* would
not use the same settings.

Adds a debug level logging of loaded options.