### PR TITLE
Fix exclude_paths from get_playbooks_and_roles

### DIFF
--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -712,9 +712,16 @@ def get_playbooks_and_roles(options=None):
 
     for p in map(Path, files):
 
-        if any(str(p).startswith(file_path) for file_path in options.exclude_paths):
+        try:
+            for file_path in options.exclude_paths:
+                if str(p.resolve()).startswith(str(file_path)):
+                    raise FileNotFoundError(
+                        f'File {file_path} matched exclusion entry: {p}')
+        except FileNotFoundError as e:
+            _logger.debug('Ignored %s due to: %s', p, e)
             continue
-        elif (next((i for i in p.parts if i.endswith('playbooks')), None) or
+
+        if (next((i for i in p.parts if i.endswith('playbooks')), None) or
                 'playbook' in p.parts[-1]):
             playbooks.append(normpath(p))
             continue

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -257,3 +257,15 @@ def test_cli_auto_detect(capfd):
         "[E401] Git checkouts must contain explicit version" in out
     # assures that our .ansible-lint exclude was effective in excluding github files
     assert "Unknown file type: .github/" not in out
+
+
+def test_auto_detect_exclude(monkeypatch):
+    """Verify that exclude option can be used to narrow down detection."""
+    options = cli.get_config(['--exclude', 'foo'])
+
+    def mockreturn(options):
+        return ['foo/playbook.yml', 'bar/playbook.yml']
+
+    monkeypatch.setattr(utils, 'get_yaml_files', mockreturn)
+    result = utils.get_playbooks_and_roles(options)
+    assert result == ['bar/playbook.yml']


### PR DESCRIPTION
Fix bug which made impossible to use relative exclude paths as
these where resolved while the file tested where not.