### PR TITLE
Require Python 3.6 or newer

### DIFF
--- a/.azure-pipelines/tox.yml
+++ b/.azure-pipelines/tox.yml
@@ -24,7 +24,7 @@ jobs:
             name: Py${{ python_env.key }}__Ansible_${{ ansible_version }}
     # coverage:
     #   with_toxenv: 'coverage' # generate .tox/.coverage, .tox/coverage.xml after test run
-    #   for_envs: [py38, py37, py36, py35, pypy3, pypy]
+    #   for_envs: [py38, py37, py36, pypy3, pypy]
     before:
       - task: UsePythonVersion@0
         condition: and(succeeded(), in(variables['TOXENV'], 'pypy'))

--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -22,7 +22,6 @@ jobs:
         - 3.8
         - 3.7
         - 3.6
-        - 3.5
         os:
         - ubuntu-latest
         - ubuntu-16.04

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,11 +49,6 @@ jobs:
     env:
       ANSIBLE_VERSION: "29"
 
-  - python: "3.5"
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      ANSIBLE_VERSION: "29"
-
   - python: "3.8"
     env:
       ANSIBLE_VERSION: "28"
@@ -64,11 +59,6 @@ jobs:
       ANSIBLE_VERSION: "28"
 
   - python: "3.6"
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      ANSIBLE_VERSION: "28"
-
-  - python: "3.5"
     <<: *if-cron-or-manual-run-or-tagged
     env:
       ANSIBLE_VERSION: "28"
@@ -84,11 +74,6 @@ jobs:
       ANSIBLE_VERSION: devel
 
   - python: "3.6"
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      ANSIBLE_VERSION: devel
-
-  - python: "3.5"
     <<: *if-cron-or-manual-run-or-tagged
     env:
       ANSIBLE_VERSION: devel

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,10 @@
+4.3.0 - Not Released
+====================
+
+Major:
+
+- Require Python 3.6 or newer
+
 4.2.0 - Released 04-Dec-2019
 ============================
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,4 +43,3 @@ jobs:
       py3: [linux]
       37: [linux, macOs]
       36: [linux, macOs]
-      35: [linux, macOs]

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,6 @@ classifiers =
 
   Programming Language :: Python
   Programming Language :: Python :: 3
-  Programming Language :: Python :: 3.5
   Programming Language :: Python :: 3.6
   Programming Language :: Python :: 3.7
   Programming Language :: Python :: 3.8
@@ -60,7 +59,7 @@ keywords =
 
 [options]
 use_scm_version = True
-python_requires = >=3.5
+python_requires = >=3.6
 package_dir =
   = lib
 packages = find:

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.5.3
-envlist = lint,py{38,37,36,35}-ansible{29,28,devel}
+envlist = lint,py{38,37,36}-ansible{29,28,devel}
 isolated_build = true
 requires =
   setuptools >= 41.4.0


### PR DESCRIPTION
This change removes support for Python 3.6 starting with 4.3.x version.

Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/452