### PR TITLE
Move Match under errors module

### DIFF
--- a/lib/ansiblelint/__init__.py
+++ b/lib/ansiblelint/__init__.py
@@ -26,6 +26,7 @@ import re
 
 import ansiblelint.utils
 import ansiblelint.skip_utils
+from ansiblelint.errors import Match
 
 default_rulesdir = os.path.join(os.path.dirname(ansiblelint.utils.__file__), 'rules')
 _logger = logging.getLogger(__name__)
@@ -202,23 +203,6 @@ class RulesCollection(object):
         for tag in sorted(tags):
             results.append("{0} {1}".format(tag, tags[tag]))
         return "\n".join(results)
-
-
-class Match(object):
-
-    def __init__(self, linenumber, line, filename, rule, message=None):
-        """Initialize a Match instance."""
-        self.linenumber = linenumber
-        self.line = line
-        self.filename = filename
-        self.rule = rule
-        self.message = message or rule.shortdesc
-
-    def __repr__(self):
-        """Return a Match instance representation."""
-        formatstr = u"[{0}] ({1}) matched {2}:{3} {4}"
-        return formatstr.format(self.rule.id, self.message,
-                                self.filename, self.linenumber, self.line)
 
 
 class Runner(object):

--- a/lib/ansiblelint/errors.py
+++ b/lib/ansiblelint/errors.py
@@ -1,0 +1,15 @@
+class Match(object):
+
+    def __init__(self, linenumber, line, filename, rule, message=None):
+        """Initialize a Match instance."""
+        self.linenumber = linenumber
+        self.line = line
+        self.filename = filename
+        self.rule = rule
+        self.message = message or rule.shortdesc
+
+    def __repr__(self):
+        """Return a Match instance representation."""
+        formatstr = u"[{0}] ({1}) matched {2}:{3} {4}"
+        return formatstr.format(self.rule.id, self.message,
+                                self.filename, self.linenumber, self.line)


### PR DESCRIPTION
Moves Match class under errors module in order to make it easier
to use from other places, avoiding cyclic imports.