### PR TITLE
Move AnsibleLintRule inside rules module

### DIFF
--- a/lib/ansiblelint/__init__.py
+++ b/lib/ansiblelint/__init__.py
@@ -22,121 +22,13 @@
 from collections import defaultdict
 import logging
 import os
-import re
 
+from ansiblelint.rules import AnsibleLintRule  # noqa F401: exposing public API
 import ansiblelint.utils
 import ansiblelint.skip_utils
-from ansiblelint.errors import Match
 
 default_rulesdir = os.path.join(os.path.dirname(ansiblelint.utils.__file__), 'rules')
 _logger = logging.getLogger(__name__)
-
-
-class AnsibleLintRule(object):
-
-    def __repr__(self):
-        """Return a AnsibleLintRule instance representation."""
-        return self.id + ": " + self.shortdesc
-
-    def verbose(self):
-        return self.id + ": " + self.shortdesc + "\n  " + self.description
-
-    match = None
-    matchtask = None
-    matchplay = None
-
-    @staticmethod
-    def unjinja(text):
-        return re.sub(r"{{[^}]*}}", "JINJA_VAR", text)
-
-    def matchlines(self, file, text):
-        matches = []
-        if not self.match:
-            return matches
-        # arrays are 0-based, line numbers are 1-based
-        # so use prev_line_no as the counter
-        for (prev_line_no, line) in enumerate(text.split("\n")):
-            if line.lstrip().startswith('#'):
-                continue
-
-            rule_id_list = ansiblelint.skip_utils.get_rule_skips_from_line(line)
-            if self.id in rule_id_list:
-                continue
-
-            result = self.match(file, line)
-            if not result:
-                continue
-            message = None
-            if isinstance(result, str):
-                message = result
-            matches.append(Match(prev_line_no + 1, line,
-                           file['path'], self, message))
-        return matches
-
-    def matchtasks(self, file, text):
-        matches = []
-        if not self.matchtask:
-            return matches
-
-        if file['type'] == 'meta':
-            return matches
-
-        yaml = ansiblelint.utils.parse_yaml_linenumbers(text, file['path'])
-        if not yaml:
-            return matches
-
-        yaml = ansiblelint.skip_utils.append_skipped_rules(yaml, text, file['type'])
-
-        for task in ansiblelint.utils.get_normalized_tasks(yaml, file):
-            if self.id in task.get('skipped_rules', ()):
-                continue
-
-            if 'action' not in task:
-                continue
-            result = self.matchtask(file, task)
-            if not result:
-                continue
-
-            message = None
-            if isinstance(result, str):
-                message = result
-            task_msg = "Task/Handler: " + ansiblelint.utils.task_to_str(task)
-            matches.append(Match(task[ansiblelint.utils.LINE_NUMBER_KEY], task_msg,
-                           file['path'], self, message))
-        return matches
-
-    def matchyaml(self, file, text):
-        matches = []
-        if not self.matchplay:
-            return matches
-
-        yaml = ansiblelint.utils.parse_yaml_linenumbers(text, file['path'])
-        if not yaml:
-            return matches
-
-        if isinstance(yaml, dict):
-            yaml = [yaml]
-
-        yaml = ansiblelint.skip_utils.append_skipped_rules(yaml, text, file['type'])
-
-        for play in yaml:
-            if self.id in play.get('skipped_rules', ()):
-                continue
-
-            result = self.matchplay(file, play)
-            if not result:
-                continue
-
-            if isinstance(result, tuple):
-                result = [result]
-
-            if not isinstance(result, list):
-                raise TypeError("{} is not a list".format(result))
-
-            for section, message in result:
-                matches.append(Match(play[ansiblelint.utils.LINE_NUMBER_KEY],
-                                     section, file['path'], self, message))
-        return matches
 
 
 class RulesCollection(object):

--- a/lib/ansiblelint/generate_docs.py
+++ b/lib/ansiblelint/generate_docs.py
@@ -2,9 +2,7 @@
 
 import os
 import importlib
-from inspect import getmembers, ismodule, isclass
 import logging
-import rules
 from ansiblelint import AnsibleLintRule
 from functools import reduce
 
@@ -60,15 +58,10 @@ def import_all_rules():
 
 
 def get_serialized_rules():
-    mod_list = [m[1] for m in getmembers(rules) if ismodule(m[1])]
-    class_list = []
-    for mod in mod_list:
-        class_temp = [m[1] for m in getmembers(mod) if isclass(m[1])]
-        class_temp = [c for c in class_temp if c is not AnsibleLintRule]
-        class_list.extend(class_temp)
+    # called after all classes are loaded
 
     all_rules = []
-    for c in class_list:
+    for c in AnsibleLintRule.__subclasses__():
         d = {
             'id': c.id,
             'shortdesc': c.shortdesc,

--- a/lib/ansiblelint/rules/__init__.py
+++ b/lib/ansiblelint/rules/__init__.py
@@ -1,1 +1,113 @@
 """All internal ansible-lint rules."""
+import re
+from ansiblelint.skip_utils import get_rule_skips_from_line
+from ansiblelint.skip_utils import append_skipped_rules
+from ansiblelint.errors import Match
+import ansiblelint.utils
+
+
+class AnsibleLintRule(object):
+
+    def __repr__(self):
+        """Return a AnsibleLintRule instance representation."""
+        return self.id + ": " + self.shortdesc
+
+    def verbose(self):
+        return self.id + ": " + self.shortdesc + "\n  " + self.description
+
+    match = None
+    matchtask = None
+    matchplay = None
+
+    @staticmethod
+    def unjinja(text):
+        return re.sub(r"{{[^}]*}}", "JINJA_VAR", text)
+
+    def matchlines(self, file, text):
+        matches = []
+        if not self.match:
+            return matches
+        # arrays are 0-based, line numbers are 1-based
+        # so use prev_line_no as the counter
+        for (prev_line_no, line) in enumerate(text.split("\n")):
+            if line.lstrip().startswith('#'):
+                continue
+
+            rule_id_list = get_rule_skips_from_line(line)
+            if self.id in rule_id_list:
+                continue
+
+            result = self.match(file, line)
+            if not result:
+                continue
+            message = None
+            if isinstance(result, str):
+                message = result
+            matches.append(Match(prev_line_no + 1, line,
+                           file['path'], self, message))
+        return matches
+
+    def matchtasks(self, file, text):
+        matches = []
+        if not self.matchtask:
+            return matches
+
+        if file['type'] == 'meta':
+            return matches
+
+        yaml = ansiblelint.utils.parse_yaml_linenumbers(text, file['path'])
+        if not yaml:
+            return matches
+
+        yaml = append_skipped_rules(yaml, text, file['type'])
+
+        for task in ansiblelint.utils.get_normalized_tasks(yaml, file):
+            if self.id in task.get('skipped_rules', ()):
+                continue
+
+            if 'action' not in task:
+                continue
+            result = self.matchtask(file, task)
+            if not result:
+                continue
+
+            message = None
+            if isinstance(result, str):
+                message = result
+            task_msg = "Task/Handler: " + ansiblelint.utils.task_to_str(task)
+            matches.append(Match(task[ansiblelint.utils.LINE_NUMBER_KEY], task_msg,
+                           file['path'], self, message))
+        return matches
+
+    def matchyaml(self, file, text):
+        matches = []
+        if not self.matchplay:
+            return matches
+
+        yaml = ansiblelint.utils.parse_yaml_linenumbers(text, file['path'])
+        if not yaml:
+            return matches
+
+        if isinstance(yaml, dict):
+            yaml = [yaml]
+
+        yaml = ansiblelint.skip_utils.append_skipped_rules(yaml, text, file['type'])
+
+        for play in yaml:
+            if self.id in play.get('skipped_rules', ()):
+                continue
+
+            result = self.matchplay(file, play)
+            if not result:
+                continue
+
+            if isinstance(result, tuple):
+                result = [result]
+
+            if not isinstance(result, list):
+                raise TypeError("{} is not a list".format(result))
+
+            for section, message in result:
+                matches.append(Match(play[ansiblelint.utils.LINE_NUMBER_KEY],
+                                     section, file['path'], self, message))
+        return matches

--- a/test/TestFormatter.py
+++ b/test/TestFormatter.py
@@ -20,8 +20,9 @@
 import pathlib
 import unittest
 
-from ansiblelint import Match, AnsibleLintRule
+from ansiblelint.errors import Match
 from ansiblelint.formatters import Formatter
+from ansiblelint.rules import AnsibleLintRule
 
 
 class TestFormatter(unittest.TestCase):


### PR DESCRIPTION
Moved code to ease reusability and avoid cyclic imports.