### PR TITLE
Added reproducer for become in blocks

### DIFF
--- a/test/TestSkipInsideYaml.py
+++ b/test/TestSkipInsideYaml.py
@@ -89,7 +89,6 @@ ROLE_TASKS_WITH_BLOCK_BECOME = '''
     - name: foo
       become: true
       block:
-
         - name: bar
           become_user: jonhdaa
           command: "/etc/test.sh"

--- a/test/TestSkipInsideYaml.py
+++ b/test/TestSkipInsideYaml.py
@@ -105,20 +105,25 @@ def test_role_tasks_with_block(default_text_runner):
     assert len(results) == 4
 
 
-def test_playbook(default_text_runner):
-    results = default_text_runner.run_playbook(PLAYBOOK)
-    assert len(results) == 7
+@pytest.mark.parametrize(
+    ('playbook_src', 'results_num'),
+    (
+        (PLAYBOOK, 7),
+        pytest.param(
+            ROLE_TASKS_WITH_BLOCK_BECOME, 0,
+            marks=pytest.mark.xfail(
+                reason="Bug: "
+                "https://github.com/ansible/ansible-lint/issues/705",
+            ),
+        ),
+    ),
+    ids=('generic', 'with block become inheritance'),
+)
+def test_playbook(default_text_runner, playbook_src, results_num):
+    results = default_text_runner.run_playbook(playbook_src)
+    assert len(results) == results_num
 
 
 def test_role_meta(default_text_runner):
     results = default_text_runner.run_role_meta_main(ROLE_META)
-    assert len(results) == 0
-
-
-@pytest.mark.xfail(
-    reason="Bug: https://github.com/ansible/ansible-lint/issues/705",
-    strict=True,
-)
-def test_block_become_inheritance(default_text_runner):
-    results = default_text_runner.run_playbook(ROLE_TASKS_WITH_BLOCK_BECOME)
     assert len(results) == 0

--- a/test/TestSkipInsideYaml.py
+++ b/test/TestSkipInsideYaml.py
@@ -1,3 +1,6 @@
+import pytest
+
+
 ROLE_TASKS = '''
 ---
 - name: test 303
@@ -80,6 +83,18 @@ galaxy_info:  # noqa 701
   license: MIT
 '''
 
+ROLE_TASKS_WITH_BLOCK_BECOME = '''
+- hosts:
+  tasks:
+    - name: foo
+      become: true
+      block:
+
+        - name: bar
+          become_user: jonhdaa
+          command: "/etc/test.sh"
+'''
+
 
 def test_role_tasks(default_text_runner):
     results = default_text_runner.run_role_tasks_main(ROLE_TASKS)
@@ -98,4 +113,13 @@ def test_playbook(default_text_runner):
 
 def test_role_meta(default_text_runner):
     results = default_text_runner.run_role_meta_main(ROLE_META)
+    assert len(results) == 0
+
+
+@pytest.mark.xfail(
+    reason="Bug: https://github.com/ansible/ansible-lint/issues/705",
+    strict=True,
+)
+def test_block_become_inheritance(default_text_runner):
+    results = default_text_runner.run_playbook(ROLE_TASKS_WITH_BLOCK_BECOME)
     assert len(results) == 0


### PR DESCRIPTION
Reproduces bug #705 with an xfail test, so we can fix it in a
follow-up.

Related: #705
Closes: #706