### PR TITLE
docs: improve rule descriptions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -237,7 +237,7 @@ Included in ``ansible-lint/examples`` are some example playbooks with undesirabl
 
     $ ansible-lint examples/example.yml
 
-    [301] Commands should not change things if nothing needs doing
+    [301] Commands should be idempotent
     examples/example.yml:9
     Task/Handler: unset variable
 
@@ -245,7 +245,7 @@ Included in ``ansible-lint/examples`` are some example playbooks with undesirabl
     examples/example.yml:10
         action: command echo {{thisvariable}} is not set in this playbook
 
-    [301] Commands should not change things if nothing needs doing
+    [301] Commands should be idempotent
     examples/example.yml:12
     Task/Handler: trailing whitespace
 
@@ -261,7 +261,7 @@ Included in ``ansible-lint/examples`` are some example playbooks with undesirabl
     examples/example.yml:18
     Task/Handler: git check 2
 
-    [301] Commands should not change things if nothing needs doing
+    [301] Commands should be idempotent
     examples/example.yml:24
     Task/Handler: executing git through command
 
@@ -304,7 +304,7 @@ If playbooks include other playbooks, or tasks, or handlers or roles, these are 
 
     $ ansible-lint examples/include.yml
 
-    [301] Commands should not change things if nothing needs doing
+    [301] Commands should be idempotent
     examples/play.yml:5
     Task/Handler: a bad play
 
@@ -324,7 +324,7 @@ If playbooks include other playbooks, or tasks, or handlers or roles, these are 
     examples/roles/morecomplex/handlers/main.yml:1
     Task/Handler: restart service using command
 
-    [301] Commands should not change things if nothing needs doing
+    [301] Commands should be idempotent
     examples/roles/morecomplex/tasks/main.yml:1
     Task/Handler: test bad command
 
@@ -332,7 +332,7 @@ If playbooks include other playbooks, or tasks, or handlers or roles, these are 
     examples/roles/morecomplex/tasks/main.yml:1
     Task/Handler: test bad command
 
-    [301] Commands should not change things if nothing needs doing
+    [301] Commands should be idempotent
     examples/roles/morecomplex/tasks/main.yml:4
     Task/Handler: test bad command v2
 
@@ -340,7 +340,7 @@ If playbooks include other playbooks, or tasks, or handlers or roles, these are 
     examples/roles/morecomplex/tasks/main.yml:4
     Task/Handler: test bad command v2
 
-    [301] Commands should not change things if nothing needs doing
+    [301] Commands should be idempotent
     examples/roles/morecomplex/tasks/main.yml:7
     Task/Handler: test bad local command
 

--- a/docs/docsite/rst/rules/default_rules.rst
+++ b/docs/docsite/rst/rules/default_rules.rst
@@ -16,10 +16,10 @@ Deprecated Rules (1xx)
 
 .. _101:
 
-101: Deprecated always_run
-**************************
+101: Deprecated ``always_run``
+******************************
 
-Instead of ``always_run``, use ``check_mode``
+Use ``check_mode`` instead of ``always_run``.
 
 .. _102:
 
@@ -33,7 +33,7 @@ Instead of ``always_run``, use ``check_mode``
 103: Deprecated sudo
 ********************
 
-Instead of ``sudo``/``sudo_user``, use ``become``/``become_user``.
+Use ``become`` or ``become_user`` instead of ``sudo`` or ``sudo_user``.
 
 .. _104:
 
@@ -89,10 +89,10 @@ Long lines make code harder to read and code review more difficult
 
 .. _205:
 
-205: Use ".yml" or ".yaml" playbook extension
-*********************************************
+205: Use ``.yml`` or ``.yaml`` playbook extension
+*************************************************
 
-Playbooks should have the ".yml" or ".yaml" extension
+Playbooks should have the ``.yml`` or ``.yaml`` extension.
 
 .. _206:
 
@@ -106,10 +106,10 @@ Command-Shell Rules (3xx)
 
 .. _301:
 
-301: Commands should not change things if nothing needs doing
-*************************************************************
+301: Commands should be idempotent
+**********************************
 
-Commands should either read information (and thus set ``changed_when``) or not do something if it has already been done (using creates/removes) or only do it if another check has a particular result (``when``)
+Commands should either read information and report ``changed_when: false``. Changing commands should use conditions like ``when``, ``creates``, ``removes``, or set changed status based on a particular ``result``.
 
 .. _302:
 
@@ -168,7 +168,7 @@ All version control checkouts must point to an explicit commit or tag, not just 
 403: Package installs should not use latest
 *******************************************
 
-Package installs should use ``state=present`` with or without a version
+Package installs should use ``state: present`` with or without a version
 
 .. _404:
 
@@ -203,27 +203,27 @@ If a task has a ``when: result.changed`` setting, it is effectively acting as a 
 
 .. _504:
 
-504: Do not use 'local_action', use 'delegate_to: localhost'
-************************************************************
+504: Use ``delegate_to: localhost`` instead of ``local_action``
+***************************************************************
 
-Do not use ``local_action``, use ``delegate_to: localhost``
+Use ``delegate_to: localhost`` instead of ``local_action``
 
 .. _505:
 
-505: referenced files must exist
+505: Referenced files must exist
 ********************************
 
-All files referenced by by include / import tasks must exist. The check excludes files with jinja2 templates in the filename.
+All files referenced by ``include_tasks`` or ``import_tasks`` must exist. The check excludes files with jinja2 templates in the filename.
 
 Idiom Rules (6xx)
 -----------------
 
 .. _601:
 
-601: Don't compare to literal True/False
-****************************************
+601: Don't compare to literal boolean.
+**************************************
 
-Use ``when: var`` rather than ``when: var == True`` (or conversely ``when: not var``)
+Use ``when: var`` instead of ``when: var == True``, or ``when: not var`` for negative checks.
 
 .. _602:
 
@@ -237,10 +237,10 @@ Metadata Rules (7xx)
 
 .. _701:
 
-701: meta/main.yml should contain relevant info
-***********************************************
+701: ``meta/main.yml`` should contain relevant info
+***************************************************
 
-meta/main.yml should contain: ``author, description, license, min_ansible_version, platforms``
+``meta/main.yml`` should contain: ``author``, ``description``, ``license``, ``min_ansible_version``, ``platforms``
 
 .. _702:
 
@@ -251,17 +251,17 @@ Tags must contain lowercase letters and digits only, and ``galaxy_tags`` is expe
 
 .. _703:
 
-703: meta/main.yml default values should be changed
-***************************************************
+703: ``meta/main.yml`` default values should be changed
+*******************************************************
 
-meta/main.yml default values should be changed for: ``author, description, company, license, license``
+meta/main.yml default values should be changed for: ``author``, ``company``, ``description``, ``license``
 
 .. _704:
 
-704: meta/main.yml video_links should be formatted correctly
-************************************************************
+704: ``meta/main.yml`` ``video_links`` should be formatted correctly
+********************************************************************
 
-Items in ``video_links`` in meta/main.yml should be dictionaries, and contain only keys ``url`` and ``title``, and have a shared link from a supported provider
+Items in ``video_links`` in ``meta/main.yml`` should be dictionaries, contain only keys like ``url``, ``title``, and have a shared link from a supported provider.
 
 Core Rules (9xx)
 ----------------

--- a/lib/ansiblelint/rules/AlwaysRunRule.py
+++ b/lib/ansiblelint/rules/AlwaysRunRule.py
@@ -23,8 +23,8 @@ from ansiblelint.rules import AnsibleLintRule
 
 class AlwaysRunRule(AnsibleLintRule):
     id = '101'
-    shortdesc = 'Deprecated always_run'
-    description = 'Instead of ``always_run``, use ``check_mode``'
+    shortdesc = 'Deprecated ``always_run``'
+    description = 'Use ``check_mode`` instead of ``always_run``.'
     severity = 'MEDIUM'
     tags = ['deprecated', 'ANSIBLE0018']
     version_added = 'historic'

--- a/lib/ansiblelint/rules/CommandHasChangesCheckRule.py
+++ b/lib/ansiblelint/rules/CommandHasChangesCheckRule.py
@@ -23,18 +23,17 @@ from ansiblelint.rules import AnsibleLintRule
 
 class CommandHasChangesCheckRule(AnsibleLintRule):
     id = '301'
-    shortdesc = 'Commands should not change things if nothing needs doing'
+    shortdesc = 'Commands should be idempotent'
     description = (
-        'Commands should either read information (and thus set '
-        '``changed_when``) or not do something if it has already been '
-        'done (using creates/removes) or only do it if another '
-        'check has a particular result (``when``)'
+        'Commands should either read information and report '
+        '``changed_when: false``. Changing commands should use conditions like ``when``, '
+        '``creates``, ``removes``, or set changed status based on a particular ``result``.'
     )
     severity = 'HIGH'
     tags = ['command-shell', 'idempotency', 'ANSIBLE0012']
     version_added = 'historic'
 
-    _commands = ['command', 'shell', 'raw']
+    _commands = ['command', 'shell', 'raw', 'idempotence']
 
     def matchtask(self, file, task):
         if task["__ansible_action_type__"] == 'task':

--- a/lib/ansiblelint/rules/ComparisonToLiteralBoolRule.py
+++ b/lib/ansiblelint/rules/ComparisonToLiteralBoolRule.py
@@ -7,10 +7,10 @@ import re
 
 class ComparisonToLiteralBoolRule(AnsibleLintRule):
     id = '601'
-    shortdesc = "Don't compare to literal True/False"
+    shortdesc = "Don't compare to literal boolean."
     description = (
-        'Use ``when: var`` rather than ``when: var == True`` '
-        '(or conversely ``when: not var``)'
+        'Use ``when: var`` instead of ``when: var == True``, '
+        'or ``when: not var`` for negative checks.'
     )
     severity = 'HIGH'
     tags = ['idiom']

--- a/lib/ansiblelint/rules/IncludeMissingFileRule.py
+++ b/lib/ansiblelint/rules/IncludeMissingFileRule.py
@@ -10,9 +10,9 @@ from ansiblelint.rules import AnsibleLintRule
 
 class IncludeMissingFileRule(AnsibleLintRule):
     id = '505'
-    shortdesc = 'referenced files must exist'
+    shortdesc = 'Referenced files must exist'
     description = (
-        'All files referenced by by include / import tasks '
+        'All files referenced by ``include_tasks`` or ``import_tasks`` '
         'must exist. The check excludes files with jinja2 '
         'templates in the filename.'
     )

--- a/lib/ansiblelint/rules/MetaChangeFromDefaultRule.py
+++ b/lib/ansiblelint/rules/MetaChangeFromDefaultRule.py
@@ -5,17 +5,17 @@ from ansiblelint.rules import AnsibleLintRule
 
 class MetaChangeFromDefaultRule(AnsibleLintRule):
     id = '703'
-    shortdesc = 'meta/main.yml default values should be changed'
+    shortdesc = '``meta/main.yml`` default values should be changed'
     field_defaults = [
         ('author', 'your name'),
-        ('description', 'your description'),
         ('company', 'your company (optional)'),
+        ('description', 'your description'),
         ('license', 'license (GPLv2, CC-BY, etc)'),
         ('license', 'license (GPL-2.0-or-later, MIT, etc)'),
     ]
     description = (
-        'meta/main.yml default values should be changed for: ``{}``'.format(
-            ', '.join(f[0] for f in field_defaults)
+        'meta/main.yml default values should be changed for: {}'.format(
+            ', '.join(sorted(set(f'``{f[0]}``' for f in field_defaults)))
         )
     )
     severity = 'HIGH'

--- a/lib/ansiblelint/rules/MetaMainHasInfoRule.py
+++ b/lib/ansiblelint/rules/MetaMainHasInfoRule.py
@@ -6,7 +6,7 @@ from ansiblelint.rules import AnsibleLintRule
 
 class MetaMainHasInfoRule(AnsibleLintRule):
     id = '701'
-    shortdesc = 'meta/main.yml should contain relevant info'
+    shortdesc = '``meta/main.yml`` should contain relevant info'
     info = [
         'author',
         'description',
@@ -15,7 +15,7 @@ class MetaMainHasInfoRule(AnsibleLintRule):
         'platforms',
     ]
     description = (
-        'meta/main.yml should contain: ``{}``'.format(', '.join(info))
+        '``meta/main.yml`` should contain: {}'.format(', '.join(f'``{k}``' for k in info))
     )
     severity = 'HIGH'
     tags = ['metadata']

--- a/lib/ansiblelint/rules/MetaVideoLinksRule.py
+++ b/lib/ansiblelint/rules/MetaVideoLinksRule.py
@@ -6,11 +6,11 @@ import re
 
 class MetaVideoLinksRule(AnsibleLintRule):
     id = '704'
-    shortdesc = "meta/main.yml video_links should be formatted correctly"
+    shortdesc = "``meta/main.yml`` ``video_links`` should be formatted correctly"
     description = (
-        'Items in ``video_links`` in meta/main.yml should be '
-        'dictionaries, and contain only keys ``url`` and ``title``, '
-        'and have a shared link from a supported provider'
+        'Items in ``video_links`` in ``meta/main.yml`` should be '
+        'dictionaries, contain only keys like ``url``, ``title``, '
+        'and have a shared link from a supported provider.'
     )
     severity = 'LOW'
     tags = ['metadata']

--- a/lib/ansiblelint/rules/PackageIsNotLatestRule.py
+++ b/lib/ansiblelint/rules/PackageIsNotLatestRule.py
@@ -25,7 +25,7 @@ class PackageIsNotLatestRule(AnsibleLintRule):
     id = '403'
     shortdesc = 'Package installs should not use latest'
     description = (
-        'Package installs should use ``state=present`` '
+        'Package installs should use ``state: present`` '
         'with or without a version'
     )
     severity = 'VERY_LOW'

--- a/lib/ansiblelint/rules/PlaybookExtension.py
+++ b/lib/ansiblelint/rules/PlaybookExtension.py
@@ -9,8 +9,8 @@ from typing import List
 
 class PlaybookExtension(AnsibleLintRule):
     id = '205'
-    shortdesc = 'Use ".yml" or ".yaml" playbook extension'
-    description = 'Playbooks should have the ".yml" or ".yaml" extension'
+    shortdesc = 'Use ``.yml`` or ``.yaml`` playbook extension'
+    description = 'Playbooks should have the ``.yml`` or ``.yaml`` extension.'
     severity = 'MEDIUM'
     tags = ['formatting']
     done = []  # type: List  # already noticed path list

--- a/lib/ansiblelint/rules/SudoRule.py
+++ b/lib/ansiblelint/rules/SudoRule.py
@@ -4,7 +4,7 @@ from ansiblelint.rules import AnsibleLintRule
 class SudoRule(AnsibleLintRule):
     id = '103'
     shortdesc = 'Deprecated sudo'
-    description = 'Instead of ``sudo``/``sudo_user``, use ``become``/``become_user``.'
+    description = 'Use ``become`` or ``become_user`` instead of ``sudo`` or ``sudo_user``.'
     severity = 'VERY_HIGH'
     tags = ['deprecated', 'ANSIBLE0008']
     version_added = 'historic'

--- a/lib/ansiblelint/rules/TaskNoLocalAction.py
+++ b/lib/ansiblelint/rules/TaskNoLocalAction.py
@@ -6,8 +6,8 @@ from ansiblelint.rules import AnsibleLintRule
 
 class TaskNoLocalAction(AnsibleLintRule):
     id = '504'
-    shortdesc = "Do not use 'local_action', use 'delegate_to: localhost'"
-    description = 'Do not use ``local_action``, use ``delegate_to: localhost``'
+    shortdesc = "Use ``delegate_to: localhost`` instead of ``local_action``"
+    description = shortdesc
     severity = 'MEDIUM'
     tags = ['task']
     version_added = 'v4.0.0'

--- a/test/TestPretaskIncludePlaybook.py
+++ b/test/TestPretaskIncludePlaybook.py
@@ -15,6 +15,6 @@ def test_task_hook_include_playbook(default_rules_collection, stage):
     results_text = str(results)
     assert len(runner.playbooks) == 2
     assert len(results) == 3
-    assert 'Commands should not change things' in results_text
+    assert 'Commands should be idempotent' in results_text
     assert '502' not in results_text
     assert 'All tasks should be named' not in results_text


### PR DESCRIPTION
- Rephrased few rule names and descriptions in order to make them
  easier to read (removed double negations, inverted conditionals)
- use correct double back-quotes as required by ReST
- rephrased grammar to improve readability