### PR TITLE
Replace deprecated getargspec w/ getfullargspec

### DIFF
--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -593,7 +593,7 @@ def parse_yaml_linenumbers(data, filename):
     try:
         import inspect
         kwargs = {}
-        if 'vault_password' in inspect.getargspec(AnsibleLoader.__init__).args:
+        if 'vault_password' in inspect.getfullargspec(AnsibleLoader.__init__).args:
             kwargs['vault_password'] = DEFAULT_VAULT_PASSWORD
         loader = AnsibleLoader(data, **kwargs)
         loader.compose_node = compose_node

--- a/pytest.ini
+++ b/pytest.ini
@@ -28,11 +28,6 @@ filterwarnings =
     # TODO: delete the following ignores once Ansible that we support gets rid of `imp`
     # Ref: https://github.com/ansible/ansible-lint/pull/734
     ignore:the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses:DeprecationWarning:ansible.plugins.loader
-    # TODO: delete the following ignores once we get rid of `inspect.getargspec()`
-    # Ref: https://github.com/ansible/ansible-lint/issues/603
-    ignore:inspect.getargspec\(\) is deprecated, use inspect.signature\(\) instead:DeprecationWarning
-    ignore:inspect.getargspec\(\) is deprecated, use inspect.signature\(\) or inspect.getfullargspec\(\):DeprecationWarning
-    ignore:inspect.getargspec\(\) is deprecated since Python 3.0, use inspect.signature\(\) or inspect.getfullargspec\(\):DeprecationWarning
 
     # TODO: delete the following ignores once Ansible gets rid of direct
     # imports from `collections`


### PR DESCRIPTION
I've also seen that ssbarnea moved `import inspect` from `try` block to the top of the file in his implementation of this issue. Should I move it like him or left as it is?

Close: #603

_Sorry that it took week to fix this issue_ :sweat_smile: