### PR TITLE
WIP: Enable downstream testing

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,2 +1,4 @@
 exclude_paths:
 - .github/
+stub_modules:
+- a_missing_module

--- a/examples/roles/bobbins/tasks/main.yml
+++ b/examples/roles/bobbins/tasks/main.yml
@@ -1,3 +1,7 @@
 ---
 - name: test tasks
   action: git a=b c=d
+
+- name: include missing module white-listed via .ansible-lint
+  a_missing_module:
+    foo: bar

--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -26,7 +26,7 @@ import pathlib
 import sys
 
 import ansiblelint.formatters as formatters
-from ansiblelint import cli, default_rulesdir, RulesCollection, Runner
+from ansiblelint import cli, default_rulesdir, RulesCollection, Runner, TMP_DIR
 from ansiblelint.utils import get_playbooks_and_roles
 from ansiblelint.utils import normpath, initialize_logger
 from ansiblelint.generate_docs import rules_as_rst
@@ -48,6 +48,24 @@ def main():
     formatter_factory: Any = formatters.Formatter
     if options.quiet:
         formatter_factory = formatters.QuietFormatter
+
+    for m in options.stub_modules:
+        with (pathlib.Path(TMP_DIR.name) / f"{m}.py") as f:
+            logging.warning(f"Generating fake module stub: {f.name}")
+            f.write_text("""
+# This is a fake {m} module used to make ansible(-lint) happy
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    return AnsibleModule(
+        argument_spec=dict(
+            data=dict(default=None),
+            path=dict(default=None, type=str),
+            file=dict(default=None, type=str),
+        )
+    )
+""")
 
     if options.parseable:
         formatter_factory = formatters.ParseableFormatter

--- a/lib/ansiblelint/cli.py
+++ b/lib/ansiblelint/cli.py
@@ -128,6 +128,10 @@ def get_cli_parser() -> argparse.ArgumentParser:
                         action='append',
                         default=[],
                         help="only check rules whose id/tags match these values")
+    parser.add_argument('--stub-modules', dest='stub_modules',
+                        action='append',
+                        default=[],
+                        help="Generate stub ansible modules to avoid loading failures")
     parser.add_argument('-T', dest='listtags', action='store_true',
                         help="list all the tags")
     parser.add_argument('-v', dest='verbosity', action='count',
@@ -195,6 +199,9 @@ def merge_config(file_config, cli_config) -> NamedTuple:
 
     if 'skip_list' in file_config:
         cli_config.skip_list = cli_config.skip_list + file_config['skip_list']
+
+    if 'stub_modules' in file_config:
+        cli_config.stub_modules = file_config['stub_modules']
 
     if 'tags' in file_config:
         cli_config.tags = cli_config.tags + file_config['tags']

--- a/playbooks/run-downstream-test.yml
+++ b/playbooks/run-downstream-test.yml
@@ -1,0 +1,25 @@
+#!/usr/bin/env ansible-playbook -v
+- hosts: localhost
+  connection: local
+  vars:
+    downstream_repos:
+      zuul-jobs: https://opendev.org/zuul/zuul-jobs
+      tripleo-operator-ansible: https://opendev.org/openstack/tripleo-operator-ansible
+    cache_dir: "{{ lookup('env', 'XDG_CACHE_DIR') or '~/.cache' }}/ansible-lint"
+  tasks:
+
+    - debug: var=cache_dir
+
+    - name: Clone downstream repos
+      git:
+        repo: "{{ item.value }}"
+        dest: "{{ cache_dir }}/{{ item.key }}"
+      loop: "{{ downstream_repos | dict2items }}"
+
+    - name: Running ansible-lint on downstream repos
+      shell:
+        cmd: |
+          python -m ansiblelint -p
+        chdir: "{{ cache_dir }}/{{ item.key }}"
+      loop: "{{ downstream_repos | dict2items }}"
+      changed_when: false

--- a/test/TestCommandLineInvocationSameAsConfig.py
+++ b/test/TestCommandLineInvocationSameAsConfig.py
@@ -27,8 +27,8 @@ def base_arguments():
                           "test/fixtures/exclude-paths.yml"),
                          (["--show-relpath"],
                           "test/fixtures/show-abspath.yml"),
-                         ([],
-                          "test/fixtures/show-relpath.yml"),
+                         (["--stub-modules", "a_missing_module"],
+                          "test/fixtures/stub-modules.yml"),
                          ))
 def test_ensure_config_are_equal(base_arguments, args, config, monkeypatch):
     command = base_arguments + args

--- a/test/TestStubs.py
+++ b/test/TestStubs.py
@@ -1,0 +1,51 @@
+from collections import namedtuple
+
+import pytest
+
+from ansiblelint import Runner
+
+
+PlayFile = namedtuple('PlayFile', ['name', 'content'])
+
+
+PLAY_STUBS = PlayFile('playbook.yml', '''
+- hosts: localhost
+  tasks:
+
+    - name: include missing module white-listed via .ansible-lint
+      a_missing_module:
+        foo: bar
+''')
+
+
+@pytest.fixture
+def play_file_path(tmp_path):
+    p = tmp_path / 'playbook.yml'
+    return str(p)
+
+
+@pytest.fixture
+def runner(play_file_path, default_rules_collection):
+    return Runner(default_rules_collection, play_file_path, [], [], [])
+
+
+@pytest.fixture
+def _play_files(tmp_path, request):
+    if request.param is None:
+        return
+    for play_file in request.param:
+        p = tmp_path / play_file.name
+        p.write_text(play_file.content)
+
+
+@pytest.mark.parametrize(
+    '_play_files',
+    (
+        pytest.param([PLAY_STUBS], id='Using stubs for missing modules'),
+    ),
+    indirect=['_play_files']
+)
+@pytest.mark.usefixtures('_play_files')
+def test_stubs(runner):
+    results = str(runner.run())
+    assert not results

--- a/test/fixtures/stub-modules.yml
+++ b/test/fixtures/stub-modules.yml
@@ -1,0 +1,2 @@
+stub_modules:
+  - a_missing_module

--- a/tox.ini
+++ b/tox.ini
@@ -47,10 +47,17 @@ passenv =
 # recreate = True
 setenv =
   ANSIBLE_COLLECTIONS_PATHS = {envtmpdir}
+  ANSIBLE_STDOUT_CALLBACK = yaml
+  ANSIBLE_NOCOWS = 1
   COVERAGE_FILE = {env:COVERAGE_FILE:{toxworkdir}/.coverage.{envname}}
   PIP_DISABLE_PIP_VERSION_CHECK = 1
 whitelist_externals =
   ansibledevel: sh
+
+[testenv:venv]
+commands = {posargs:true}
+whitelist_externals =
+  true
 
 [testenv:.dev-env]
 #basepython = python3
@@ -116,3 +123,6 @@ skip_install = true
 # Ref: https://twitter.com/di_codes/status/1044358639081975813
 commands =
   twine check {toxinidir}/dist/*
+
+[testenv:downstream]
+commands = ansible-playbook -i localhost, playbooks/run-downstream-test.yml


### PR DESCRIPTION
Enable testing of few downstream consumers of ansible-lint in order
to assure that newer versions do not break their use.

Fixes: #778