### PR TITLE
Enable stub/fake modules

### DIFF
--- a/examples/roles/bobbins/tasks/main.yml
+++ b/examples/roles/bobbins/tasks/main.yml
@@ -1,3 +1,7 @@
 ---
 - name: test tasks
   action: git a=b c=d
+
+- name: include missing module white-listed via .ansible-lint
+  a_missing_module:
+    foo: bar

--- a/lib/ansiblelint/__init__.py
+++ b/lib/ansiblelint/__init__.py
@@ -22,13 +22,31 @@
 from collections import defaultdict
 import logging
 import os
+import pathlib
+import tempfile
+from typing import List, Set
+
+
+# this code needs to run before any ansible module import happens in order to
+# properly setup additional module paths.
+lib_paths = os.environ.get(
+    'ANSIBLE_LIBRARY',
+    "~/.ansible/plugins/modules:/usr/share/ansible/plugins/modules").split(":")
+# add plugins/modules to module paths if it exists
+p = pathlib.Path.cwd() / "plugins" / "modules"
+if p.exists():
+    lib_paths.append(str(p))
+# creates temporary directory for stub modules (auto-cleaned)
+TMP_DIR = tempfile.TemporaryDirectory()
+lib_paths.append(TMP_DIR.name)
+os.environ['ANSIBLE_LIBRARY'] = ":".join(lib_paths)
+logging.warning(f"Altered module path ANSIBLE_LIBRARY={os.environ['ANSIBLE_LIBRARY']}")
 
 from ansiblelint.rules import AnsibleLintRule  # noqa F401: exposing public API
-import ansiblelint.utils
-import ansiblelint.skip_utils
-from ansiblelint.errors import MatchError
-from ansiblelint.rules.LoadingFailureRule import LoadingFailureRule
-from typing import List, Set
+import ansiblelint.utils  # noqa E402
+import ansiblelint.skip_utils  # noqa E402
+from ansiblelint.errors import MatchError  # noqa E402
+from ansiblelint.rules.LoadingFailureRule import LoadingFailureRule  # noqa E402
 
 
 default_rulesdir = os.path.join(os.path.dirname(ansiblelint.utils.__file__), 'rules')

--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -26,7 +26,7 @@ import pathlib
 import sys
 
 import ansiblelint.formatters as formatters
-from ansiblelint import cli, default_rulesdir, RulesCollection, Runner
+from ansiblelint import cli, default_rulesdir, RulesCollection, Runner, TMP_DIR
 from ansiblelint.utils import get_playbooks_and_roles
 from ansiblelint.utils import normpath, initialize_logger
 from ansiblelint.generate_docs import rules_as_rst
@@ -48,6 +48,24 @@ def main():
     formatter_factory: Any = formatters.Formatter
     if options.quiet:
         formatter_factory = formatters.QuietFormatter
+
+    for m in options.stub_modules:
+        with (pathlib.Path(TMP_DIR.name) / f"{m}.py") as f:
+            logging.warning(f"Generating fake module stub: {f.name}")
+            f.write_text("""
+# This is a fake {m} module used to make ansible(-lint) happy
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    return AnsibleModule(
+        argument_spec=dict(
+            data=dict(default=None),
+            path=dict(default=None, type=str),
+            file=dict(default=None, type=str),
+        )
+    )
+""")
 
     if options.parseable:
         formatter_factory = formatters.ParseableFormatter

--- a/lib/ansiblelint/cli.py
+++ b/lib/ansiblelint/cli.py
@@ -128,6 +128,10 @@ def get_cli_parser() -> argparse.ArgumentParser:
                         action='append',
                         default=[],
                         help="only check rules whose id/tags match these values")
+    parser.add_argument('--stub-modules', dest='stub_modules',
+                        action='append',
+                        default=[],
+                        help="Generate stub ansible modules to avoid loading failures")
     parser.add_argument('-T', dest='listtags', action='store_true',
                         help="list all the tags")
     parser.add_argument('-v', dest='verbosity', action='count',
@@ -195,6 +199,8 @@ def merge_config(file_config, cli_config) -> NamedTuple:
 
     if 'skip_list' in file_config:
         cli_config.skip_list = cli_config.skip_list + file_config['skip_list']
+
+    cli_config.stub_modules.extend(file_config.get('stub_modules', []))
 
     if 'tags' in file_config:
         cli_config.tags = cli_config.tags + file_config['tags']

--- a/test/TestCommandLineInvocationSameAsConfig.py
+++ b/test/TestCommandLineInvocationSameAsConfig.py
@@ -29,6 +29,8 @@ def base_arguments():
                           "test/fixtures/show-abspath.yml"),
                          ([],
                           "test/fixtures/show-relpath.yml"),
+                         (["--stub-modules", "a_missing_module"],
+                          "test/fixtures/stub-modules.yml"),
                          ))
 def test_ensure_config_are_equal(base_arguments, args, config, monkeypatch):
     command = base_arguments + args

--- a/test/fixtures/stub-modules.yml
+++ b/test/fixtures/stub-modules.yml
@@ -1,4 +1,2 @@
-exclude_paths:
-- .github/
 stub_modules:
 - a_missing_module


### PR DESCRIPTION
Provides a way to define a list of ansible modules that would be
mocked by the linter in order to allow Ansible to load the linted
files.

This should fix a very common problem which hindered linting on
various repositories, where the modules where hard to install inside
the linting jobs.

This changes also auto-adds `plugins/modules` if the folder is found,
as this is the official location for putting modules.

Fixes: #778
