### PR TITLE
Refactor default_rulesdir

### DIFF
--- a/lib/ansiblelint/__init__.py
+++ b/lib/ansiblelint/__init__.py
@@ -31,7 +31,6 @@ from ansiblelint.rules.LoadingFailureRule import LoadingFailureRule
 from typing import List, Set
 
 
-default_rulesdir = os.path.join(os.path.dirname(ansiblelint.utils.__file__), 'rules')
 _logger = logging.getLogger(__name__)
 
 
@@ -44,6 +43,7 @@ class RulesCollection(object):
         self.rulesdirs = ansiblelint.utils.expand_paths_vars(rulesdirs)
         self.rules = []
         for rulesdir in self.rulesdirs:
+            _logger.debug("Loading rules from %s", rulesdir)
             self.extend(ansiblelint.utils.load_plugins(rulesdir))
         self.rules = sorted(self.rules, key=lambda r: r.id)
 

--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -26,7 +26,8 @@ import pathlib
 import sys
 
 import ansiblelint.formatters as formatters
-from ansiblelint import cli, default_rulesdir, RulesCollection, Runner
+from ansiblelint import cli, RulesCollection, Runner
+from ansiblelint.constants import DEFAULT_RULESDIR
 from ansiblelint.utils import get_playbooks_and_roles
 from ansiblelint.utils import normpath, initialize_logger
 from ansiblelint.generate_docs import rules_as_rst
@@ -58,9 +59,9 @@ def main():
     formatter = formatter_factory(cwd, options.display_relative_path)
 
     if options.use_default_rules:
-        rulesdirs = options.rulesdir + [default_rulesdir]
+        rulesdirs = options.rulesdir + [DEFAULT_RULESDIR]
     else:
-        rulesdirs = options.rulesdir or [default_rulesdir]
+        rulesdirs = options.rulesdir or [DEFAULT_RULESDIR]
     rules = RulesCollection(rulesdirs)
 
     if options.listrules:

--- a/lib/ansiblelint/cli.py
+++ b/lib/ansiblelint/cli.py
@@ -9,8 +9,9 @@ import sys
 import yaml
 from typing import NamedTuple
 
-import ansiblelint
+from ansiblelint.constants import DEFAULT_RULESDIR
 from ansiblelint.version import __version__
+import ansiblelint.utils
 
 
 _logger = logging.getLogger(__name__)
@@ -110,17 +111,12 @@ def get_cli_parser() -> argparse.ArgumentParser:
                         help="parseable output including severity of rule")
     parser.add_argument('-r', action=AbspathArgAction, dest='rulesdir',
                         default=[], type=Path,
-                        help="specify one or more rules directories using "
-                             "one or more -r arguments. Any -r flags override "
-                             "the default rules in %s, unless -R is also used."
-                             % ansiblelint.default_rulesdir)
+                        help="Specify custom rule directories. Add -R "
+                             f"to keep using embedded rules from {DEFAULT_RULESDIR}")
     parser.add_argument('-R', action='store_true',
                         default=False,
                         dest='use_default_rules',
-                        help="Use default rules in %s in addition to any extra "
-                             "rules directories specified with -r. There is "
-                             "no need to specify this if no -r flags are used"
-                             % ansiblelint.default_rulesdir)
+                        help="Keep default rules when using -r")
     parser.add_argument('--show-relpath', dest='display_relative_path', action='store_false',
                         default=True,
                         help="Display path relative to CWD")

--- a/lib/ansiblelint/constants.py
+++ b/lib/ansiblelint/constants.py
@@ -1,0 +1,5 @@
+"""Constants used by AnsibleLint."""
+import os.path
+
+
+DEFAULT_RULESDIR = os.path.join(os.path.dirname(__file__), 'rules')


### PR DESCRIPTION
- Simplify -r/-R documentation by avoiding repetitions
- Correct grammar (avoid two plural nouns in a row)
- Reduce internal imports
- Avoid use of ``__init__``
- Add debugging message about effective directories used to load rules

## Before

>   -r RULESDIR           specify one or more rules directories using one or
>                         more -r arguments. Any -r flags override the default
>                         rules in /home/ssbarnea/.local/lib/python3.6/site-
>                         packages/ansiblelint/rules, unless -R is also used.
>   -R                    Use default rules in
>                         /home/ssbarnea/.local/lib/python3.6/site-
>                         packages/ansiblelint/rules in addition to any extra
>                         rules directories specified with -r. There is no need
>                         to specify this if no -r flags are used
> 

## After


>   -r RULESDIR           Specify custom rule directories. Add -R to keep using embedded rules from /Users/ssbarnea/c/os/ansible-lint/lib/ansiblelint/rules
>   -R                    Keep using default rules when using -r


Partial: #812