### PR TITLE
Changed AnsibleLintRule imports

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -541,7 +541,7 @@ An example rule using ``match`` is:
 
 .. code-block:: python
 
-    from ansiblelint import AnsibleLintRule
+    from ansiblelint.rules import AnsibleLintRule
 
     class DeprecatedVariableRule(AnsibleLintRule):
 
@@ -559,7 +559,7 @@ An example rule using ``matchtask`` is:
 .. code-block:: python
 
     import ansiblelint.utils
-    from ansiblelint import AnsibleLintRule
+    from ansiblelint.rules import AnsibleLintRule
 
     class TaskHasTag(AnsibleLintRule):
         id = 'EXAMPLE001'

--- a/examples/rules/TaskHasTag.py
+++ b/examples/rules/TaskHasTag.py
@@ -1,5 +1,5 @@
 """Example implementation of a rule requiring tasks to have tags set."""
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 
 
 class TaskHasTag(AnsibleLintRule):

--- a/lib/ansiblelint/__init__.py
+++ b/lib/ansiblelint/__init__.py
@@ -22,7 +22,6 @@
 from collections import defaultdict
 import logging
 
-from ansiblelint.rules import AnsibleLintRule  # noqa F401: exposing public API
 import ansiblelint.utils
 import ansiblelint.skip_utils
 from typing import List
@@ -97,3 +96,6 @@ class RulesCollection(object):
         for tag in sorted(tags):
             results.append("{0} {1}".format(tag, tags[tag]))
         return "\n".join(results)
+
+
+from ansiblelint.rules import AnsibleLintRule  # noqa F401: exposing public API

--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -26,8 +26,9 @@ import pathlib
 import sys
 
 import ansiblelint.formatters as formatters
-from ansiblelint import cli, RulesCollection
+from ansiblelint import cli
 from ansiblelint.constants import DEFAULT_RULESDIR
+from ansiblelint.rules import RulesCollection
 from ansiblelint.runner import Runner
 from ansiblelint.utils import get_playbooks_and_roles
 from ansiblelint.utils import normpath, initialize_logger

--- a/lib/ansiblelint/rules/AlwaysRunRule.py
+++ b/lib/ansiblelint/rules/AlwaysRunRule.py
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 
 
 class AlwaysRunRule(AnsibleLintRule):

--- a/lib/ansiblelint/rules/BecomeUserWithoutBecomeRule.py
+++ b/lib/ansiblelint/rules/BecomeUserWithoutBecomeRule.py
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 
 
 def _become_user_without_become(data):

--- a/lib/ansiblelint/rules/CommandHasChangesCheckRule.py
+++ b/lib/ansiblelint/rules/CommandHasChangesCheckRule.py
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 
 
 class CommandHasChangesCheckRule(AnsibleLintRule):

--- a/lib/ansiblelint/rules/CommandsInsteadOfArgumentsRule.py
+++ b/lib/ansiblelint/rules/CommandsInsteadOfArgumentsRule.py
@@ -20,7 +20,7 @@
 
 import os
 
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 from ansiblelint.utils import get_first_cmd_arg
 try:
     from ansible.module_utils.parsing.convert_bool import boolean

--- a/lib/ansiblelint/rules/CommandsInsteadOfModulesRule.py
+++ b/lib/ansiblelint/rules/CommandsInsteadOfModulesRule.py
@@ -20,7 +20,7 @@
 
 import os
 
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 from ansiblelint.utils import get_first_cmd_arg
 try:
     from ansible.module_utils.parsing.convert_bool import boolean

--- a/lib/ansiblelint/rules/ComparisonToEmptyStringRule.py
+++ b/lib/ansiblelint/rules/ComparisonToEmptyStringRule.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Will Thames and contributors
 # Copyright (c) 2018, Ansible Project
 
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 import re
 
 

--- a/lib/ansiblelint/rules/ComparisonToLiteralBoolRule.py
+++ b/lib/ansiblelint/rules/ComparisonToLiteralBoolRule.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Will Thames and contributors
 # Copyright (c) 2018, Ansible Project
 
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 import re
 
 

--- a/lib/ansiblelint/rules/DeprecatedModuleRule.py
+++ b/lib/ansiblelint/rules/DeprecatedModuleRule.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2018, Ansible Project
 
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 
 
 class DeprecatedModuleRule(AnsibleLintRule):

--- a/lib/ansiblelint/rules/EnvVarsInCommandRule.py
+++ b/lib/ansiblelint/rules/EnvVarsInCommandRule.py
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 from ansiblelint.utils import LINE_NUMBER_KEY, FILENAME_KEY, get_first_cmd_arg
 
 

--- a/lib/ansiblelint/rules/GitHasVersionRule.py
+++ b/lib/ansiblelint/rules/GitHasVersionRule.py
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 
 
 class GitHasVersionRule(AnsibleLintRule):

--- a/lib/ansiblelint/rules/IncludeMissingFileRule.py
+++ b/lib/ansiblelint/rules/IncludeMissingFileRule.py
@@ -5,7 +5,7 @@ import os.path
 
 import ansible.parsing.yaml.objects
 
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 
 
 class IncludeMissingFileRule(AnsibleLintRule):

--- a/lib/ansiblelint/rules/LineTooLongRule.py
+++ b/lib/ansiblelint/rules/LineTooLongRule.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Will Thames and contributors
 # Copyright (c) 2018, Ansible Project
 
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 
 
 class LineTooLongRule(AnsibleLintRule):

--- a/lib/ansiblelint/rules/LoadingFailureRule.py
+++ b/lib/ansiblelint/rules/LoadingFailureRule.py
@@ -1,6 +1,6 @@
 """Rule definition for a failure to load a file."""
 
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 
 
 class LoadingFailureRule(AnsibleLintRule):

--- a/lib/ansiblelint/rules/MercurialHasRevisionRule.py
+++ b/lib/ansiblelint/rules/MercurialHasRevisionRule.py
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 
 
 class MercurialHasRevisionRule(AnsibleLintRule):

--- a/lib/ansiblelint/rules/MetaChangeFromDefaultRule.py
+++ b/lib/ansiblelint/rules/MetaChangeFromDefaultRule.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2018, Ansible Project
 
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 
 
 class MetaChangeFromDefaultRule(AnsibleLintRule):

--- a/lib/ansiblelint/rules/MetaMainHasInfoRule.py
+++ b/lib/ansiblelint/rules/MetaMainHasInfoRule.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Will Thames and contributors
 # Copyright (c) 2018, Ansible Project
 
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 
 
 class MetaMainHasInfoRule(AnsibleLintRule):

--- a/lib/ansiblelint/rules/MetaTagValidRule.py
+++ b/lib/ansiblelint/rules/MetaTagValidRule.py
@@ -2,7 +2,7 @@
 
 import re
 
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 
 
 class MetaTagValidRule(AnsibleLintRule):

--- a/lib/ansiblelint/rules/MetaVideoLinksRule.py
+++ b/lib/ansiblelint/rules/MetaVideoLinksRule.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2018, Ansible Project
 
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 import re
 
 

--- a/lib/ansiblelint/rules/NoFormattingInWhenRule.py
+++ b/lib/ansiblelint/rules/NoFormattingInWhenRule.py
@@ -1,4 +1,4 @@
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 
 
 class NoFormattingInWhenRule(AnsibleLintRule):

--- a/lib/ansiblelint/rules/NoTabsRule.py
+++ b/lib/ansiblelint/rules/NoTabsRule.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Will Thames and contributors
 # Copyright (c) 2018, Ansible Project
 
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 
 
 class NoTabsRule(AnsibleLintRule):

--- a/lib/ansiblelint/rules/OctalPermissionsRule.py
+++ b/lib/ansiblelint/rules/OctalPermissionsRule.py
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 
 
 class OctalPermissionsRule(AnsibleLintRule):

--- a/lib/ansiblelint/rules/PackageIsNotLatestRule.py
+++ b/lib/ansiblelint/rules/PackageIsNotLatestRule.py
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 
 
 class PackageIsNotLatestRule(AnsibleLintRule):

--- a/lib/ansiblelint/rules/PlaybookExtension.py
+++ b/lib/ansiblelint/rules/PlaybookExtension.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Tsukinowa Inc. <info@tsukinowa.jp>
 # Copyright (c) 2018, Ansible Project
 
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 
 import os
 from typing import List

--- a/lib/ansiblelint/rules/RoleNames.py
+++ b/lib/ansiblelint/rules/RoleNames.py
@@ -20,7 +20,7 @@
 # THE SOFTWARE.
 
 import re
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 from typing import List
 
 ROLE_NAME_REGEX = '^[a-z][a-z0-9_]+$'

--- a/lib/ansiblelint/rules/RoleRelativePath.py
+++ b/lib/ansiblelint/rules/RoleRelativePath.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Tsukinowa Inc. <info@tsukinowa.jp>
 # Copyright (c) 2018, Ansible Project
 
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 
 
 class RoleRelativePath(AnsibleLintRule):

--- a/lib/ansiblelint/rules/ShellWithoutPipefail.py
+++ b/lib/ansiblelint/rules/ShellWithoutPipefail.py
@@ -1,6 +1,6 @@
 import re
 
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 
 
 class ShellWithoutPipefail(AnsibleLintRule):

--- a/lib/ansiblelint/rules/SudoRule.py
+++ b/lib/ansiblelint/rules/SudoRule.py
@@ -1,4 +1,4 @@
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 
 
 class SudoRule(AnsibleLintRule):

--- a/lib/ansiblelint/rules/TaskHasNameRule.py
+++ b/lib/ansiblelint/rules/TaskHasNameRule.py
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 
 
 class TaskHasNameRule(AnsibleLintRule):

--- a/lib/ansiblelint/rules/TaskNoLocalAction.py
+++ b/lib/ansiblelint/rules/TaskNoLocalAction.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Tsukinowa Inc. <info@tsukinowa.jp>
 # Copyright (c) 2018, Ansible Project
 
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 
 
 class TaskNoLocalAction(AnsibleLintRule):

--- a/lib/ansiblelint/rules/TrailingWhitespaceRule.py
+++ b/lib/ansiblelint/rules/TrailingWhitespaceRule.py
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 
 
 class TrailingWhitespaceRule(AnsibleLintRule):

--- a/lib/ansiblelint/rules/UseCommandInsteadOfShellRule.py
+++ b/lib/ansiblelint/rules/UseCommandInsteadOfShellRule.py
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 
 
 class UseCommandInsteadOfShellRule(AnsibleLintRule):

--- a/lib/ansiblelint/rules/UseHandlerRatherThanWhenChangedRule.py
+++ b/lib/ansiblelint/rules/UseHandlerRatherThanWhenChangedRule.py
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 
 
 def _changed_in_when(item):

--- a/lib/ansiblelint/rules/UsingBareVariablesIsDeprecatedRule.py
+++ b/lib/ansiblelint/rules/UsingBareVariablesIsDeprecatedRule.py
@@ -20,7 +20,7 @@
 
 import os
 import re
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 
 
 class UsingBareVariablesIsDeprecatedRule(AnsibleLintRule):

--- a/lib/ansiblelint/rules/VariableHasSpacesRule.py
+++ b/lib/ansiblelint/rules/VariableHasSpacesRule.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Will Thames and contributors
 # Copyright (c) 2018, Ansible Project
 
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 import re
 
 

--- a/lib/ansiblelint/rules/__init__.py
+++ b/lib/ansiblelint/rules/__init__.py
@@ -120,3 +120,5 @@ class AnsibleLintRule(object):
                 matches.append(Match(linenumber,
                                      section, file['path'], self, message))
         return matches
+
+from ansiblelint import RulesCollection  # noqa F401: new class location

--- a/test/TestAlwaysRunRule.py
+++ b/test/TestAlwaysRunRule.py
@@ -1,5 +1,5 @@
 import unittest
-from ansiblelint import RulesCollection
+from ansiblelint.rules import RulesCollection
 from ansiblelint.runner import Runner
 from ansiblelint.rules.AlwaysRunRule import AlwaysRunRule
 

--- a/test/TestBecomeUserWithoutBecome.py
+++ b/test/TestBecomeUserWithoutBecome.py
@@ -1,5 +1,5 @@
 import unittest
-from ansiblelint import RulesCollection
+from ansiblelint.rules import RulesCollection
 from ansiblelint.runner import Runner
 from ansiblelint.rules.BecomeUserWithoutBecomeRule import BecomeUserWithoutBecomeRule
 

--- a/test/TestCommandHasChangesCheck.py
+++ b/test/TestCommandHasChangesCheck.py
@@ -1,6 +1,6 @@
 import unittest
-from ansiblelint import RulesCollection
 from ansiblelint.runner import Runner
+from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.CommandHasChangesCheckRule import CommandHasChangesCheckRule
 
 

--- a/test/TestComparisonToEmptyString.py
+++ b/test/TestComparisonToEmptyString.py
@@ -1,6 +1,6 @@
 import unittest
 
-from ansiblelint import RulesCollection
+from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.ComparisonToEmptyStringRule import (
     ComparisonToEmptyStringRule)
 from test import RunFromText

--- a/test/TestComparisonToLiteralBool.py
+++ b/test/TestComparisonToLiteralBool.py
@@ -1,6 +1,6 @@
 import unittest
 
-from ansiblelint import RulesCollection
+from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.ComparisonToLiteralBoolRule import (
     ComparisonToLiteralBoolRule)
 from test import RunFromText

--- a/test/TestDeprecatedModule.py
+++ b/test/TestDeprecatedModule.py
@@ -3,7 +3,7 @@ import unittest
 from ansible import __version__ as ansible_version_str
 import pytest
 
-from ansiblelint import RulesCollection
+from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.DeprecatedModuleRule import DeprecatedModuleRule
 from test import RunFromText
 

--- a/test/TestEnvVarsInCommand.py
+++ b/test/TestEnvVarsInCommand.py
@@ -1,6 +1,6 @@
 import unittest
 
-from ansiblelint import RulesCollection
+from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.EnvVarsInCommandRule import EnvVarsInCommandRule
 from test import RunFromText
 

--- a/test/TestLineTooLong.py
+++ b/test/TestLineTooLong.py
@@ -1,6 +1,6 @@
 import unittest
 
-from ansiblelint import RulesCollection
+from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.LineTooLongRule import LineTooLongRule
 from test import RunFromText
 

--- a/test/TestMetaChangeFromDefault.py
+++ b/test/TestMetaChangeFromDefault.py
@@ -1,6 +1,6 @@
 import unittest
 
-from ansiblelint import RulesCollection
+from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.MetaChangeFromDefaultRule import (
     MetaChangeFromDefaultRule)
 from test import RunFromText

--- a/test/TestMetaMainHasInfo.py
+++ b/test/TestMetaMainHasInfo.py
@@ -1,6 +1,6 @@
 import unittest
 
-from ansiblelint import RulesCollection
+from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.MetaMainHasInfoRule import MetaMainHasInfoRule
 from test import RunFromText
 

--- a/test/TestMetaTagValid.py
+++ b/test/TestMetaTagValid.py
@@ -1,6 +1,6 @@
 import unittest
 
-from ansiblelint import RulesCollection
+from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.MetaTagValidRule import MetaTagValidRule
 from test import RunFromText
 

--- a/test/TestMetaVideoLinks.py
+++ b/test/TestMetaVideoLinks.py
@@ -1,6 +1,6 @@
 import unittest
 
-from ansiblelint import RulesCollection
+from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.MetaVideoLinksRule import MetaVideoLinksRule
 from test import RunFromText
 

--- a/test/TestNoFormattingInWhenRule.py
+++ b/test/TestNoFormattingInWhenRule.py
@@ -1,5 +1,5 @@
 import unittest
-from ansiblelint import RulesCollection
+from ansiblelint.rules import RulesCollection
 from ansiblelint.runner import Runner
 from ansiblelint.rules.NoFormattingInWhenRule import NoFormattingInWhenRule
 

--- a/test/TestOctalPermissions.py
+++ b/test/TestOctalPermissions.py
@@ -1,6 +1,6 @@
 import unittest
 
-from ansiblelint import RulesCollection
+from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.OctalPermissionsRule import OctalPermissionsRule
 from test import RunFromText
 

--- a/test/TestPackageIsNotLatest.py
+++ b/test/TestPackageIsNotLatest.py
@@ -1,6 +1,6 @@
 import unittest
-from ansiblelint import RulesCollection
 from ansiblelint.runner import Runner
+from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.PackageIsNotLatestRule import PackageIsNotLatestRule
 
 

--- a/test/TestRoleHandlers.py
+++ b/test/TestRoleHandlers.py
@@ -1,6 +1,6 @@
 import unittest
-from ansiblelint import RulesCollection
 from ansiblelint.runner import Runner
+from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.UseHandlerRatherThanWhenChangedRule import (
     UseHandlerRatherThanWhenChangedRule)
 

--- a/test/TestRoleRelativePath.py
+++ b/test/TestRoleRelativePath.py
@@ -1,6 +1,6 @@
 import unittest
 
-from ansiblelint import RulesCollection
+from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.RoleRelativePath import RoleRelativePath
 from test import RunFromText
 

--- a/test/TestRulesCollection.py
+++ b/test/TestRulesCollection.py
@@ -23,7 +23,7 @@ import os
 
 import pytest
 
-from ansiblelint import RulesCollection
+from ansiblelint.rules import RulesCollection
 
 
 @pytest.fixture

--- a/test/TestRunner.py
+++ b/test/TestRunner.py
@@ -20,8 +20,7 @@
 import os
 
 import pytest
-
-from ansiblelint import formatters
+import ansiblelint.formatters as formatters
 from ansiblelint.runner import Runner
 from ansiblelint.cli import abspath
 

--- a/test/TestRunner.py
+++ b/test/TestRunner.py
@@ -20,6 +20,7 @@
 import os
 
 import pytest
+
 import ansiblelint.formatters as formatters
 from ansiblelint.runner import Runner
 from ansiblelint.cli import abspath

--- a/test/TestShellWithoutPipefail.py
+++ b/test/TestShellWithoutPipefail.py
@@ -1,6 +1,6 @@
 import unittest
 
-from ansiblelint import RulesCollection
+from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.ShellWithoutPipefail import ShellWithoutPipefail
 from test import RunFromText
 

--- a/test/TestSudoRule.py
+++ b/test/TestSudoRule.py
@@ -1,6 +1,6 @@
 import unittest
 
-from ansiblelint import RulesCollection
+from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.SudoRule import SudoRule
 from test import RunFromText
 

--- a/test/TestTaskHasName.py
+++ b/test/TestTaskHasName.py
@@ -1,6 +1,6 @@
 import unittest
-from ansiblelint import RulesCollection
 from ansiblelint.runner import Runner
+from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.TaskHasNameRule import TaskHasNameRule
 
 

--- a/test/TestTaskNoLocalAction.py
+++ b/test/TestTaskNoLocalAction.py
@@ -1,6 +1,6 @@
 import unittest
 
-from ansiblelint import RulesCollection
+from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.TaskNoLocalAction import TaskNoLocalAction
 from test import RunFromText
 

--- a/test/TestUseCommandInsteadOfShell.py
+++ b/test/TestUseCommandInsteadOfShell.py
@@ -1,6 +1,6 @@
 import unittest
-from ansiblelint import RulesCollection
 from ansiblelint.runner import Runner
+from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.UseCommandInsteadOfShellRule import UseCommandInsteadOfShellRule
 
 

--- a/test/TestUseHandlerRatherThanWhenChanged.py
+++ b/test/TestUseHandlerRatherThanWhenChanged.py
@@ -1,6 +1,6 @@
 import unittest
 
-from ansiblelint import RulesCollection
+from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.UseHandlerRatherThanWhenChangedRule import (
     UseHandlerRatherThanWhenChangedRule)
 from test import RunFromText

--- a/test/TestUsingBareVariablesIsDeprecated.py
+++ b/test/TestUsingBareVariablesIsDeprecated.py
@@ -1,6 +1,6 @@
 import unittest
-from ansiblelint import RulesCollection
 from ansiblelint.runner import Runner
+from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.UsingBareVariablesIsDeprecatedRule import UsingBareVariablesIsDeprecatedRule
 
 

--- a/test/TestVariableHasSpaces.py
+++ b/test/TestVariableHasSpaces.py
@@ -1,6 +1,6 @@
 import unittest
 
-from ansiblelint import RulesCollection
+from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.VariableHasSpacesRule import VariableHasSpacesRule
 from test import RunFromText
 

--- a/test/TestWithSkipTagId.py
+++ b/test/TestWithSkipTagId.py
@@ -1,5 +1,5 @@
 import unittest
-from ansiblelint import RulesCollection
+from ansiblelint.rules import RulesCollection
 from ansiblelint.runner import Runner
 from ansiblelint.rules.TrailingWhitespaceRule import TrailingWhitespaceRule
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,7 +3,7 @@ import os
 import pytest
 from test import RunFromText
 
-from ansiblelint import RulesCollection
+from ansiblelint.rules import RulesCollection
 
 
 @pytest.fixture

--- a/test/rules/EMatcherRule.py
+++ b/test/rules/EMatcherRule.py
@@ -1,4 +1,4 @@
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 
 
 class EMatcherRule(AnsibleLintRule):

--- a/test/rules/UnsetVariableMatcherRule.py
+++ b/test/rules/UnsetVariableMatcherRule.py
@@ -1,4 +1,4 @@
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 
 
 class UnsetVariableMatcherRule(AnsibleLintRule):


### PR DESCRIPTION
Change all imports of AnsibleLintRule to point to its future location.

This change does not move implementation, that will be done in a
follow-up in order to make it easier to review.

Related: #801