### PR TITLE
Moved exit codes to constants

### DIFF
--- a/lib/ansiblelint/cli.py
+++ b/lib/ansiblelint/cli.py
@@ -9,9 +9,8 @@ import sys
 import yaml
 from typing import NamedTuple
 
-from ansiblelint.constants import DEFAULT_RULESDIR
+from ansiblelint.constants import DEFAULT_RULESDIR, INVALID_CONFIG_RC
 from ansiblelint.version import __version__
-import ansiblelint.utils
 
 
 _logger = logging.getLogger(__name__)
@@ -60,7 +59,7 @@ def load_config(config_file):
     if config_file:
         if not os.path.exists(config_path):
             _logger.error("Config file not found '%s'", config_path)
-            sys.exit(ansiblelint.utils.INVALID_CONFIG_RC)
+            sys.exit(INVALID_CONFIG_RC)
     elif not os.path.exists(config_path):
         # a missing default config file should not trigger an error
         return
@@ -70,13 +69,13 @@ def load_config(config_file):
             config = yaml.safe_load(stream)
     except yaml.YAMLError as e:
         _logger.error(e)
-        sys.exit(ansiblelint.utils.INVALID_CONFIG_RC)
+        sys.exit(INVALID_CONFIG_RC)
     # TODO(ssbarnea): implement schema validation for config file
     if isinstance(config, list):
         _logger.error(
             "Invalid configuration '%s', expected YAML mapping in the config file.",
             config_path)
-        sys.exit(ansiblelint.utils.INVALID_CONFIG_RC)
+        sys.exit(INVALID_CONFIG_RC)
 
     config_dir = os.path.dirname(config_path)
     expand_to_normalized_paths(config, config_dir)

--- a/lib/ansiblelint/constants.py
+++ b/lib/ansiblelint/constants.py
@@ -3,3 +3,6 @@ import os.path
 
 
 DEFAULT_RULESDIR = os.path.join(os.path.dirname(__file__), 'rules')
+
+INVALID_CONFIG_RC = 2
+ANSIBLE_FAILURE_RC = 3

--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -44,6 +44,7 @@ from ansible.parsing.yaml.loader import AnsibleLoader
 from ansible.parsing.yaml.objects import AnsibleSequence
 from ansible.plugins.loader import module_loader
 from ansible.template import Templar
+from ansiblelint.constants import ANSIBLE_FAILURE_RC
 from ansiblelint.errors import MatchError
 from typing import List
 
@@ -55,8 +56,6 @@ DEFAULT_VAULT_PASSWORD = 'x'
 
 PLAYBOOK_DIR = os.environ.get('ANSIBLE_PLAYBOOK_DIR', None)
 
-INVALID_CONFIG_RC = 2
-ANSIBLE_FAILURE_RC = 3
 
 _logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Moves two more constants to their specific module, causing simplification of  internal module dependency graph.