### PR TITLE
Make testing ansible-2.10 compatible

### DIFF
--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -74,13 +74,13 @@ def test_normalize(reference_form, alternate_forms):
 
 
 def test_normalize_complex_command():
-    task1 = dict(name="hello", action={'module': 'ec2',
-                                       'region': 'us-east1',
-                                       'etc': 'whatever'})
-    task2 = dict(name="hello", ec2={'region': 'us-east1',
-                                    'etc': 'whatever'})
-    task3 = dict(name="hello", ec2="region=us-east1 etc=whatever")
-    task4 = dict(name="hello", action="ec2 region=us-east1 etc=whatever")
+    task1 = dict(name="hello", action={'module': 'pip',
+                                       'name': 'df',
+                                       'editable': 'false'})
+    task2 = dict(name="hello", pip={'name': 'df',
+                                    'editable': 'false'})
+    task3 = dict(name="hello", pip="name=df editable=false")
+    task4 = dict(name="hello", action="pip name=df editable=false")
     assert utils.normalize_task(task1, 'tasks.yml') == utils.normalize_task(task2, 'tasks.yml')
     assert utils.normalize_task(task2, 'tasks.yml') == utils.normalize_task(task3, 'tasks.yml')
     assert utils.normalize_task(task3, 'tasks.yml') == utils.normalize_task(task4, 'tasks.yml')

--- a/test/package-check-success.yml
+++ b/test/package-check-success.yml
@@ -12,9 +12,3 @@
     package:
       name: some-package
       state: present
-
-  - name: Install curl on Windows
-    win_chocolatey:
-      name: curl
-      state: latest
-      version: '7.65.1'

--- a/tox.ini
+++ b/tox.ini
@@ -31,9 +31,6 @@ deps =
 commands =
   # safety measure to assure we do not accidentaly run tests with broken dependencies
   python -m pip check
-  # Collections outside of ACD that config/routing.yml points to in Core:
-  ansibledevel: ansible-galaxy collection install --collections-path "{envtmpdir}" amazon.aws
-  ansibledevel: ansible-galaxy collection install --collections-path "{envtmpdir}" chocolatey.chocolatey
   {envpython} -m pytest \
   --cov "{envsitepackagesdir}/ansiblelint" \
   --junitxml "{toxworkdir}/junit.{envname}.xml" \


### PR DESCRIPTION
- avoids use of ec2 and chocolately modules in tests, as they do not longer
  ship with ansible in 2.10
- avoids installing extra galaxy collections are they take too much time and randomly fail