### PR TITLE
Disable ansible devel testing

### DIFF
--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -29,7 +29,7 @@ jobs:
         # - windows-latest
         # - windows-2016
         ansible-version:
-        - devel
+        # - devel
         - 29
         - 28
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,20 +63,20 @@ jobs:
     env:
       ANSIBLE_VERSION: "28"
 
-  - python: "3.8"
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      ANSIBLE_VERSION: devel
+  # - python: "3.8"
+  #   <<: *if-cron-or-manual-run-or-tagged
+  #   env:
+  #     ANSIBLE_VERSION: devel
 
-  - python: "3.7"
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      ANSIBLE_VERSION: devel
+  # - python: "3.7"
+  #   <<: *if-cron-or-manual-run-or-tagged
+  #   env:
+  #     ANSIBLE_VERSION: devel
 
-  - python: "3.6"
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      ANSIBLE_VERSION: devel
+  # - python: "3.6"
+  #   <<: *if-cron-or-manual-run-or-tagged
+  #   env:
+  #     ANSIBLE_VERSION: devel
 
   - &deploy-job
     <<: *reset-prerequisites

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,7 +37,7 @@ jobs:
     ansible_versions:
     - 29
     - 28
-    - devel
+    # - devel
     python_envs:
       38: [linux, macOs]
       py3: [linux]


### PR DESCRIPTION
As ansible-devel proved to be break our jobs far too often, we will
stop testing it until a working pre-release is published on
pypi.org.

This will allow the project to move-on without being blocked or
slowed down by ansible internal works.

This changes should be reverted once we have an official pre-release.