### PR TITLE
🚑 Install amazon.aws from GitHub

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ commands =
   ansibledevel: sh -c "{envpython} -m pip show ansible | >/dev/null grep '^Version: 2.10.0$'"
   ansibledevel: sh -c "{envpython} -m pip show ansible-base | >/dev/null grep '^Version: 2.10.0.dev0$'"
   # Collections outside of ACD that config/routing.yml points to in Core:
-  ansibledevel: ansible-galaxy collection install --collections-path "{envtmpdir}" amazon.aws
+  ansibledevel: ansible-galaxy collection install --collections-path "{envtmpdir}" git+https://github.com/ansible-collections/amazon.aws
   ansibledevel: ansible-galaxy collection install --collections-path "{envtmpdir}" --pre chocolatey.chocolatey
   {envpython} -m pytest \
   --cov "{envsitepackagesdir}/ansiblelint" \


### PR DESCRIPTION
This works around the broken command:

    $ ansible-galaxy collection install amazon.aws

Resolves #824.