### PR TITLE
Fix ansible-devel install

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,11 +15,10 @@ description =
 deps =
   ansible28: ansible>=2.8,<2.9
   ansible29: ansible>=2.9,<2.10
-  ansibledevel: ansible-base @ git+https://github.com/ansible/ansible.git@devel#egg=ansible-base==2.10.0
-  # ATTENTION: The following tarball is a temporary ACD incarnation
-  # ATTENTION: and may be removed/disappear at any time.
-  # FIXME: Replace this once ACD is out:
-  ansibledevel: ansible @ https://toshio.fedorapeople.org/ansible/acd/ansible/ansible-2.10.0.tar.gz#egg=ansible==2.10.0
+  # TODO(ssbarnea): Replace replace the two tarbals created by @abadger1999 once
+  # we official (pre-)releases are available on pypi.org
+  ansibledevel: ansible-base @ https://toshio.fedorapeople.org/ansible/acd/ansible-base/ansible-base-2.10.0.dev1.tar.gz#egg=ansible-base
+  ansibledevel: ansible @ https://toshio.fedorapeople.org/ansible/acd/ansible/ansible-2.10.0.tar.gz#egg=ansible
   ruamel.yaml==0.16.5  # NOTE: 0.15.34 has issues with py37
   flake8
   pep8-naming
@@ -30,11 +29,11 @@ deps =
   setuptools >= 40.4.3
   wheel
 commands =
-  ansibledevel: sh -c "{envpython} -m pip show ansible | >/dev/null grep '^Version: 2.10.0$'"
-  ansibledevel: sh -c "{envpython} -m pip show ansible-base | >/dev/null grep '^Version: 2.10.0.dev0$'"
+  # safety measure to assure we do not accidentaly run tests with broken dependencies
+  python -m pip check
   # Collections outside of ACD that config/routing.yml points to in Core:
-  ansibledevel: ansible-galaxy collection install --collections-path "{envtmpdir}" git+https://github.com/ansible-collections/amazon.aws
-  ansibledevel: ansible-galaxy collection install --collections-path "{envtmpdir}" --pre chocolatey.chocolatey
+  ansibledevel: ansible-galaxy collection install --collections-path "{envtmpdir}" amazon.aws
+  ansibledevel: ansible-galaxy collection install --collections-path "{envtmpdir}" chocolatey.chocolatey
   {envpython} -m pytest \
   --cov "{envsitepackagesdir}/ansiblelint" \
   --junitxml "{toxworkdir}/junit.{envname}.xml" \
@@ -42,7 +41,6 @@ commands =
 install_command =
   {envpython} -m \
     pip install \
-    --unstable-feature=resolver \
     {opts} \
     {packages}
 passenv =


### PR DESCRIPTION
- fixes recent regressions introduced via https://github.com/ansible/ansible-lint/commit/24166165df60e8756cf61012283f6fcfe4ce67c3 https://github.com/ansible/ansible-lint/commit/fb53235595341a6998bc97f16d8ec20f9f1abb9b https://github.com/ansible/ansible-lint/commit/47050d8ab1e99585ecbfd0d2479428a227082fc0 (broke CI)
- use pre-build packages made by @abadger
- avoid accidental regressions, where conflicting packages where
  installed and used

Relates: #815