### PR TITLE
Moved initialize_logger

### DIFF
--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -24,19 +24,37 @@ import errno
 import logging
 import pathlib
 import sys
-
-import ansiblelint.formatters as formatters
-from ansiblelint import cli
-from ansiblelint.constants import DEFAULT_RULESDIR
-from ansiblelint.rules import RulesCollection
-from ansiblelint.runner import Runner
-from ansiblelint.utils import get_playbooks_and_roles
-from ansiblelint.utils import normpath, initialize_logger
-from ansiblelint.generate_docs import rules_as_rst
 from typing import Any, Set
 
+from ansiblelint import cli
+from ansiblelint.constants import DEFAULT_RULESDIR
+from ansiblelint.generate_docs import rules_as_rst
+from ansiblelint.utils import normpath, get_playbooks_and_roles
+import ansiblelint.formatters as formatters
+from ansiblelint.runner import Runner
+from ansiblelint.rules import RulesCollection
 
 _logger = logging.getLogger(__name__)
+
+
+def initialize_logger(level: int = 0) -> None:
+    """Set up the global logging level based on the verbosity number."""
+    VERBOSITY_MAP = {
+        0: logging.NOTSET,
+        1: logging.INFO,
+        2: logging.DEBUG
+    }
+
+    handler = logging.StreamHandler()
+    formatter = logging.Formatter('%(levelname)-8s %(message)s')
+    handler.setFormatter(formatter)
+    logger = logging.getLogger(__package__)
+    logger.addHandler(handler)
+    # Unknown logging level is treated as DEBUG
+    logging_level = VERBOSITY_MAP.get(level, logging.DEBUG)
+    logger.setLevel(logging_level)
+    # Use module-level _logger instance to validate it
+    _logger.debug("Logging initialized to level %s", logging_level)
 
 
 def main():

--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -58,26 +58,6 @@ PLAYBOOK_DIR = os.environ.get('ANSIBLE_PLAYBOOK_DIR', None)
 _logger = logging.getLogger(__name__)
 
 
-def initialize_logger(level: int = 0) -> None:
-    """Set up the global logging level based on the verbosity number."""
-    VERBOSITY_MAP = {
-        0: logging.NOTSET,
-        1: logging.INFO,
-        2: logging.DEBUG
-    }
-
-    handler = logging.StreamHandler()
-    formatter = logging.Formatter('%(levelname)-8s %(message)s')
-    handler.setFormatter(formatter)
-    logger = logging.getLogger(__package__)
-    logger.addHandler(handler)
-    # Unknown logging level is treated as DEBUG
-    logging_level = VERBOSITY_MAP.get(level, logging.DEBUG)
-    logger.setLevel(logging_level)
-    # Use module-level _logger instance to validate it
-    _logger.debug("Logging initialized to level %s", logging_level)
-
-
 def parse_yaml_from_file(filepath):
     dl = DataLoader()
     if hasattr(dl, 'set_vault_password'):

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -29,6 +29,7 @@ import sys
 import pytest
 
 import ansiblelint.utils as utils
+from ansiblelint.__main__ import initialize_logger
 from ansiblelint import cli
 
 
@@ -165,7 +166,7 @@ def test_get_yaml_files_git_verbose(
     caplog
 ):
     options = cli.get_config(['-v'])
-    utils.initialize_logger(options.verbosity)
+    initialize_logger(options.verbosity)
     monkeypatch.setenv(reset_env_var, '')
     utils.get_yaml_files(options)
 
@@ -214,10 +215,10 @@ def test_get_yaml_files_silent(is_in_git, monkeypatch, capsys):
 def test_logger_debug(caplog):
     """Test that the double verbosity arg causes logger to be DEBUG."""
     options = cli.get_config(['-vv'])
-    utils.initialize_logger(options.verbosity)
+    initialize_logger(options.verbosity)
 
     expected_info = (
-        "ansiblelint.utils",
+        "ansiblelint.__main__",
         logging.DEBUG,
         'Logging initialized to level 10',
     )


### PR DESCRIPTION
Moves implementation of initialize_logger inside __main__ in order to reduce internal module imports.