### PR TITLE
Enable testing against Ubuntu 20.04 in GHA

### DIFF
--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -23,6 +23,7 @@ jobs:
         - 3.7
         - 3.6
         os:
+        - ubuntu-20.04
         - ubuntu-latest
         - ubuntu-16.04
         - macOS-latest


### PR DESCRIPTION
(I noticed only today that it appeared in GHA docs and is not the `latest`. AFAIK none of the other CIs run it atm)