### PR TITLE
Add support for ansible 2.10

### DIFF
--- a/lib/ansiblelint/errors.py
+++ b/lib/ansiblelint/errors.py
@@ -19,19 +19,35 @@ class Match(object):
                                 self.filename, self.linenumber, self.line)
 
 
+class AnsibleLintInternalRule():
+    """Internal error likely caused by parsing failures."""
+
+    id = "999"
+    shortdesc = "Parsing Error"
+    description = "Ansible failed to file."
+
+
 class MatchError(ValueError):
     """Exception that would end-up as linter rule match."""
 
-    def __init__(self, message, rule=None):
+    def __init__(self, message, rule=AnsibleLintInternalRule, filename="", linenumber=0, line=None):
         """Initialize a MatchError instance."""
         super().__init__(message)
 
         self.message = message
-        self.linenumber = 0
-        self.line = None
-        self.filename = None
+        self.linenumber = linenumber
+        self.line = line
+        self.filename = filename
         self.rule = rule
 
     def get_match(self) -> Match:
         """Return a Match instance."""
         return Match(self.linenumber, self.line, self.filename, self.rule, self.message)
+
+    def __eq__(self, other):
+        """Identify duplicate matches."""
+        return self.__hash__() == other.__hash__()
+
+    def __hash__(self):
+        """Perform hash of matches."""
+        return hash((self.message, self.rule, self.filename, self.linenumber))

--- a/tox.ini
+++ b/tox.ini
@@ -15,10 +15,7 @@ description =
 deps =
   ansible28: ansible>=2.8,<2.9
   ansible29: ansible>=2.9,<2.10
-  # TODO(ssbarnea): Replace replace the two tarbals created by @abadger1999 once
-  # we official (pre-)releases are available on pypi.org
-  ansibledevel: ansible-base @ https://toshio.fedorapeople.org/ansible/acd/ansible-base/ansible-base-2.10.0.dev1.tar.gz#egg=ansible-base
-  ansibledevel: ansible @ https://toshio.fedorapeople.org/ansible/acd/ansible/ansible-2.10.0.tar.gz#egg=ansible
+  ansibledevel: ansible>=2.10.0a1,<2.11
   ruamel.yaml==0.16.5  # NOTE: 0.15.34 has issues with py37
   flake8
   pep8-naming


### PR DESCRIPTION
- switch to use official pre-release from pypi
- fix bug where newer ModuleArgsParser no longer accepts our custom
  attributes when loading tasks
- address parsing failure with now removed "always_run"
- avoid duplicate match errors at runtime

Fixes: #843