### PR TITLE
Remove emoji from job names

### DIFF
--- a/.github/workflows/tox-linters.yml
+++ b/.github/workflows/tox-linters.yml
@@ -1,4 +1,4 @@
-name: 🚨
+name: linters
 
 on:
   push:

--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -1,4 +1,4 @@
-name: 👷
+name: unit
 
 on:
   push:


### PR DESCRIPTION
Remove emoji from code as it can be distracting and make communication
or debugging harder (like searching code).
