### PR TITLE
Skip running always_run rule with ansible 2.10

### DIFF
--- a/test/TestAlwaysRunRule.py
+++ b/test/TestAlwaysRunRule.py
@@ -2,8 +2,15 @@ import unittest
 from ansiblelint.rules import RulesCollection
 from ansiblelint.runner import Runner
 from ansiblelint.rules.AlwaysRunRule import AlwaysRunRule
+from test import ANSIBLE_MAJOR_VERSION
+import pytest
 
 
+@pytest.mark.skipif(
+    ANSIBLE_MAJOR_VERSION > (2, 9),
+    reason='Ansible 2.10 removed always_run attribute.',
+    raises=SystemExit, strict=True,
+)
 class TestAlwaysRun(unittest.TestCase):
     collection = RulesCollection()
 

--- a/test/TestDeprecatedModule.py
+++ b/test/TestDeprecatedModule.py
@@ -1,15 +1,10 @@
 import unittest
 
-from ansible import __version__ as ansible_version_str
 import pytest
 
 from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.DeprecatedModuleRule import DeprecatedModuleRule
-from test import RunFromText
-
-
-ANSIBLE_MAJOR_VERSION = tuple(map(int, ansible_version_str.split('.')[:2]))
-
+from test import RunFromText, ANSIBLE_MAJOR_VERSION
 
 MODULE_DEPRECATED = '''
 - name: task example

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -4,7 +4,12 @@ import tempfile
 import shutil
 import os
 
+from ansible import __version__ as ansible_version_str
+
 from ansiblelint.runner import Runner
+
+
+ANSIBLE_MAJOR_VERSION = tuple(map(int, ansible_version_str.split('.')[:2]))
 
 
 class RunFromText(object):


### PR DESCRIPTION
On Ansible 2.10, presence of `always_run` generates a parsing error so we need to skip running that
particular test.