### PR TITLE
Improve unjinja function

### DIFF
--- a/lib/ansiblelint/rules/__init__.py
+++ b/lib/ansiblelint/rules/__init__.py
@@ -36,7 +36,10 @@ class AnsibleLintRule(object):
 
     @staticmethod
     def unjinja(text):
-        return re.sub(r"{{[^}]*}}", "JINJA_VAR", text)
+        text = re.sub(r"{{.+?}}", "JINJA_EXPRESSION", text)
+        text = re.sub(r"{%.+?%}", "JINJA_STATEMENT", text)
+        text = re.sub(r"{#.+?#}", "JINJA_COMMENT", text)
+        return text
 
     def matchlines(self, file, text) -> List[Match]:
         matches: List[Match] = []

--- a/test/TestAnsibleLintRule.py
+++ b/test/TestAnsibleLintRule.py
@@ -1,0 +1,7 @@
+from ansiblelint.rules import AnsibleLintRule
+
+
+def test_unjinja():
+    input = "{{ a }} {% b %} {# try to confuse parsing inside a comment { {{}} } #}"
+    output = "JINJA_EXPRESSION JINJA_STATEMENT JINJA_COMMENT"
+    assert AnsibleLintRule.unjinja(input) == output


### PR DESCRIPTION
Corrects unjinja implementation in order to assure it also removes
statements and comments, not only expressions.

Fixes: #544