### PR TITLE
Refactor _taskshandlers_children in ansiblelint.utils

### DIFF
--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -248,8 +248,7 @@ def _taskshandlers_children(basedir, k, v, parent_type):
 
 
 def _maybe_th_children_for_tasks_or_playbooks(th, basedir, k, parent_type):
-    """
-    Try to get and return children of taskhandler of type, include,
+    """Try to get and return children of taskhandler of type, include,
     include_tasks, import_playbook and import_tasks.
     """
     for tht in ('include', 'include_tasks', 'import_playbook', 'import_tasks'):

--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -234,14 +234,7 @@ def _taskshandlers_children(basedir, k, v, parent_type):
 
         elif 'include_role' in th or 'import_role' in th:
             th = normalize_task_v2(th)
-            module = th['action']['__ansible_module__']
-            if "name" not in th['action']:
-                raise MatchError(
-                    "Failed to find required 'name' key in %s" % module)
-            if not isinstance(th['action']["name"], str):
-                raise RuntimeError(
-                    "Value assigned to 'name' key on '%s' is not a string." %
-                    module)
+            _validate_th_action_for_role(th['action'])
             results.extend(_roles_children(basedir, k, [th['action'].get("name")],
                                            parent_type,
                                            main=th['action'].get('tasks_from', 'main')))
@@ -267,6 +260,19 @@ def _maybe_th_children_for_tasks_or_playbooks(th, basedir, k, parent_type):
             }
 
     return None
+
+
+def _validate_th_action_for_role(th_action):
+    name = th_action.get("name", None)
+    module = th_action['__ansible_module__']
+
+    if name is None:
+        raise MatchError("Failed to find required 'name' key in %s" % module)
+
+    if not isinstance(name, str):
+        raise RuntimeError(
+            "Value assigned to 'name' key on '%s' is not a string." % module
+        )
 
 
 def _roles_children(basedir, k, v, parent_type, main='main'):

--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -248,9 +248,7 @@ def _taskshandlers_children(basedir, k, v, parent_type):
 
 
 def _maybe_th_children_for_tasks_or_playbooks(th, basedir, k, parent_type):
-    """Try to get and return children of taskhandler of type, include,
-    include_tasks, import_playbook and import_tasks.
-    """
+    """Try to get children of taskhandler for include/import tasks/playbooks."""
     for tht in ('include', 'include_tasks', 'import_playbook', 'import_tasks'):
         if tht in th:
             return {


### PR DESCRIPTION
A pair of changes to fix #744 partially to refactor and simplify _taskshandlers_children:

- added _maybe_th_children_for_tasks_or_playbooks
- added _validate_th_action_for_role