### PR TITLE
Assure we run sphinx with warnings as errors

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -495,10 +495,8 @@ If the rule is line-based, ``# noqa [rule_id]`` must be at the end of the partic
 
 It's also a good practice to comment the reasons why a task is being skipped.
 
-If you want skip running a rule entirely, you can use either:
-
-* `command-line skip_list`_ via ``-x``
-* `config file skip_list`_
+If you want skip running a rule entirely, you can use either use ``-x`` command
+line argument, or add it to ``skip_list`` inside the configuration file.
 
 A less-preferred method of skipping is to skip all task-based rules for a task (this does not skip line-based rules). There are two mechanisms for this: the ``skip_ansible_lint`` tag works with all tasks, and the ``warn`` parameter works with the *command* or *shell* modules only. Examples:
 
@@ -597,5 +595,3 @@ ansible-lint was created by `Will Thames`_ and is now maintained as part of the 
 .. _Will Thames: https://github.com/willthames
 .. _Ansible: https://ansible.com
 .. _Red Hat: https://redhat.com
-.. _command-line skip_list: https://docs.ansible.com/ansible-lint/usage/usage.html#command-line-options
-.. _config file skip_list: https://docs.ansible.com/ansible-lint/configuring/configuring.html#configuration-file

--- a/docs/docsite/Makefile
+++ b/docs/docsite/Makefile
@@ -71,5 +71,5 @@ epub:
 	(CPUS=$(CPUS) $(MAKE) -f Makefile.sphinx epub)
 
 htmlsingle: assertrst
-	sphinx-build -j $(CPUS) -b html -d $(BUILDDIR)/doctrees ./rst $(BUILDDIR)/html rst/$(rst)
+	sphinx-build -W -j $(CPUS) -b html -d $(BUILDDIR)/doctrees ./rst $(BUILDDIR)/html rst/$(rst)
 	@echo "Output is in $(BUILDDIR)/html/$(rst:.rst=.html)"

--- a/docs/docsite/Makefile.sphinx
+++ b/docs/docsite/Makefile.sphinx
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -j $(CPUS) -n -w rst_warnings
+SPHINXOPTS    = -W -j $(CPUS) -n -w rst_warnings
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = sdfsdf
 SOURCEDIR     = rst


### PR DESCRIPTION
Enforce warning as errors in order to prevent introducing new bugs.

Fixes related issues:
- avoid external links for own doc (we will move it, does not play well with PRs)
- sphinx seems not to like these two URLs and complains about missing refs on them