### PR TITLE
Expose package version

### DIFF
--- a/lib/ansiblelint/__init__.py
+++ b/lib/ansiblelint/__init__.py
@@ -19,5 +19,11 @@
 # THE SOFTWARE.
 """Main ansible-lint package."""
 
-# deprecated backwards compability:
-from ansiblelint.rules import AnsibleLintRule  # noqa: F401 api backwards compability
+from ansiblelint.rules import AnsibleLintRule
+from ansiblelint.version import __version__
+
+
+__all__ = (
+    "__version__",
+    "AnsibleLintRule"  # deprecated, import it directly from rules
+)


### PR DESCRIPTION
Export `ansiblelint.__version__` which is a very common way to expose version of a python module.