### PR TITLE
Revert to using `{temp_dir}` substitution in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -112,8 +112,6 @@ commands =
   sh -c "{envpython} -m ansiblelint -L -f rst > rst/rules/default_rules.rst"
 
   # Build the html docs with Sphinx:
-  # FIXME: Use `-d "{temp_dir}/.doctrees"` once
-  # FIXME: https://github.com/tox-dev/tox/pull/1609 is released.
   {envpython} -m sphinx \
     -j auto \
     -b html \
@@ -121,7 +119,7 @@ commands =
     -a \
     -n \
     -W \
-    -d "{toxworkdir}/.tmp/.doctrees" \
+    -d "{temp_dir}/.doctrees" \
     rst/ \
     "{envdir}/html"
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-minversion = 3.5.3
+minversion = 3.16.1
 envlist = lint,py{38,37,36}-ansible{29,28,devel}
 isolated_build = true
 requires =


### PR DESCRIPTION
This change ensures that we don't rely on tox's internal implementation details and just use
a proper substitution for the temporary dir.