### PR TITLE
Change documentation website to RTD

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@
    :alt: PyPI version
 
 .. image:: https://img.shields.io/badge/Ansible--lint-rules%20table-blue.svg
-   :target: https://docs.ansible.com/ansible-lint/rules/default_rules.html
+   :target: https://ansible-lint.readthedocs.io/en/latest/default_rules.html
    :alt: Ansible-lint rules explanation
 
 .. image:: https://img.shields.io/badge/Code%20of%20Conduct-black.svg
@@ -34,7 +34,7 @@ Ansible-lint
 potentially be improved. As a community backed project ansible-lint supports
 only the last two major versions of Ansible.
 
-`Visit the Ansible Lint docs site <https://docs.ansible.com/ansible-lint/>`_
+`Visit the Ansible Lint docs site <https://ansible-lint.readthedocs.io/en/latest/>`_
 
 Installing
 ==========

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -185,7 +185,7 @@ html_copy_source = False
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.  The value of this option must be the
 # base URL from which the finished HTML is served.
-html_use_opensearch = 'https://docs.ansible.com/ansible/latest/'
+html_use_opensearch = 'https://ansible-lint.readthedocs.io/en/latest/'
 
 # If nonempty, this is the file name suffix for HTML files (e.g. ".xhtml").
 # html_file_suffix = ''

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ project_urls =
   Bug Tracker = https://github.com/ansible/ansible-lint/issues
   CI: GitHub = https://github.com/ansible/ansible-lint/actions?query=workflow:gh+branch:master+event:push
   Code of Conduct = https://docs.ansible.com/ansible/latest/community/code_of_conduct.html
-  Documentation = https://docs.ansible.com/ansible-lint/
+  Documentation = https://ansible-lint.readthedocs.io/en/latest/
   Mailing lists = https://docs.ansible.com/ansible/latest/community/communication.html#mailing-list-information
   Source Code = https://github.com/ansible/ansible-lint
 description = Checks playbooks for practices and behaviour that could potentially be improved


### PR DESCRIPTION
Being unable to publish docs to docs.ansible.com, we are forced to
move back official docs back to: https://ansible-lint.readthedocs.io/en/latest/