### PR TITLE
Fix broken always_run rule on Ansible 2.10

### DIFF
--- a/lib/ansiblelint/rules/__init__.py
+++ b/lib/ansiblelint/rules/__init__.py
@@ -69,7 +69,9 @@ class AnsibleLintRule(object):
             matches.append(m)
         return matches
 
-    def matchtasks(self, file: str, text: str) -> List[MatchError]:
+    # TODO(ssbarnea): Reduce mccabe complexity
+    # https://github.com/ansible/ansible-lint/issues/744
+    def matchtasks(self, file: str, text: str) -> List[MatchError]:  # noqa: C901
         matches: List[MatchError] = []
         if not self.matchtask:
             return matches
@@ -83,7 +85,12 @@ class AnsibleLintRule(object):
 
         yaml = append_skipped_rules(yaml, text, file['type'])
 
-        for task in ansiblelint.utils.get_normalized_tasks(yaml, file):
+        try:
+            tasks = ansiblelint.utils.get_normalized_tasks(yaml, file)
+        except MatchError as e:
+            return [e]
+
+        for task in tasks:
             if self.id in task.get('skipped_rules', ()):
                 continue
 

--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -363,7 +363,11 @@ def _kv_to_dict(v):
 
 
 def _sanitize_task(task):
-    """Remove internally used data from task arguments."""
+    """Return a stripped-off task structure compatible with new Ansible.
+
+    This helper takes a copy of the incoming task and drops
+    any internally used keys from it.
+    """
     result = task.copy()
     # task is an AnsibleMapping which inherits from OrderedDict, so we need
     # to use `del` to remove unwanted keys.

--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -362,21 +362,41 @@ def _kv_to_dict(v):
     return dict(__ansible_module__=command, __ansible_arguments__=args, **kwargs)
 
 
+def _sanitize_task(task):
+    """Remove internally used data from task arguments."""
+    result = task.copy()
+    # task is an AnsibleMapping which inherits from OrderedDict, so we need
+    # to use `del` to remove unwanted keys.
+    for k in ['skipped_rules', FILENAME_KEY, LINE_NUMBER_KEY]:
+        if k in result:
+            del result[k]
+    return result
+
+
 def normalize_task_v2(task):
     """Ensure tasks have an action key and strings are converted to python objects."""
     result = dict()
-    mod_arg_parser = ModuleArgsParser(task)
+    if 'always_run' in task:
+        # FIXME(ssbarnea): Delayed import to avoid circular import
+        # See https://github.com/ansible/ansible-lint/issues/880
+        from ansiblelint.rules.AlwaysRunRule import AlwaysRunRule  # noqa: # pylint:disable=cyclic-import,import-outside-toplevel
+
+        raise MatchError(
+            rule=AlwaysRunRule,
+            filename=task[FILENAME_KEY],
+            linenumber=task[LINE_NUMBER_KEY])
+
+    sanitized_task = _sanitize_task(task)
+    mod_arg_parser = ModuleArgsParser(sanitized_task)
     try:
         action, arguments, result['delegate_to'] = mod_arg_parser.parse()
     except AnsibleParserError as e:
         try:
             task_info = "%s:%s" % (task[FILENAME_KEY], task[LINE_NUMBER_KEY])
-            del task[FILENAME_KEY]
-            del task[LINE_NUMBER_KEY]
         except KeyError:
             task_info = "Unknown"
         pp = pprint.PrettyPrinter(indent=2)
-        task_pprint = pp.pformat(task)
+        task_pprint = pp.pformat(sanitized_task)
 
         _logger.critical("Couldn't parse task at %s (%s)\n%s", task_info, e.message, task_pprint)
         raise SystemExit(ANSIBLE_FAILURE_RC)

--- a/test/TestAlwaysRunRule.py
+++ b/test/TestAlwaysRunRule.py
@@ -1,19 +1,10 @@
 import unittest
 
-import pytest
-
 from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.AlwaysRunRule import AlwaysRunRule
 from ansiblelint.runner import Runner
 
-from . import ANSIBLE_MAJOR_VERSION
 
-
-@pytest.mark.skipif(
-    ANSIBLE_MAJOR_VERSION > (2, 9),
-    reason='Ansible 2.10 removed always_run attribute.',
-    raises=SystemExit, strict=True,
-)
 class TestAlwaysRun(unittest.TestCase):
     collection = RulesCollection()
 


### PR DESCRIPTION
- address parsing failure with now removed "always_run"
- remove skipif for 2.10 as it works correctly now
