### PR TITLE
Avoid sorting failure with matches without an id

### DIFF
--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -115,7 +115,11 @@ def main() -> int:
                         options.verbosity, checked_files)
         matches.extend(runner.run())
 
-    matches.sort(key=lambda x: (normpath(x.filename), x.linenumber, x.rule.id))
+    matches.sort(
+        key=lambda x: (
+            normpath(x.filename),
+            x.linenumber,
+            getattr(x.rule, 'id', 0)))
 
     for match in matches:
         print(formatter.format(match, options.colored))

--- a/lib/ansiblelint/formatters/__init__.py
+++ b/lib/ansiblelint/formatters/__init__.py
@@ -42,14 +42,15 @@ class Formatter(BaseFormatter):
 
     def format(self, match, colored=False):
         formatstr = u"{0} {1}\n{2}:{3}\n{4}\n"
+        _id = getattr(match.rule, 'id', '000')
         if colored:
-            return formatstr.format(colorize(u"[{0}]".format(match.rule.id), Color.error_code),
+            return formatstr.format(colorize(u"[{0}]".format(_id), Color.error_code),
                                     colorize(match.message, Color.error_title),
                                     colorize(self._format_path(match.filename), Color.filename),
                                     colorize(str(match.linenumber), Color.linenumber),
                                     colorize(u"{0}".format(match.line), Color.line))
         else:
-            return formatstr.format(match.rule.id,
+            return formatstr.format(_id,
                                     match.message,
                                     match.filename,
                                     match.linenumber,


### PR DESCRIPTION
If a match did contain rules with None class, sorting them would have failed. This prevents such an error.