### PR TITLE
Move normpath out of utils

### DIFF
--- a/lib/ansiblelint/file_utils.py
+++ b/lib/ansiblelint/file_utils.py
@@ -1,0 +1,13 @@
+"""Utility functions related to file operations."""
+import os
+
+
+def normpath(path) -> str:
+    """
+    Normalize a path in order to provide a more consistent output.
+
+    Currently it generates a relative path but in the future we may want to
+    make this user configurable.
+    """
+    # convertion to string in order to allow receiving non string objects
+    return os.path.relpath(str(path))

--- a/lib/ansiblelint/runner.py
+++ b/lib/ansiblelint/runner.py
@@ -4,6 +4,7 @@ import os
 from typing import List, Set
 
 import ansiblelint.utils
+import ansiblelint.file_utils
 import ansiblelint.skip_utils
 from .errors import MatchError
 from .rules.LoadingFailureRule import LoadingFailureRule
@@ -59,7 +60,7 @@ class Runner(object):
         for playbook in self.playbooks:
             if self.is_excluded(playbook[0]) or playbook[1] == 'role':
                 continue
-            files.append({'path': ansiblelint.utils.normpath(playbook[0]),
+            files.append({'path': ansiblelint.file_utils.normpath(playbook[0]),
                           'type': playbook[1],
                           # add an absolute path here, so rules are able to validate if
                           # referenced files exist
@@ -88,7 +89,7 @@ class Runner(object):
         for file in files:
             _logger.debug(
                 "Examining %s of type %s",
-                ansiblelint.utils.normpath(file['path']),
+                ansiblelint.file_utils.normpath(file['path']),
                 file['type'])
             matches.extend(self.rules.run(file, tags=set(self.tags),
                            skip_list=self.skip_list))

--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -35,6 +35,7 @@ from yaml.representer import RepresenterError
 from ansible import constants
 from ansible.errors import AnsibleError
 from ansible.errors import AnsibleParserError
+from ansiblelint.file_utils import normpath
 from ansible.parsing.dataloader import DataLoader
 from ansible.parsing.mod_args import ModuleArgsParser
 from ansible.parsing.splitter import split_args
@@ -577,17 +578,6 @@ def get_first_cmd_arg(task):
     except IndexError:
         return None
     return first_cmd_arg
-
-
-def normpath(path) -> str:
-    """
-    Normalize a path in order to provide a more consistent output.
-
-    Currently it generates a relative path but in the future we may want to
-    make this user configurable.
-    """
-    # convertion to string in order to allow receiving non string objects
-    return os.path.relpath(str(path))
 
 
 def is_playbook(filename: str) -> bool:

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -29,6 +29,7 @@ import sys
 import pytest
 
 import ansiblelint.utils as utils
+from ansiblelint.file_utils import normpath
 from ansiblelint.__main__ import initialize_logger
 from ansiblelint import cli
 
@@ -132,7 +133,7 @@ def test_task_to_str_unicode():
     pytest.param('a/b/../', id='str'),
 ))
 def test_normpath_with_path_object(path):
-    assert utils.normpath(path) == "a"
+    assert normpath(path) == "a"
 
 
 def test_expand_path_vars(monkeypatch):


### PR DESCRIPTION
Moves normpath to file_utils, avoding the need to import whole utils which brings a chain of own imports.

Generic utils is an kitchensink anti-pattern, good explnation can be found at https://breadcrumbscollector.tech/stop-naming-your-python-modules-utils/