### PR TITLE
Combine MatchError into Match

### DIFF
--- a/lib/ansiblelint/errors.py
+++ b/lib/ansiblelint/errors.py
@@ -1,37 +1,29 @@
 """Exceptions and error representations."""
 
 
-class Match(object):
-    """Rule violation detected during linting."""
+class Match(ValueError):
+    """Rule violation detected during linting.
 
-    def __init__(self, linenumber, line, filename, rule, message=None) -> None:
+    It can be raised as Exception but also just added to the list of found
+    rules violations.
+    """
+
+    def __init__(self, message=None, linenumber=0, line=None, filename=None, rule=None) -> None:
         """Initialize a Match instance."""
+        super().__init__(message)
+
+        self.message = message or getattr(rule, 'shortdesc', "")
         self.linenumber = linenumber
         self.line = line
         self.filename = filename
         self.rule = rule
-        self.message = message or rule.shortdesc
 
     def __repr__(self):
         """Return a Match instance representation."""
         formatstr = u"[{0}] ({1}) matched {2}:{3} {4}"
-        return formatstr.format(self.rule.id, self.message,
+        # note that `rule.id` can be int, str or even missing, as users
+        # can defined their own custom rules.
+        _id = getattr(self.rule, "id", "000")
+
+        return formatstr.format(_id, self.message,
                                 self.filename, self.linenumber, self.line)
-
-
-class MatchError(ValueError):
-    """Exception that would end-up as linter rule match."""
-
-    def __init__(self, message, rule=None):
-        """Initialize a MatchError instance."""
-        super().__init__(message)
-
-        self.message = message
-        self.linenumber = 0
-        self.line = None
-        self.filename = None
-        self.rule = rule
-
-    def get_match(self) -> Match:
-        """Return a Match instance."""
-        return Match(self.linenumber, self.line, self.filename, self.rule, self.message)

--- a/lib/ansiblelint/errors.py
+++ b/lib/ansiblelint/errors.py
@@ -1,7 +1,7 @@
 """Exceptions and error representations."""
 
 
-class Match(ValueError):
+class MatchError(ValueError):
     """Rule violation detected during linting.
 
     It can be raised as Exception but also just added to the list of found
@@ -9,7 +9,7 @@ class Match(ValueError):
     """
 
     def __init__(self, message=None, linenumber=0, line=None, filename=None, rule=None) -> None:
-        """Initialize a Match instance."""
+        """Initialize a MatchError instance."""
         super().__init__(message)
 
         self.message = message or getattr(rule, 'shortdesc', "")
@@ -19,7 +19,7 @@ class Match(ValueError):
         self.rule = rule
 
     def __repr__(self):
-        """Return a Match instance representation."""
+        """Return a MatchError instance representation."""
         formatstr = u"[{0}] ({1}) matched {2}:{3} {4}"
         # note that `rule.id` can be int, str or even missing, as users
         # can defined their own custom rules.

--- a/lib/ansiblelint/rules/__init__.py
+++ b/lib/ansiblelint/rules/__init__.py
@@ -61,8 +61,13 @@ class AnsibleLintRule(object):
             message = None
             if isinstance(result, str):
                 message = result
-            matches.append(Match(prev_line_no + 1, line,
-                           file['path'], self, message))
+            m = Match(
+                message=message,
+                linenumber=prev_line_no + 1,
+                line=line,
+                filename=file['path'],
+                rule=self)
+            matches.append(m)
         return matches
 
     def matchtasks(self, file: str, text: str) -> List[Match]:
@@ -93,8 +98,13 @@ class AnsibleLintRule(object):
             if isinstance(result, str):
                 message = result
             task_msg = "Task/Handler: " + ansiblelint.utils.task_to_str(task)
-            matches.append(Match(task[ansiblelint.utils.LINE_NUMBER_KEY], task_msg,
-                           file['path'], self, message))
+            m = Match(
+                message=message,
+                linenumber=task[ansiblelint.utils.LINE_NUMBER_KEY],
+                line=task_msg,
+                filename=file['path'],
+                rule=self)
+            matches.append(m)
         return matches
 
     @staticmethod
@@ -135,8 +145,13 @@ class AnsibleLintRule(object):
 
             for section, message, *optional_linenumber in result:
                 linenumber = self._matchplay_linenumber(play, optional_linenumber)
-                matches.append(Match(linenumber,
-                                     section, file['path'], self, message))
+                m = Match(
+                    message=message,
+                    linenumber=linenumber,
+                    line=section,
+                    filename=file['path'],
+                    rule=self)
+                matches.append(m)
         return matches
 
 

--- a/lib/ansiblelint/rules/__init__.py
+++ b/lib/ansiblelint/rules/__init__.py
@@ -10,7 +10,7 @@ from typing import List
 
 from ansiblelint.skip_utils import get_rule_skips_from_line
 from ansiblelint.skip_utils import append_skipped_rules
-from ansiblelint.errors import Match
+from ansiblelint.errors import MatchError
 import ansiblelint.utils
 
 
@@ -41,8 +41,8 @@ class AnsibleLintRule(object):
         text = re.sub(r"{#.+?#}", "JINJA_COMMENT", text)
         return text
 
-    def matchlines(self, file, text) -> List[Match]:
-        matches: List[Match] = []
+    def matchlines(self, file, text) -> List[MatchError]:
+        matches: List[MatchError] = []
         if not self.match:
             return matches
         # arrays are 0-based, line numbers are 1-based
@@ -61,7 +61,7 @@ class AnsibleLintRule(object):
             message = None
             if isinstance(result, str):
                 message = result
-            m = Match(
+            m = MatchError(
                 message=message,
                 linenumber=prev_line_no + 1,
                 line=line,
@@ -70,8 +70,8 @@ class AnsibleLintRule(object):
             matches.append(m)
         return matches
 
-    def matchtasks(self, file: str, text: str) -> List[Match]:
-        matches: List[Match] = []
+    def matchtasks(self, file: str, text: str) -> List[MatchError]:
+        matches: List[MatchError] = []
         if not self.matchtask:
             return matches
 
@@ -98,7 +98,7 @@ class AnsibleLintRule(object):
             if isinstance(result, str):
                 message = result
             task_msg = "Task/Handler: " + ansiblelint.utils.task_to_str(task)
-            m = Match(
+            m = MatchError(
                 message=message,
                 linenumber=task[ansiblelint.utils.LINE_NUMBER_KEY],
                 line=task_msg,
@@ -115,8 +115,8 @@ class AnsibleLintRule(object):
             linenumber = play[ansiblelint.utils.LINE_NUMBER_KEY]
         return linenumber
 
-    def matchyaml(self, file: str, text: str) -> List[Match]:
-        matches: List[Match] = []
+    def matchyaml(self, file: str, text: str) -> List[MatchError]:
+        matches: List[MatchError] = []
         if not self.matchplay:
             return matches
 
@@ -145,7 +145,7 @@ class AnsibleLintRule(object):
 
             for section, message, *optional_linenumber in result:
                 linenumber = self._matchplay_linenumber(play, optional_linenumber)
-                m = Match(
+                m = MatchError(
                     message=message,
                     linenumber=linenumber,
                     line=section,

--- a/lib/ansiblelint/runner.py
+++ b/lib/ansiblelint/runner.py
@@ -6,7 +6,7 @@ from typing import List, Set
 import ansiblelint.utils
 import ansiblelint.file_utils
 import ansiblelint.skip_utils
-from .errors import Match
+from .errors import MatchError
 from .rules.LoadingFailureRule import LoadingFailureRule
 
 
@@ -76,7 +76,7 @@ class Runner(object):
                             continue
                         self.playbooks.add((child['path'], child['type']))
                         files.append(child)
-                except Match as e:
+                except MatchError as e:
                     e.rule = LoadingFailureRule
                     matches.append(e)
                 visited.add(arg)

--- a/lib/ansiblelint/runner.py
+++ b/lib/ansiblelint/runner.py
@@ -6,7 +6,7 @@ from typing import List, Set
 import ansiblelint.utils
 import ansiblelint.file_utils
 import ansiblelint.skip_utils
-from .errors import MatchError
+from .errors import Match
 from .rules.LoadingFailureRule import LoadingFailureRule
 
 
@@ -76,9 +76,9 @@ class Runner(object):
                             continue
                         self.playbooks.add((child['path'], child['type']))
                         files.append(child)
-                except MatchError as e:
+                except Match as e:
                     e.rule = LoadingFailureRule
-                    matches.append(e.get_match())
+                    matches.append(e)
                 visited.add(arg)
 
         # remove duplicates from files list

--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -45,7 +45,7 @@ from ansible.parsing.yaml.objects import AnsibleSequence
 from ansible.plugins.loader import module_loader
 from ansible.template import Templar
 from ansiblelint.constants import ANSIBLE_FAILURE_RC
-from ansiblelint.errors import Match
+from ansiblelint.errors import MatchError
 from typing import Callable, ItemsView, List, Tuple
 
 
@@ -139,7 +139,7 @@ def _rebind_match_filename(filename: str, func) -> Callable:
     def func_wrapper(*args, **kwargs):
         try:
             return func(*args, **kwargs)
-        except Match as e:
+        except MatchError as e:
             e.filename = filename
             raise e
     return func_wrapper
@@ -241,7 +241,7 @@ def _taskshandlers_children(basedir, k, v, parent_type):
             th = normalize_task_v2(th)
             module = th['action']['__ansible_module__']
             if "name" not in th['action']:
-                raise Match(
+                raise MatchError(
                     "Failed to find required 'name' key in %s" % module)
             if not isinstance(th['action']["name"], str):
                 raise RuntimeError(

--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -45,7 +45,7 @@ from ansible.parsing.yaml.objects import AnsibleSequence
 from ansible.plugins.loader import module_loader
 from ansible.template import Templar
 from ansiblelint.constants import ANSIBLE_FAILURE_RC
-from ansiblelint.errors import MatchError
+from ansiblelint.errors import Match
 from typing import Callable, ItemsView, List, Tuple
 
 
@@ -139,7 +139,7 @@ def _rebind_match_filename(filename: str, func) -> Callable:
     def func_wrapper(*args, **kwargs):
         try:
             return func(*args, **kwargs)
-        except MatchError as e:
+        except Match as e:
             e.filename = filename
             raise e
     return func_wrapper
@@ -241,7 +241,7 @@ def _taskshandlers_children(basedir, k, v, parent_type):
             th = normalize_task_v2(th)
             module = th['action']['__ansible_module__']
             if "name" not in th['action']:
-                raise MatchError(
+                raise Match(
                     "Failed to find required 'name' key in %s" % module)
             if not isinstance(th['action']["name"], str):
                 raise RuntimeError(

--- a/test/TestFormatter.py
+++ b/test/TestFormatter.py
@@ -20,7 +20,7 @@
 import pathlib
 import unittest
 
-from ansiblelint.errors import Match
+from ansiblelint.errors import MatchError
 from ansiblelint.formatters import Formatter
 from ansiblelint.rules import AnsibleLintRule
 
@@ -33,13 +33,13 @@ class TestFormatter(unittest.TestCase):
         self.formatter = Formatter(pathlib.Path.cwd(), True)
 
     def test_format_coloured_string(self):
-        match = Match("message", 1, "hello", "filename.yml", self.rule)
+        match = MatchError("message", 1, "hello", "filename.yml", self.rule)
         self.formatter.format(match, True)
 
     def test_unicode_format_string(self):
-        match = Match(u'\U0001f427', 1, "hello", "filename.yml", self.rule)
+        match = MatchError(u'\U0001f427', 1, "hello", "filename.yml", self.rule)
         self.formatter.format(match, False)
 
     def test_dict_format_line(self):
-        match = Match("xyz", 1, {'hello': 'world'}, "filename.yml", self.rule,)
+        match = MatchError("xyz", 1, {'hello': 'world'}, "filename.yml", self.rule,)
         self.formatter.format(match, True)

--- a/test/TestFormatter.py
+++ b/test/TestFormatter.py
@@ -33,13 +33,13 @@ class TestFormatter(unittest.TestCase):
         self.formatter = Formatter(pathlib.Path.cwd(), True)
 
     def test_format_coloured_string(self):
-        match = Match(1, "hello", "filename.yml", self.rule, "message")
+        match = Match("message", 1, "hello", "filename.yml", self.rule)
         self.formatter.format(match, True)
 
     def test_unicode_format_string(self):
-        match = Match(1, "hello", "filename.yml", self.rule, u'\U0001f427')
+        match = Match(u'\U0001f427', 1, "hello", "filename.yml", self.rule)
         self.formatter.format(match, False)
 
     def test_dict_format_line(self):
-        match = Match(1, {'hello': 'world'}, "filename.yml", self.rule, "xyz")
+        match = Match("xyz", 1, {'hello': 'world'}, "filename.yml", self.rule,)
         self.formatter.format(match, True)


### PR DESCRIPTION
Combine two very similar classes in order to avoid extra complexity
in processing rule validates.

From now on a Match is an Exception so it can be raised, captured,
and annotated in various places in the call stack.