### PR TITLE
Enable isort

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,9 @@
+[settings]
+include_trailing_comma = true
+known_first_party = ansiblelint
+known_third_party = ansible,pytest,ruamel,setuptools,sphinx,yaml
+# picked to match the current flake8 value:
+line_length = 100
+# https://github.com/timothycrosley/isort#multi-line-output-modes
+multi_line_output = 5
+use_parentheses = true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,13 @@ repos:
     files: \.(yaml|yml)$
     types: [file, yaml]
     entry: yamllint --strict
+- repo: https://github.com/pre-commit/mirrors-isort
+  rev: v5.0.8
+  hooks:
+  - id: isort
+    args:
+    # https://github.com/pre-commit/mirrors-isort/issues/9#issuecomment-624404082
+    - --filter-files
 - repo: https://gitlab.com/pycqa/flake8.git
   rev: 3.8.1
   hooks:

--- a/docs/rules_table_generator_ext.py
+++ b/docs/rules_table_generator_ext.py
@@ -13,7 +13,6 @@ from ansiblelint.constants import DEFAULT_RULESDIR
 from ansiblelint.generate_docs import rules_as_rst
 from ansiblelint.rules import RulesCollection
 
-
 DEFAULT_RULES_RST = (Path(__file__).parent / 'default_rules.rst').resolve()
 
 

--- a/lib/ansiblelint/__init__.py
+++ b/lib/ansiblelint/__init__.py
@@ -22,7 +22,6 @@
 from ansiblelint.rules import AnsibleLintRule
 from ansiblelint.version import __version__
 
-
 __all__ = (
     "__version__",
     "AnsibleLintRule"  # deprecated, import it directly from rules

--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -33,7 +33,6 @@ from ansiblelint.rules import RulesCollection
 from ansiblelint.runner import Runner
 from ansiblelint.utils import get_playbooks_and_roles
 
-
 _logger = logging.getLogger(__name__)
 
 

--- a/lib/ansiblelint/cli.py
+++ b/lib/ansiblelint/cli.py
@@ -12,7 +12,6 @@ import yaml
 from ansiblelint.constants import DEFAULT_RULESDIR, INVALID_CONFIG_RC
 from ansiblelint.version import __version__
 
-
 _logger = logging.getLogger(__name__)
 _PATH_VARS = ['exclude_paths', 'rulesdir', ]
 

--- a/lib/ansiblelint/constants.py
+++ b/lib/ansiblelint/constants.py
@@ -1,7 +1,6 @@
 """Constants used by AnsibleLint."""
 import os.path
 
-
 DEFAULT_RULESDIR = os.path.join(os.path.dirname(__file__), 'rules')
 
 INVALID_CONFIG_RC = 2

--- a/lib/ansiblelint/generate_docs.py
+++ b/lib/ansiblelint/generate_docs.py
@@ -3,7 +3,6 @@ import logging
 
 from ansiblelint.rules import RulesCollection
 
-
 DOC_HEADER = """
 .. _lint_default_rules:
 

--- a/lib/ansiblelint/rules/CommandsInsteadOfArgumentsRule.py
+++ b/lib/ansiblelint/rules/CommandsInsteadOfArgumentsRule.py
@@ -22,6 +22,7 @@ import os
 
 from ansiblelint.rules import AnsibleLintRule
 from ansiblelint.utils import get_first_cmd_arg
+
 try:
     from ansible.module_utils.parsing.convert_bool import boolean
 except ImportError:

--- a/lib/ansiblelint/rules/CommandsInsteadOfModulesRule.py
+++ b/lib/ansiblelint/rules/CommandsInsteadOfModulesRule.py
@@ -22,6 +22,7 @@ import os
 
 from ansiblelint.rules import AnsibleLintRule
 from ansiblelint.utils import get_first_cmd_arg
+
 try:
     from ansible.module_utils.parsing.convert_bool import boolean
 except ImportError:

--- a/lib/ansiblelint/rules/MetaMainHasInfoRule.py
+++ b/lib/ansiblelint/rules/MetaMainHasInfoRule.py
@@ -3,7 +3,6 @@
 
 from ansiblelint.rules import AnsibleLintRule
 
-
 META_STR_INFO = (
     'author',
     'description'

--- a/lib/ansiblelint/rules/RoleNames.py
+++ b/lib/ansiblelint/rules/RoleNames.py
@@ -24,7 +24,6 @@ from typing import List
 
 from ansiblelint.rules import AnsibleLintRule
 
-
 ROLE_NAME_REGEX = '^[a-z][a-z0-9_]+$'
 
 

--- a/lib/ansiblelint/rules/__init__.py
+++ b/lib/ansiblelint/rules/__init__.py
@@ -12,7 +12,6 @@ import ansiblelint.utils
 from ansiblelint.errors import MatchError
 from ansiblelint.skip_utils import append_skipped_rules, get_rule_skips_from_line
 
-
 _logger = logging.getLogger(__name__)
 
 

--- a/lib/ansiblelint/runner.py
+++ b/lib/ansiblelint/runner.py
@@ -6,9 +6,9 @@ from typing import List, Set
 import ansiblelint.file_utils
 import ansiblelint.skip_utils
 import ansiblelint.utils
+
 from .errors import MatchError
 from .rules.LoadingFailureRule import LoadingFailureRule
-
 
 _logger = logging.getLogger(__name__)
 

--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -400,7 +400,8 @@ def normalize_task_v2(task):  # noqa: C901
     if 'always_run' in task:
         # FIXME(ssbarnea): Delayed import to avoid circular import
         # See https://github.com/ansible/ansible-lint/issues/880
-        from ansiblelint.rules.AlwaysRunRule import AlwaysRunRule  # noqa: # pylint:disable=cyclic-import,import-outside-toplevel
+        # noqa: # pylint:disable=cyclic-import,import-outside-toplevel
+        from ansiblelint.rules.AlwaysRunRule import AlwaysRunRule
 
         raise MatchError(
             rule=AlwaysRunRule,

--- a/test/TestImportIncludeRole.py
+++ b/test/TestImportIncludeRole.py
@@ -2,7 +2,6 @@ import pytest
 
 from ansiblelint.runner import Runner
 
-
 ROLE_TASKS_MAIN = '''
 - name: shell instead of command
   shell: echo hello world

--- a/test/TestImportWithMalformed.py
+++ b/test/TestImportWithMalformed.py
@@ -4,7 +4,6 @@ import pytest
 
 from ansiblelint.runner import Runner
 
-
 PlayFile = namedtuple('PlayFile', ['name', 'content'])
 
 

--- a/test/TestIncludeMissingFileRule.py
+++ b/test/TestIncludeMissingFileRule.py
@@ -4,7 +4,6 @@ import pytest
 
 from ansiblelint.runner import Runner
 
-
 PlayFile = namedtuple('PlayFile', ['name', 'content'])
 
 

--- a/test/TestLineNumber.py
+++ b/test/TestLineNumber.py
@@ -20,7 +20,6 @@
 
 from ansiblelint.rules.SudoRule import SudoRule
 
-
 TEST_TASKLIST = """
 - debug:
     msg: test

--- a/test/TestNestedJinjaRule.py
+++ b/test/TestNestedJinjaRule.py
@@ -27,7 +27,6 @@ import pytest
 
 from ansiblelint.runner import Runner
 
-
 PlayFile = namedtuple('PlayFile', ['name', 'content'])
 
 

--- a/test/TestSkipInsideYaml.py
+++ b/test/TestSkipInsideYaml.py
@@ -1,6 +1,5 @@
 import pytest
 
-
 ROLE_TASKS = '''
 ---
 - name: test 303

--- a/test/TestSkipPlaybookItems.py
+++ b/test/TestSkipPlaybookItems.py
@@ -1,6 +1,5 @@
 import pytest
 
-
 PLAYBOOK_PRE_TASKS = '''
 - hosts: all
   tasks:

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -8,7 +8,6 @@ from ansible import __version__ as ansible_version_str
 
 from ansiblelint.runner import Runner
 
-
 ANSIBLE_MAJOR_VERSION = tuple(map(int, ansible_version_str.split('.')[:2]))
 
 


### PR DESCRIPTION
Introduce isort with minimal configuration needed in order to make it work (not make mistake).

The only files manually modified here the `.pre-config-config.yml` ones, the other ones where automatically fixed by isort.

Note that I am against including "preference" like configuration to isort as they are objective. We already had long debates with pylint and before and I will stick to minimalism, just enough to make
it produce decent output (does not even have to be perfect). The amount of changes done highlights
the number of human mistakes made at sorting and grouping dependencies.

Unless there is a clear bug like import present in wrong section, please do not comment regarding
isort decision to split or join imports, accept it and move on. We do have far more important changes
to review and merge.