### PR TITLE
LRU Cache for frequently called functions

### DIFF
--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -26,6 +26,7 @@ import pprint
 import subprocess
 from argparse import Namespace
 from collections import OrderedDict
+from functools import lru_cache
 from pathlib import Path
 from typing import Callable, ItemsView, List, Tuple
 
@@ -533,6 +534,7 @@ def get_normalized_tasks(yaml, file):
     return res
 
 
+@lru_cache(maxsize=128)
 def parse_yaml_linenumbers(data, filename):
     """Parse yaml as ansible.utils.parse_yaml but with linenumbers.
 


### PR DESCRIPTION
#### This PR should speed up running of ansible-lint by a noticeable amount  by using `@lru_cache` decorator 

#### Measurements
For my 10kloc of yaml ansible repo:
 * `ansible-lint 4.2.0`: `time ansible-lint *.yml -q` returns `real    0m56.920`
 * version from PR returns: `real    0m8.039s` for the same command (same environment, just used setup.py to install)

OS: macOS 10.15.4
CPU: 2,3 GHz 8-Core Intel Core i9
Python: Python 3.7.8 