### PR TITLE
Allow backticks in shell commands

### DIFF
--- a/lib/ansiblelint/rules/UseCommandInsteadOfShellRule.py
+++ b/lib/ansiblelint/rules/UseCommandInsteadOfShellRule.py
@@ -42,4 +42,4 @@ class UseCommandInsteadOfShellRule(AnsibleLintRule):
             else:
                 unjinjad_cmd = self.unjinja(
                     ' '.join(task["action"].get("__ansible_arguments__", [])))
-            return not any([ch in unjinjad_cmd for ch in '&|<>;$\n*[]{}?'])
+            return not any([ch in unjinjad_cmd for ch in '&|<>;$\n*[]{}?`'])

--- a/test/command-instead-of-shell-success.yml
+++ b/test/command-instead-of-shell-success.yml
@@ -26,6 +26,9 @@
   - name: use shell generator
     shell: ls foo{.txt,.xml}
 
+  - name: use backticks
+    shell: ls `ls foo*`
+
   - name: use shell with cmd
     shell:
       cmd: |


### PR DESCRIPTION
```yaml
- name: create rabbitmq-admin-creds creds
  shell: kubectl --context {{ k8s_context }} \
                 -n {{ namespace }} create secret generic rabbitmq-admin-creds \
                 --from-literal=password=`openssl rand -base64 12` \
                 --from-literal=cookie=`uuidgen`
  register: rbt_secret
  changed_when: rbt_secret.rc == 0
  failed_when: rbt_secret.rc != 0 and 'AlreadyExists' not in rbt_secret.stderr
```

Ansible-lint did not like it:

```
[305] Use shell only when shell functionality is required
roles/secrets/tasks/main.yml:29
Task/Handler: create rabbitmq-admin-creds creds
```

I switched it to a command, and it failed because the backticks were not expanded by the shell.

This PR prevents 305 from being thrown if a backtick is present in the command.  A unit test is also included.