### PR TITLE
Standardize test imports

### DIFF
--- a/test/TestAlwaysRunRule.py
+++ b/test/TestAlwaysRunRule.py
@@ -1,9 +1,12 @@
 import unittest
-from ansiblelint.rules import RulesCollection
-from ansiblelint.runner import Runner
-from ansiblelint.rules.AlwaysRunRule import AlwaysRunRule
-from test import ANSIBLE_MAJOR_VERSION
+
 import pytest
+
+from ansiblelint.rules import RulesCollection
+from ansiblelint.rules.AlwaysRunRule import AlwaysRunRule
+from ansiblelint.runner import Runner
+
+from . import ANSIBLE_MAJOR_VERSION
 
 
 @pytest.mark.skipif(

--- a/test/TestBecomeUserWithoutBecome.py
+++ b/test/TestBecomeUserWithoutBecome.py
@@ -1,7 +1,8 @@
 import unittest
+
 from ansiblelint.rules import RulesCollection
-from ansiblelint.runner import Runner
 from ansiblelint.rules.BecomeUserWithoutBecomeRule import BecomeUserWithoutBecomeRule
+from ansiblelint.runner import Runner
 
 
 class TestBecomeUserWithoutBecome(unittest.TestCase):

--- a/test/TestCliRolePaths.py
+++ b/test/TestCliRolePaths.py
@@ -1,7 +1,7 @@
-import unittest
-import subprocess
 import os
+import subprocess
 import sys
+import unittest
 
 
 class TestCliRolePaths(unittest.TestCase):

--- a/test/TestCommandHasChangesCheck.py
+++ b/test/TestCommandHasChangesCheck.py
@@ -1,7 +1,8 @@
 import unittest
-from ansiblelint.runner import Runner
+
 from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.CommandHasChangesCheckRule import CommandHasChangesCheckRule
+from ansiblelint.runner import Runner
 
 
 class TestCommandHasChangesCheck(unittest.TestCase):

--- a/test/TestCommandLineInvocationSameAsConfig.py
+++ b/test/TestCommandLineInvocationSameAsConfig.py
@@ -1,5 +1,5 @@
-from pathlib import Path
 import sys
+from pathlib import Path
 
 import pytest
 

--- a/test/TestComparisonToEmptyString.py
+++ b/test/TestComparisonToEmptyString.py
@@ -1,9 +1,9 @@
 import unittest
 
 from ansiblelint.rules import RulesCollection
-from ansiblelint.rules.ComparisonToEmptyStringRule import (
-    ComparisonToEmptyStringRule)
-from test import RunFromText
+from ansiblelint.rules.ComparisonToEmptyStringRule import ComparisonToEmptyStringRule
+
+from . import RunFromText
 
 SUCCESS_TASKS = '''
 - name: shut down

--- a/test/TestComparisonToLiteralBool.py
+++ b/test/TestComparisonToLiteralBool.py
@@ -1,9 +1,9 @@
 import unittest
 
 from ansiblelint.rules import RulesCollection
-from ansiblelint.rules.ComparisonToLiteralBoolRule import (
-    ComparisonToLiteralBoolRule)
-from test import RunFromText
+from ansiblelint.rules.ComparisonToLiteralBoolRule import ComparisonToLiteralBoolRule
+
+from . import RunFromText
 
 PASS_WHEN = '''
 - name: example task

--- a/test/TestDeprecatedModule.py
+++ b/test/TestDeprecatedModule.py
@@ -4,7 +4,8 @@ import pytest
 
 from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.DeprecatedModuleRule import DeprecatedModuleRule
-from test import RunFromText, ANSIBLE_MAJOR_VERSION
+
+from . import ANSIBLE_MAJOR_VERSION, RunFromText
 
 MODULE_DEPRECATED = '''
 - name: task example

--- a/test/TestEnvVarsInCommand.py
+++ b/test/TestEnvVarsInCommand.py
@@ -2,8 +2,8 @@ import unittest
 
 from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.EnvVarsInCommandRule import EnvVarsInCommandRule
-from test import RunFromText
 
+from . import RunFromText
 
 SUCCESS_PLAY_TASKS = '''
 - hosts: localhost

--- a/test/TestIncludeMissFileWithRole.py
+++ b/test/TestIncludeMissFileWithRole.py
@@ -1,7 +1,7 @@
+import os
 from collections import namedtuple
 
 import pytest
-import os
 
 from ansiblelint.runner import Runner
 

--- a/test/TestLineTooLong.py
+++ b/test/TestLineTooLong.py
@@ -2,7 +2,8 @@ import unittest
 
 from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.LineTooLongRule import LineTooLongRule
-from test import RunFromText
+
+from . import RunFromText
 
 LONG_LINE = '''
 - name: task example

--- a/test/TestLintRule.py
+++ b/test/TestLintRule.py
@@ -20,8 +20,7 @@
 
 import unittest
 
-from .rules import EMatcherRule
-from .rules import UnsetVariableMatcherRule
+from .rules import EMatcherRule, UnsetVariableMatcherRule
 
 
 class TestRule(unittest.TestCase):

--- a/test/TestMatchError.py
+++ b/test/TestMatchError.py
@@ -2,12 +2,12 @@
 
 import operator
 
+import pytest
+
 from ansiblelint.errors import MatchError
 from ansiblelint.rules import AnsibleLintRule
 from ansiblelint.rules.AlwaysRunRule import AlwaysRunRule
 from ansiblelint.rules.BecomeUserWithoutBecomeRule import BecomeUserWithoutBecomeRule
-
-import pytest
 
 
 @pytest.mark.parametrize(

--- a/test/TestMetaChangeFromDefault.py
+++ b/test/TestMetaChangeFromDefault.py
@@ -1,9 +1,9 @@
 import unittest
 
 from ansiblelint.rules import RulesCollection
-from ansiblelint.rules.MetaChangeFromDefaultRule import (
-    MetaChangeFromDefaultRule)
-from test import RunFromText
+from ansiblelint.rules.MetaChangeFromDefaultRule import MetaChangeFromDefaultRule
+
+from . import RunFromText
 
 DEFAULT_GALAXY_INFO = '''
 galaxy_info:

--- a/test/TestMetaMainHasInfo.py
+++ b/test/TestMetaMainHasInfo.py
@@ -2,7 +2,8 @@ import unittest
 
 from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.MetaMainHasInfoRule import MetaMainHasInfoRule
-from test import RunFromText
+
+from . import RunFromText
 
 NO_GALAXY_INFO = '''
 author: the author

--- a/test/TestMetaTagValid.py
+++ b/test/TestMetaTagValid.py
@@ -2,7 +2,8 @@ import unittest
 
 from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.MetaTagValidRule import MetaTagValidRule
-from test import RunFromText
+
+from . import RunFromText
 
 META_TAG_VALID = '''
 galaxy_info:

--- a/test/TestMetaVideoLinks.py
+++ b/test/TestMetaVideoLinks.py
@@ -2,7 +2,8 @@ import unittest
 
 from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.MetaVideoLinksRule import MetaVideoLinksRule
-from test import RunFromText
+
+from . import RunFromText
 
 META_VIDEO_LINKS = '''
 galaxy_info:

--- a/test/TestNoFormattingInWhenRule.py
+++ b/test/TestNoFormattingInWhenRule.py
@@ -1,7 +1,8 @@
 import unittest
+
 from ansiblelint.rules import RulesCollection
-from ansiblelint.runner import Runner
 from ansiblelint.rules.NoFormattingInWhenRule import NoFormattingInWhenRule
+from ansiblelint.runner import Runner
 
 
 class TestNoFormattingInWhenRule(unittest.TestCase):

--- a/test/TestOctalPermissions.py
+++ b/test/TestOctalPermissions.py
@@ -2,7 +2,8 @@ import unittest
 
 from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.OctalPermissionsRule import OctalPermissionsRule
-from test import RunFromText
+
+from . import RunFromText
 
 SUCCESS_TASKS = '''
 ---

--- a/test/TestPackageIsNotLatest.py
+++ b/test/TestPackageIsNotLatest.py
@@ -1,7 +1,8 @@
 import unittest
-from ansiblelint.runner import Runner
+
 from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.PackageIsNotLatestRule import PackageIsNotLatestRule
+from ansiblelint.runner import Runner
 
 
 class TestPackageIsNotLatestRule(unittest.TestCase):

--- a/test/TestRoleHandlers.py
+++ b/test/TestRoleHandlers.py
@@ -1,8 +1,10 @@
 import unittest
-from ansiblelint.runner import Runner
+
 from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.UseHandlerRatherThanWhenChangedRule import (
-    UseHandlerRatherThanWhenChangedRule)
+    UseHandlerRatherThanWhenChangedRule,
+)
+from ansiblelint.runner import Runner
 
 
 class TestRoleHandlers(unittest.TestCase):

--- a/test/TestRoleRelativePath.py
+++ b/test/TestRoleRelativePath.py
@@ -2,7 +2,8 @@ import unittest
 
 from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.RoleRelativePath import RoleRelativePath
-from test import RunFromText
+
+from . import RunFromText
 
 FAIL_TASKS = '''
 - name: template example

--- a/test/TestRunner.py
+++ b/test/TestRunner.py
@@ -21,10 +21,9 @@ import os
 
 import pytest
 
-import ansiblelint.formatters as formatters
-from ansiblelint.runner import Runner
+from ansiblelint import formatters
 from ansiblelint.cli import abspath
-
+from ansiblelint.runner import Runner
 
 LOTS_OF_WARNINGS_PLAYBOOK = abspath('examples/lots_of_warnings.yml', os.getcwd())
 

--- a/test/TestShellWithoutPipefail.py
+++ b/test/TestShellWithoutPipefail.py
@@ -2,7 +2,8 @@ import unittest
 
 from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.ShellWithoutPipefail import ShellWithoutPipefail
-from test import RunFromText
+
+from . import RunFromText
 
 FAIL_TASKS = '''
 ---

--- a/test/TestSudoRule.py
+++ b/test/TestSudoRule.py
@@ -2,7 +2,8 @@ import unittest
 
 from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.SudoRule import SudoRule
-from test import RunFromText
+
+from . import RunFromText
 
 ROLE_2_ERRORS = '''
 - name: test

--- a/test/TestTaskHasName.py
+++ b/test/TestTaskHasName.py
@@ -1,7 +1,8 @@
 import unittest
-from ansiblelint.runner import Runner
+
 from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.TaskHasNameRule import TaskHasNameRule
+from ansiblelint.runner import Runner
 
 
 class TestTaskHasNameRule(unittest.TestCase):

--- a/test/TestTaskNoLocalAction.py
+++ b/test/TestTaskNoLocalAction.py
@@ -2,7 +2,8 @@ import unittest
 
 from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.TaskNoLocalAction import TaskNoLocalAction
-from test import RunFromText
+
+from . import RunFromText
 
 TASK_LOCAL_ACTION = '''
 - name: task example

--- a/test/TestUseCommandInsteadOfShell.py
+++ b/test/TestUseCommandInsteadOfShell.py
@@ -1,7 +1,8 @@
 import unittest
-from ansiblelint.runner import Runner
+
 from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.UseCommandInsteadOfShellRule import UseCommandInsteadOfShellRule
+from ansiblelint.runner import Runner
 
 
 class TestUseCommandInsteadOfShell(unittest.TestCase):

--- a/test/TestUseHandlerRatherThanWhenChanged.py
+++ b/test/TestUseHandlerRatherThanWhenChanged.py
@@ -2,9 +2,10 @@ import unittest
 
 from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.UseHandlerRatherThanWhenChangedRule import (
-    UseHandlerRatherThanWhenChangedRule)
-from test import RunFromText
+    UseHandlerRatherThanWhenChangedRule,
+)
 
+from . import RunFromText
 
 SUCCESS_TASKS = '''
 - name: print helpful error message

--- a/test/TestUsingBareVariablesIsDeprecated.py
+++ b/test/TestUsingBareVariablesIsDeprecated.py
@@ -1,7 +1,8 @@
 import unittest
-from ansiblelint.runner import Runner
+
 from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.UsingBareVariablesIsDeprecatedRule import UsingBareVariablesIsDeprecatedRule
+from ansiblelint.runner import Runner
 
 
 class TestUsingBareVariablesIsDeprecated(unittest.TestCase):

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -22,16 +22,15 @@
 
 import logging
 import os
-from pathlib import Path
 import subprocess
 import sys
+from pathlib import Path
 
 import pytest
 
-import ansiblelint.utils as utils
-from ansiblelint.file_utils import normpath
+from ansiblelint import cli, utils
 from ansiblelint.__main__ import initialize_logger
-from ansiblelint import cli
+from ansiblelint.file_utils import normpath
 
 
 @pytest.mark.parametrize(('string', 'expected_cmd', 'expected_args', 'expected_kwargs'), (

--- a/test/TestVariableHasSpaces.py
+++ b/test/TestVariableHasSpaces.py
@@ -2,7 +2,8 @@ import unittest
 
 from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.VariableHasSpacesRule import VariableHasSpacesRule
-from test import RunFromText
+
+from . import RunFromText
 
 TASK_VARIABLES = '''
 - name: good variable format

--- a/test/TestWithSkipTagId.py
+++ b/test/TestWithSkipTagId.py
@@ -1,7 +1,8 @@
 import unittest
+
 from ansiblelint.rules import RulesCollection
-from ansiblelint.runner import Runner
 from ansiblelint.rules.TrailingWhitespaceRule import TrailingWhitespaceRule
+from ansiblelint.runner import Runner
 
 
 class TestWithSkipTagId(unittest.TestCase):

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,8 +1,8 @@
 """Test suite for ansible-lint."""
 
-import tempfile
-import shutil
 import os
+import shutil
+import tempfile
 
 from ansible import __version__ as ansible_version_str
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,9 +1,10 @@
 import os
 
 import pytest
-from test import RunFromText
 
 from ansiblelint.rules import RulesCollection
+
+from . import RunFromText
 
 
 @pytest.fixture


### PR DESCRIPTION
Adopt standard stdlib, 3rd-party, 1st-party sectioning for imports
inside tests.

Reduces size of #887 review.