### PR TITLE
Avoid failure with playbooks having tasks key a null value

### DIFF
--- a/lib/ansiblelint/rules/IncludeMissingFileRule.py
+++ b/lib/ansiblelint/rules/IncludeMissingFileRule.py
@@ -23,7 +23,9 @@ class IncludeMissingFileRule(AnsibleLintRule):
     def matchplay(self, file, data):
         absolute_directory = file.get('absolute_directory', None)
         results = []
-        for task in data.get('tasks', []):
+
+        # avoid failing with a playbook having tasks: null
+        for task in (data.get('tasks', []) or []):
 
             # check if the id of the current rule is not in list of skipped rules for this play
             if self.id in task['skipped_rules']:

--- a/test/TestAnsibleSyntax.py
+++ b/test/TestAnsibleSyntax.py
@@ -1,0 +1,16 @@
+"""Test Ansible Syntax.
+
+This module contains tests that validate that linter does not produce errors
+when encountering what counts as valid Ansible syntax.
+"""
+
+PB_WITH_NULL_TASKS = '''
+- hosts: all
+  tasks:
+'''
+
+
+def test_null_tasks(default_text_runner):
+    """Assure we do not fail when encountering null tasks."""
+    results = default_text_runner.run_playbook(PB_WITH_NULL_TASKS)
+    assert not results


### PR DESCRIPTION
Avoid creating a stacktrace when encountering playbooks where tasks is defined but has a null value.

Fixes: #850