### PR TITLE
Add release-drafter config

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,21 @@
+# Format and labels used aim to match those used by Ansible project
+categories:
+  - title: 'Major Changes'
+    labels:
+      - 'major'  # c6476b
+  - title: 'Minor Changes'
+    labels:
+      - 'feature'  # 006b75
+      - 'enhancement'  # ededed
+  - title: 'Bugfixes'
+    labels:
+      - 'bug'  # fbca04
+  - title: 'Deprecations'
+    labels:
+      - 'deprecated'  # fef2c0
+exclude-labels:
+  - 'skip-changelog'
+template: |
+  ## Changes
+
+  $CHANGES


### PR DESCRIPTION
That file helps release drafter categorize changes into sections from changelog. The list of labels is standard among multiple projects.

`skip-changelog` special label tells it to not mention change in changelog, very useful for changes that do not end-up in the released product (CI ones).

Please do not create more sections as this can make reading of changelog harder, 2-3 is usually more than enough, with major changes being listed first.

The file from https://github.com/ansible-community/molecule/blob/master/.github/release-drafter.yml did not require any change in the last 9 months.

The only thing cores need to pay attention is to check labels before pressing merge button, any change should have one of the labels recognized by the release-drafter. Those that do not have one are counted as "change". Changing the PR title or the labels is possible even after merge but in this case the release note message may be updated bit later, when another merge happens.

Once a release is made, release-drafter stops refreshing it.