### PR TITLE
Include contributing inside docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -587,7 +587,7 @@ Authors
 
 ansible-lint was created by `Will Thames`_ and is now maintained as part of the `Ansible`_ by `Red Hat`_ project.
 
-.. _Contribution guidelines: https://github.com/ansible/ansible-lint/blob/master/CONTRIBUTING.md
+.. _Contribution guidelines: https://github.com/ansible/ansible-lint/blob/master/docs/CONTRIBUTING.md
 .. _Will Thames: https://github.com/willthames
 .. _Ansible: https://ansible.com
 .. _Red Hat: https://redhat.com

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Standards
 ---------
 
 ansible-lint is flake8 compliant with `max-line-length` set to 100
-(see [setup.cfg](setup.cfg)).
+(see [.flake8][.flake8]).
 
 ansible-lint works only with [supported Ansible versions](
 https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html#release-status
@@ -49,3 +49,5 @@ Code of Conduct
 ---------------
 
 As with all Ansible projects, we have a [Code of Conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html)
+
+[.flake8]: https://github.com/ansible/ansible-lint/blob/master/.flake8

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Standards
 ---------
 
 ansible-lint is flake8 compliant with `max-line-length` set to 100
-(see [.flake8][.flake8]).
+(see [.flake8]).
 
 ansible-lint works only with [supported Ansible versions](
 https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html#release-status

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,6 +48,7 @@ AUTHOR = 'Ansible, Inc'
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 # TEST: 'sphinxcontrib.fulltoc'
 extensions = [
+    'myst_parser',
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
     'rules_table_generator_ext',  # in-tree extension
@@ -94,7 +95,7 @@ today_fmt = '%B %d, %Y'
 # A list of glob-style patterns that should be excluded when looking
 # for source files.
 # OBSOLETE - removing this - dharmabumstead 2018-02-06
-# exclude_patterns = ['modules']
+exclude_patterns = ['README.md']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,3 +40,8 @@ transferred to the Ansible project team.
 
    rules
    default_rules
+
+.. toctree::
+   :caption: Contributing
+
+   CONTRIBUTING

--- a/docs/requirements.in
+++ b/docs/requirements.in
@@ -1,2 +1,3 @@
+myst-parser
 Sphinx
 sphinx_ansible_theme

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,6 +8,10 @@ alabaster==0.7.12 \
     --hash=sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359 \
     --hash=sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02 \
     # via sphinx
+attrs==19.3.0 \
+    --hash=sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c \
+    --hash=sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72 \
+    # via markdown-it-py
 babel==2.8.0 \
     --hash=sha256:1aac2ae2d0d8ea368fa90906567f5c08463d98ade155c0c4bfedd6a0f7160e38 \
     --hash=sha256:d670ea0b10f8b723672d3a6abeb87b565b244da220d76b4dba1b66269ec152d4 \
@@ -23,7 +27,7 @@ chardet==3.0.4 \
 docutils==0.16 \
     --hash=sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af \
     --hash=sha256:c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc \
-    # via sphinx
+    # via myst-parser, sphinx
 idna==2.10 \
     --hash=sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6 \
     --hash=sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0 \
@@ -36,6 +40,10 @@ jinja2==2.11.2 \
     --hash=sha256:89aab215427ef59c34ad58735269eb58b1a5808103067f7bb9d5836c651b3bb0 \
     --hash=sha256:f0a4641d3cf955324a89c04f3d94663aa4d638abe8f733ecd3582848e1c37035 \
     # via sphinx
+markdown-it-py==0.4.8 \
+    --hash=sha256:96b1b710f52607a70501246010effaf257c202abc8e8ee85eb2c681035ddc2b1 \
+    --hash=sha256:fff51f9d107deb393dcd81e484a4334459fc2752ae83a76bea4b523372be6393 \
+    # via myst-parser
 markupsafe==1.1.1 \
     --hash=sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473 \
     --hash=sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161 \
@@ -71,6 +79,10 @@ markupsafe==1.1.1 \
     --hash=sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7 \
     --hash=sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be \
     # via jinja2
+myst-parser==0.9.1 \
+    --hash=sha256:2ea28ed2aa4c71862c60b946c22043cfef6d07867c9b1541d1560e465b3ef2c7 \
+    --hash=sha256:c62eae06188ae1415af7243b3d3e19d6da6985f4e4d6862e8b00f13eafc06f98 \
+    # via -r docs/requirements.in
 packaging==20.4 \
     --hash=sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8 \
     --hash=sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181 \
@@ -87,6 +99,19 @@ pytz==2020.1 \
     --hash=sha256:a494d53b6d39c3c6e44c3bec237336e14305e4f29bbf800b599253057fbb79ed \
     --hash=sha256:c35965d010ce31b23eeb663ed3cc8c906275d6be1a34393a1d73a41febf4a048 \
     # via babel
+pyyaml==5.3.1 \
+    --hash=sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97 \
+    --hash=sha256:240097ff019d7c70a4922b6869d8a86407758333f02203e0fc6ff79c5dcede76 \
+    --hash=sha256:4f4b913ca1a7319b33cfb1369e91e50354d6f07a135f3b901aca02aa95940bd2 \
+    --hash=sha256:69f00dca373f240f842b2931fb2c7e14ddbacd1397d57157a9b005a6a9942648 \
+    --hash=sha256:73f099454b799e05e5ab51423c7bcf361c58d3206fa7b0d555426b1f4d9a3eaf \
+    --hash=sha256:74809a57b329d6cc0fdccee6318f44b9b8649961fa73144a98735b0aaf029f1f \
+    --hash=sha256:7739fc0fa8205b3ee8808aea45e968bc90082c10aef6ea95e855e10abf4a37b2 \
+    --hash=sha256:95f71d2af0ff4227885f7a6605c37fd53d3a106fcab511b8860ecca9fcf400ee \
+    --hash=sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d \
+    --hash=sha256:cc8955cfbfc7a115fa81d85284ee61147059a753344bc51098f3ccd69b0d7e0c \
+    --hash=sha256:d13155f591e6fcc1ec3b30685d50bf0711574e2c0dfffd7644babf8b5102ca1a \
+    # via myst-parser
 requests==2.24.0 \
     --hash=sha256:b3559a131db72c33ee969480840fff4bb6dd111de7dd27c8ee1f820f4f00231b \
     --hash=sha256:fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898 \
@@ -99,6 +124,10 @@ snowballstemmer==2.0.0 \
     --hash=sha256:209f257d7533fdb3cb73bdbd24f436239ca3b2fa67d56f6ff88e86be08cc5ef0 \
     --hash=sha256:df3bac3df4c2c01363f3dd2cfa78cce2840a79b9f1c2d2de9ce8d31683992f52 \
     # via sphinx
+sphinx-ansible-theme==0.3.1 \
+    --hash=sha256:173c57c7d78f08b88b3eca2c71afc6806d64739959cab5faef69ac37fcdba22c \
+    --hash=sha256:2eafc6f60c41b7acd293b3715f0f660365ab92e7d67c88628f8718ca81e07b21 \
+    # via -r docs/requirements.in
 sphinx-notfound-page==0.4 \
     --hash=sha256:0105a40d8a305d3e1003630d8ee99296baa08cf2a4c1ce1db8d91fbbe78f90db \
     --hash=sha256:609fd7cd7f9ea73c030f1b67a3f2bc90f60bff87b30026fbd2bcb19c7c59c484 \
@@ -107,14 +136,10 @@ sphinx-rtd-theme==0.5.0 \
     --hash=sha256:22c795ba2832a169ca301cd0a083f7a434e09c538c70beb42782c073651b707d \
     --hash=sha256:373413d0f82425aaa28fb288009bf0d0964711d347763af2f1b65cafcb028c82 \
     # via sphinx-ansible-theme
-sphinx_ansible_theme==0.3.1 \
-    --hash=sha256:173c57c7d78f08b88b3eca2c71afc6806d64739959cab5faef69ac37fcdba22c \
-    --hash=sha256:2eafc6f60c41b7acd293b3715f0f660365ab92e7d67c88628f8718ca81e07b21 \
-    # via -r requirements.in
-sphinx==3.1.2 \
-    --hash=sha256:97dbf2e31fc5684bb805104b8ad34434ed70e6c588f6896991b2fdfd2bef8c00 \
-    --hash=sha256:b9daeb9b39aa1ffefc2809b43604109825300300b987a24f45976c001ba1a8fd \
-    # via -r requirements.in, sphinx-rtd-theme
+sphinx==2.4.4 \
+    --hash=sha256:b4c750d546ab6d7e05bdff6ac24db8ae3e8b8253a3569b754e445110a0a12b66 \
+    --hash=sha256:fc312670b56cb54920d6cc2ced455a22a547910de10b3142276495ced49231cb \
+    # via -r docs/requirements.in, myst-parser, sphinx-rtd-theme
 sphinxcontrib-applehelp==1.0.2 \
     --hash=sha256:806111e5e962be97c29ec4c1e7fe277bfd19e9652fb1a4392105b43e01af885a \
     --hash=sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58 \


### PR DESCRIPTION
Previously contributing information was not included as part
of the builded docs. This change address this issue, making
it part of the documentation.