### PR TITLE
Make newlines after imports  consistent

### DIFF
--- a/docs/rules_table_generator_ext.py
+++ b/docs/rules_table_generator_ext.py
@@ -13,7 +13,6 @@ from ansiblelint.constants import DEFAULT_RULESDIR
 from ansiblelint.generate_docs import rules_as_rst
 from ansiblelint.rules import RulesCollection
 
-
 DEFAULT_RULES_RST = (Path(__file__).parent / 'default_rules.rst').resolve()
 
 

--- a/lib/ansiblelint/__init__.py
+++ b/lib/ansiblelint/__init__.py
@@ -22,7 +22,6 @@
 from ansiblelint.rules import AnsibleLintRule
 from ansiblelint.version import __version__
 
-
 __all__ = (
     "__version__",
     "AnsibleLintRule"  # deprecated, import it directly from rules

--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -33,7 +33,6 @@ from ansiblelint.rules import RulesCollection
 from ansiblelint.runner import Runner
 from ansiblelint.utils import get_playbooks_and_roles
 
-
 _logger = logging.getLogger(__name__)
 
 

--- a/lib/ansiblelint/cli.py
+++ b/lib/ansiblelint/cli.py
@@ -12,7 +12,6 @@ import yaml
 from ansiblelint.constants import DEFAULT_RULESDIR, INVALID_CONFIG_RC
 from ansiblelint.version import __version__
 
-
 _logger = logging.getLogger(__name__)
 _PATH_VARS = ['exclude_paths', 'rulesdir', ]
 

--- a/lib/ansiblelint/constants.py
+++ b/lib/ansiblelint/constants.py
@@ -1,7 +1,6 @@
 """Constants used by AnsibleLint."""
 import os.path
 
-
 DEFAULT_RULESDIR = os.path.join(os.path.dirname(__file__), 'rules')
 
 INVALID_CONFIG_RC = 2

--- a/lib/ansiblelint/generate_docs.py
+++ b/lib/ansiblelint/generate_docs.py
@@ -3,7 +3,6 @@ import logging
 
 from ansiblelint.rules import RulesCollection
 
-
 DOC_HEADER = """
 .. _lint_default_rules:
 

--- a/lib/ansiblelint/rules/CommandsInsteadOfArgumentsRule.py
+++ b/lib/ansiblelint/rules/CommandsInsteadOfArgumentsRule.py
@@ -22,6 +22,7 @@ import os
 
 from ansiblelint.rules import AnsibleLintRule
 from ansiblelint.utils import get_first_cmd_arg
+
 try:
     from ansible.module_utils.parsing.convert_bool import boolean
 except ImportError:

--- a/lib/ansiblelint/rules/CommandsInsteadOfModulesRule.py
+++ b/lib/ansiblelint/rules/CommandsInsteadOfModulesRule.py
@@ -22,6 +22,7 @@ import os
 
 from ansiblelint.rules import AnsibleLintRule
 from ansiblelint.utils import get_first_cmd_arg
+
 try:
     from ansible.module_utils.parsing.convert_bool import boolean
 except ImportError:

--- a/lib/ansiblelint/rules/MetaMainHasInfoRule.py
+++ b/lib/ansiblelint/rules/MetaMainHasInfoRule.py
@@ -3,7 +3,6 @@
 
 from ansiblelint.rules import AnsibleLintRule
 
-
 META_STR_INFO = (
     'author',
     'description'

--- a/lib/ansiblelint/rules/RoleNames.py
+++ b/lib/ansiblelint/rules/RoleNames.py
@@ -24,7 +24,6 @@ from typing import List
 
 from ansiblelint.rules import AnsibleLintRule
 
-
 ROLE_NAME_REGEX = '^[a-z][a-z0-9_]+$'
 
 

--- a/lib/ansiblelint/rules/__init__.py
+++ b/lib/ansiblelint/rules/__init__.py
@@ -12,7 +12,6 @@ import ansiblelint.utils
 from ansiblelint.errors import MatchError
 from ansiblelint.skip_utils import append_skipped_rules, get_rule_skips_from_line
 
-
 _logger = logging.getLogger(__name__)
 
 

--- a/lib/ansiblelint/runner.py
+++ b/lib/ansiblelint/runner.py
@@ -6,9 +6,9 @@ from typing import List, Set
 import ansiblelint.file_utils
 import ansiblelint.skip_utils
 import ansiblelint.utils
+
 from .errors import MatchError
 from .rules.LoadingFailureRule import LoadingFailureRule
-
 
 _logger = logging.getLogger(__name__)
 

--- a/test/TestImportIncludeRole.py
+++ b/test/TestImportIncludeRole.py
@@ -2,7 +2,6 @@ import pytest
 
 from ansiblelint.runner import Runner
 
-
 ROLE_TASKS_MAIN = '''
 - name: shell instead of command
   shell: echo hello world

--- a/test/TestImportWithMalformed.py
+++ b/test/TestImportWithMalformed.py
@@ -4,7 +4,6 @@ import pytest
 
 from ansiblelint.runner import Runner
 
-
 PlayFile = namedtuple('PlayFile', ['name', 'content'])
 
 

--- a/test/TestIncludeMissingFileRule.py
+++ b/test/TestIncludeMissingFileRule.py
@@ -4,7 +4,6 @@ import pytest
 
 from ansiblelint.runner import Runner
 
-
 PlayFile = namedtuple('PlayFile', ['name', 'content'])
 
 

--- a/test/TestLineNumber.py
+++ b/test/TestLineNumber.py
@@ -20,7 +20,6 @@
 
 from ansiblelint.rules.SudoRule import SudoRule
 
-
 TEST_TASKLIST = """
 - debug:
     msg: test

--- a/test/TestNestedJinjaRule.py
+++ b/test/TestNestedJinjaRule.py
@@ -27,7 +27,6 @@ import pytest
 
 from ansiblelint.runner import Runner
 
-
 PlayFile = namedtuple('PlayFile', ['name', 'content'])
 
 

--- a/test/TestSkipInsideYaml.py
+++ b/test/TestSkipInsideYaml.py
@@ -1,6 +1,5 @@
 import pytest
 
-
 ROLE_TASKS = '''
 ---
 - name: test 303

--- a/test/TestSkipPlaybookItems.py
+++ b/test/TestSkipPlaybookItems.py
@@ -1,6 +1,5 @@
 import pytest
 
-
 PLAYBOOK_PRE_TASKS = '''
 - hosts: all
   tasks:

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -8,7 +8,6 @@ from ansible import __version__ as ansible_version_str
 
 from ansiblelint.runner import Runner
 
-
 ANSIBLE_MAJOR_VERSION = tuple(map(int, ansible_version_str.split('.')[:2]))
 
 


### PR DESCRIPTION
Our current code-base uses a random mix of 1-2 newlines after imports and before variable assignment.

This change **normalize** number of newlines after imports to 1 newline
as this seems to be the default setting current preferred by tools
like isort/black/pylint.

Included changes are result of cherry picking newlines changes from running isort from https://github.com/ansible/ansible-lint/pull/887 so not much credit to claim on my side. Still, is needed in order to cleanup isort enable itself.

isort [documentation](https://github.com/timothycrosley/isort/wiki/isort-Settings) seems to clear about the rule, and user does not even need to remember it as isort will reformat when needed:

> lines_after_imports: Forces a certain number of lines after the imports and before the first line of functional code. By default this is 2 lines if the first line of code is a class or function. Otherwise it's 1.

Do not confuse newlines after import with newlines before function or class definition, which remains 2. When there are no variables-section the "2" value takes precedence, which seems natural.

Note: if someone would try to implement the opposite and force "2" newlines
after imports, we would have to touch ~40 files instead of 20, and also diverge from default settings, requiring us to add custom options to isort.