### PR TITLE
Prevent merging on missing labels

### DIFF
--- a/.github/workflows/edit.yml
+++ b/.github/workflows/edit.yml
@@ -1,0 +1,16 @@
+name: edit
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+
+jobs:
+  labels:
+
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: yogevbd/enforce-label-action@2.1.0
+        with:
+          REQUIRED_LABELS_ANY: "bug,enhancement,feature,deprecated,major,skip-changelog"
+          REQUIRED_LABELS_ANY_DESCRIPTION: "Select at least one label: bug,enhancement,feature,deprecated,major,skip-changelog"
+          BANNED_LABELS: "banned"


### PR DESCRIPTION
Prevents merging patches that do not include one of the required
labels. This helps release-drafter create the release-notes.

For any change that does not end-up as shipped or that is not expected
to produce any visible outcomes to the user, just use
`skip-changelist` label.