### PR TITLE
Assure we do not produce duplicated matches

### DIFF
--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -115,7 +115,7 @@ def main() -> int:
                         options.verbosity, checked_files)
         matches.extend(runner.run())
 
-    for match in sorted(matches):
+    for match in sorted(set(matches)):
         print(formatter.format(match, options.colored))
 
     if matches:

--- a/lib/ansiblelint/rules/__init__.py
+++ b/lib/ansiblelint/rules/__init__.py
@@ -154,7 +154,7 @@ class AnsibleLintRule(object):
                 m = MatchError(
                     message=message,
                     linenumber=linenumber,
-                    details=section,
+                    details=str(section),
                     filename=file['path'],
                     rule=self)
                 matches.append(m)

--- a/lib/ansiblelint/runner.py
+++ b/lib/ansiblelint/runner.py
@@ -96,4 +96,4 @@ class Runner(object):
         # update list of checked files
         self.checked_files.update([x['path'] for x in files])
 
-        return matches
+        return sorted(set(matches))

--- a/test/TestExamples.py
+++ b/test/TestExamples.py
@@ -1,0 +1,8 @@
+"""Assure samples produced desire outcomes."""
+from ansiblelint.runner import Runner
+
+
+def test_example(default_rules_collection):
+    """example.yml is expected to have 5 match errors inside."""
+    result = Runner(default_rules_collection, 'examples/example.yml', [], [], []).run()
+    assert len(result) == 5

--- a/test/TestMetaMainHasInfo.py
+++ b/test/TestMetaMainHasInfo.py
@@ -89,6 +89,6 @@ class TestMetaMainHasInfo(unittest.TestCase):
 
     def test_platform_list_of_str(self):
         results = self.runner.run_role_meta_main(PLATFORMS_LIST_OF_STR)
-        assert len(results) == 2
+        assert len(results) == 1
         self.assertIn("Platforms should be a list of dictionaries",
                       str(results))


### PR DESCRIPTION
Due to the way we parse files it is possible to get duplicated matches.

This change avoids printing duplications and also assures no regressions are made.

Our `examples/example.yml` was not used during testing and was a good example that caused duplicates. Now we test it and assure we find the exact number of matches that we were expecting.