### PR TITLE
Replace line attribute from Match with details

### DIFF
--- a/lib/ansiblelint/errors.py
+++ b/lib/ansiblelint/errors.py
@@ -24,7 +24,7 @@ class MatchError(ValueError):
             self,
             message=None,
             linenumber=0,
-            line: dict = None,
+            details: str = "",
             filename=None,
             rule=None) -> None:
         """Initialize a MatchError instance."""
@@ -38,7 +38,7 @@ class MatchError(ValueError):
 
         self.message = message or getattr(rule, 'shortdesc', "")
         self.linenumber = linenumber
-        self.line = line
+        self.details = details
         self.filename = normpath(filename) if filename else None
         self.rule = rule
 
@@ -50,12 +50,18 @@ class MatchError(ValueError):
         _id = getattr(self.rule, "id", "000")
 
         return formatstr.format(_id, self.message,
-                                self.filename, self.linenumber, self.line)
+                                self.filename, self.linenumber, self.details)
 
     @property
     def _hash_key(self):
         # line attr is knowingly excluded, as dict is not hashable
-        return self.filename, self.linenumber, str(getattr(self.rule, 'id', 0)), self.message
+        return (
+            self.filename,
+            self.linenumber,
+            str(getattr(self.rule, 'id', 0)),
+            self.message,
+            self.details,
+        )
 
     def __lt__(self, other):
         """Return whether the current object is less than the other."""

--- a/lib/ansiblelint/formatters/__init__.py
+++ b/lib/ansiblelint/formatters/__init__.py
@@ -49,13 +49,13 @@ class Formatter(BaseFormatter):
                                     colorize(match.message, Color.error_title),
                                     colorize(self._format_path(match.filename), Color.filename),
                                     colorize(str(match.linenumber), Color.linenumber),
-                                    colorize(u"{0}".format(match.line), Color.line))
+                                    colorize(u"{0}".format(match.details), Color.line))
         else:
             return formatstr.format(_id,
                                     match.message,
                                     match.filename,
                                     match.linenumber,
-                                    match.line)
+                                    match.details)
 
 
 class QuietFormatter(BaseFormatter):

--- a/lib/ansiblelint/rules/__init__.py
+++ b/lib/ansiblelint/rules/__init__.py
@@ -63,7 +63,7 @@ class AnsibleLintRule(object):
             m = MatchError(
                 message=message,
                 linenumber=prev_line_no + 1,
-                line=line,
+                details=line,
                 filename=file['path'],
                 rule=self)
             matches.append(m)
@@ -107,7 +107,7 @@ class AnsibleLintRule(object):
             m = MatchError(
                 message=message,
                 linenumber=task[ansiblelint.utils.LINE_NUMBER_KEY],
-                line=task_msg,
+                details=task_msg,
                 filename=file['path'],
                 rule=self)
             matches.append(m)
@@ -154,7 +154,7 @@ class AnsibleLintRule(object):
                 m = MatchError(
                     message=message,
                     linenumber=linenumber,
-                    line=section,
+                    details=section,
                     filename=file['path'],
                     rule=self)
                 matches.append(m)

--- a/test/TestMatchError.py
+++ b/test/TestMatchError.py
@@ -50,8 +50,7 @@ class DummySentinelTestObject:
     ('left_match_error', 'right_match_error'),
     (
         (MatchError("foo"), MatchError("foo")),
-        # `line` is ignored in comparisions, even when it differs:
-        (MatchError("a", line={}), MatchError("a", line={"a": "b"})),
+        (MatchError("a", details="foo"), MatchError("a", details="foo")),
     ),
 )
 def test_matcherror_compare(left_match_error, right_match_error):
@@ -80,8 +79,8 @@ def test_matcherror_invalid():
         (MatchError(rule=BecomeUserWithoutBecomeRule), MatchError(rule=AlwaysRunRule)),
         # rule id "200" > rule id 101
         (MatchError(rule=AnsibleLintRuleWithStringId), MatchError(rule=AlwaysRunRule)),
-        # line will not be taken into account
-        (MatchError("b", line={}), MatchError("a", line={"a": "b"})),
+        # details are taken into account
+        (MatchError("a", details="foo"), MatchError("a", details="bar")),
     ))
 class TestMatchErrorCompare:
 


### PR DESCRIPTION
Corrects confusing attribute name "line" with "details" and assures
it is a string and that is used when comparing instances.