### PR TITLE
Fix severity formatter wrong use of color

### DIFF
--- a/lib/ansiblelint/color.py
+++ b/lib/ansiblelint/color.py
@@ -13,6 +13,6 @@ class Color(Enum):
     line = "0;35"  # purple
 
 
-def colorize(text: str, color: Color):
+def colorize(text: str, color: Color) -> str:
     """Return ANSI formated string."""
     return f"\u001b[{color.value}m{text}\u001b[{Color.reset.value}m"

--- a/lib/ansiblelint/formatters/__init__.py
+++ b/lib/ansiblelint/formatters/__init__.py
@@ -99,11 +99,11 @@ class ParseableSeverityFormatter(BaseFormatter):
         message = str(match.message)
 
         if colored:
-            filename = colorize(filename, 'blue')
-            linenumber = colorize(linenumber, 'cyan')
-            rule_id = colorize(rule_id, 'bright red')
-            severity = colorize(severity, 'bright red')
-            message = colorize(message, 'red')
+            filename = colorize(filename, Color.filename)
+            linenumber = colorize(linenumber, Color.linenumber)
+            rule_id = colorize(rule_id, Color.error_code)
+            severity = colorize(severity, Color.error_code)
+            message = colorize(message, Color.error_title)
 
         return formatstr.format(
             filename,


### PR DESCRIPTION
Fix bug where severity formatter was passing strings to colorize() instead of Color enum.