### PR TITLE
Enable xdist when running tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -10,7 +10,6 @@ addopts =
     # --testmon
 
     --durations=10
-    -v
     -ra
     --showlocals
     --doctest-modules

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,8 @@ commands =
   {envpython} -m pytest \
   --cov "{envsitepackagesdir}/ansiblelint" \
   --junitxml "{toxworkdir}/junit.{envname}.xml" \
-  {posargs:}
+  # -n auto kept as default to avoid it when running tox with posargs
+  {posargs:-n auto}
 install_command =
   {envpython} -m \
     pip install \


### PR DESCRIPTION
- removes hardocde verbose mode from pytest.ini as it does not
  produce desirable effects with parallel run
- enables "-n auto" mode on CI as we do not want to enforce developers
  to run with parallel mode.

Fixes: #678