### PR TITLE
Make run_ansible_lint reusable across tests

### DIFF
--- a/test/TestCliRolePaths.py
+++ b/test/TestCliRolePaths.py
@@ -1,35 +1,18 @@
 import os
-import subprocess
-import sys
 import unittest
+
+from . import run_ansible_lint
 
 
 class TestCliRolePaths(unittest.TestCase):
     def setUp(self):
         self.local_test_dir = os.path.dirname(os.path.realpath(__file__))
 
-    def run_ansible_lint(self, cwd, role_path=None, bin=None, env=None):
-        command = '{} -v {}'.format(
-            bin or (sys.executable + " -m ansiblelint"),
-            role_path or "")
-
-        result, err = subprocess.Popen(
-            [command],
-            cwd=cwd,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            shell=True,
-            env=env,
-        ).communicate()
-
-        return result
-
     def test_run_single_role_path_no_trailing_slash_module(self):
         cwd = self.local_test_dir
         role_path = 'test-role'
 
-        result = self.run_ansible_lint(cwd=cwd, role_path=role_path)
+        result = run_ansible_lint(cwd=cwd, role_path=role_path)
         self.assertIn('Use shell only when shell functionality is required',
                       str(result))
 
@@ -37,7 +20,7 @@ class TestCliRolePaths(unittest.TestCase):
         cwd = self.local_test_dir
         role_path = 'test-role'
 
-        result = self.run_ansible_lint(cwd=cwd, role_path=role_path, bin="ansible-lint")
+        result = run_ansible_lint(cwd=cwd, role_path=role_path, bin="ansible-lint")
         self.assertIn('Use shell only when shell functionality is required',
                       str(result))
 
@@ -45,7 +28,7 @@ class TestCliRolePaths(unittest.TestCase):
         cwd = self.local_test_dir
         role_path = 'test-role/'
 
-        result = self.run_ansible_lint(cwd=cwd, role_path=role_path)
+        result = run_ansible_lint(cwd=cwd, role_path=role_path)
         self.assertIn('Use shell only when shell functionality is required',
                       str(result))
 
@@ -53,7 +36,7 @@ class TestCliRolePaths(unittest.TestCase):
         cwd = self.local_test_dir
         role_path = 'roles/test-role'
 
-        result = self.run_ansible_lint(cwd=cwd, role_path=role_path)
+        result = run_ansible_lint(cwd=cwd, role_path=role_path)
         self.assertIn('Use shell only when shell functionality is required',
                       str(result))
 
@@ -61,7 +44,7 @@ class TestCliRolePaths(unittest.TestCase):
         cwd = self.local_test_dir
         role_path = 'roles/test-role/'
 
-        result = self.run_ansible_lint(cwd=cwd, role_path=role_path)
+        result = run_ansible_lint(cwd=cwd, role_path=role_path)
         self.assertIn('Use shell only when shell functionality is required',
                       str(result))
 
@@ -69,7 +52,7 @@ class TestCliRolePaths(unittest.TestCase):
         cwd = os.path.join(self.local_test_dir, 'test-role/')
         role_path = '.'
 
-        result = self.run_ansible_lint(cwd=cwd, role_path=role_path)
+        result = run_ansible_lint(cwd=cwd, role_path=role_path)
         self.assertIn('Use shell only when shell functionality is required',
                       str(result))
 
@@ -77,7 +60,7 @@ class TestCliRolePaths(unittest.TestCase):
         cwd = self.local_test_dir
         role_path = 'testproject/roles/test-role'
 
-        result = self.run_ansible_lint(cwd=cwd, role_path=role_path)
+        result = run_ansible_lint(cwd=cwd, role_path=role_path)
         self.assertIn('Use shell only when shell functionality is required',
                       str(result))
 
@@ -90,12 +73,12 @@ class TestCliRolePaths(unittest.TestCase):
         env = os.environ.copy()
         env['ANSIBLE_ROLES_PATH'] = os.path.dirname(cwd)
 
-        result = self.run_ansible_lint(cwd=cwd, role_path=role_path, env=env)
+        result = run_ansible_lint(cwd=cwd, role_path=role_path, env=env)
         self.assertIn('Use shell only when shell functionality is required', str(result))
 
     def test_run_role_name_invalid(self):
         cwd = self.local_test_dir
         role_path = 'roles/invalid-name'
 
-        result = self.run_ansible_lint(cwd=cwd, role_path=role_path)
+        result = run_ansible_lint(cwd=cwd, role_path=role_path)
         assert '106 Role name invalid-name does not match' in str(result)

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -2,6 +2,8 @@
 
 import os
 import shutil
+import subprocess
+import sys
 import tempfile
 
 from ansible import __version__ as ansible_version_str
@@ -49,3 +51,22 @@ class RunFromText(object):
         results = self._call_runner(role_path)
         shutil.rmtree(role_path)
         return results
+
+
+def run_ansible_lint(cwd, role_path=None, bin=None, env=None):
+    """Run ansible-lint on a given path and returns its output."""
+    command = '{} -v {}'.format(
+        bin or (sys.executable + " -m ansiblelint"),
+        role_path or "")
+
+    result, err = subprocess.Popen(
+        [command],
+        cwd=cwd,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        shell=True,
+        env=env,
+    ).communicate()
+
+    return result


### PR DESCRIPTION
Moves implementation of run_ansible_lint function to root module of
tests in order to make it easy to reuse.

Related: #926