### PR TITLE
refactor: reduce complexity in main function

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -52,7 +52,6 @@ per-file-ignores =
   # FIXME: drop these once they're made simpler
   # Ref: https://github.com/ansible/ansible-lint/issues/744
   # lib/ansiblelint/__main__.py:32:1: C901 'main' is too complex (13)
-  lib/ansiblelint/__main__.py: C901
   lib/ansiblelint/cli.py: D101 D102 D103
   lib/ansiblelint/formatters/__init__.py: D101 D102
   lib/ansiblelint/utils.py: D103

--- a/.flake8
+++ b/.flake8
@@ -51,7 +51,8 @@ per-file-ignores =
   # FIXME: D103 Missing docstring in public function
   # FIXME: drop these once they're made simpler
   # Ref: https://github.com/ansible/ansible-lint/issues/744
-  # lib/ansiblelint/__main__.py:32:1: C901 'main' is too complex (13)
+  # lib/ansiblelint/__main__.py:32:1: C901 'main' is too complex (12)
+  lib/ansiblelint/__main__.py: C901
   lib/ansiblelint/cli.py: D101 D102 D103
   lib/ansiblelint/formatters/__init__.py: D101 D102
   lib/ansiblelint/utils.py: D103

--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -60,7 +60,7 @@ def initialize_logger(level: int = 0) -> None:
 
 
 def initalize_formatter_factory(options_list: Namespace):
-    """Apply options from command line arguments to the formatter_factory."""
+    """Select an output formatter based on the incoming command line arguments."""
     formatter_factory: Any = formatters.Formatter
     if options_list.quiet:
         formatter_factory = formatters.QuietFormatter

--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -82,7 +82,7 @@ def main() -> int:
     initialize_logger(options.verbosity)
     _logger.debug("Options: %s", options)
 
-    formatter_factory = initalize_formatter_factory(options)
+    formatter_factory = choose_formatter_factory(options)
     formatter = formatter_factory(cwd, options.display_relative_path)
 
     if options.use_default_rules:

--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -61,7 +61,7 @@ def initialize_logger(level: int = 0) -> None:
 
 def choose_formatter_factory(options_list: Namespace) -> Type[formatters.BaseFormatter]:
     """Select an output formatter based on the incoming command line arguments."""
-    formatter_factory: Any = formatters.Formatter
+    formatter_factory = formatters.Formatter
     if options_list.quiet:
         formatter_factory = formatters.QuietFormatter
 

--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -59,7 +59,7 @@ def initialize_logger(level: int = 0) -> None:
     _logger.debug("Logging initialized to level %s", logging_level)
 
 
-def initalize_formatter_factory(options_list: Namespace):
+def choose_formatter_factory(options_list: Namespace) -> Type[formatters.BaseFormatter]:
     """Select an output formatter based on the incoming command line arguments."""
     formatter_factory: Any = formatters.Formatter
     if options_list.quiet:

--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -24,8 +24,10 @@ import errno
 import logging
 import pathlib
 import sys
-from argparse import Namespace
-from typing import Any, Set
+from typing import Any, Set, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from argparse import Namespace
 
 from ansiblelint import cli, formatters
 from ansiblelint.constants import DEFAULT_RULESDIR

--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -24,7 +24,7 @@ import errno
 import logging
 import pathlib
 import sys
-from typing import TYPE_CHECKING, Set, Type, Union
+from typing import TYPE_CHECKING, Set, Type
 
 from ansiblelint import cli, formatters
 from ansiblelint.constants import DEFAULT_RULESDIR
@@ -61,17 +61,16 @@ def initialize_logger(level: int = 0) -> None:
 
 def choose_formatter_factory(
     options_list: "Namespace"
-) -> Union[Type[formatters.Formatter], Type[formatters.QuietFormatter],
-           Type[formatters.ParseableFormatter],
-           Type[formatters.ParseableSeverityFormatter]]:
+) -> Type[formatters.BaseFormatter]:
     """Select an output formatter based on the incoming command line arguments."""
+    r: Type[formatters.BaseFormatter] = formatters.Formatter
     if options_list.quiet:
-        return formatters.QuietFormatter
+        r = formatters.QuietFormatter
     elif options_list.parseable:
-        return formatters.ParseableFormatter
+        r = formatters.ParseableFormatter
     elif options_list.parseable_severity:
-        return formatters.ParseableSeverityFormatter
-    return formatters.Formatter
+        r = formatters.ParseableSeverityFormatter
+    return r
 
 
 def main() -> int:

--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -19,6 +19,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 """Command line implementation."""
+
 import errno
 import logging
 import pathlib
@@ -40,7 +41,11 @@ _logger = logging.getLogger(__name__)
 
 def initialize_logger(level: int = 0) -> None:
     """Set up the global logging level based on the verbosity number."""
-    VERBOSITY_MAP = {0: logging.NOTSET, 1: logging.INFO, 2: logging.DEBUG}
+    VERBOSITY_MAP = {
+        0: logging.NOTSET,
+        1: logging.INFO,
+        2: logging.DEBUG
+    }
 
     handler = logging.StreamHandler()
     formatter = logging.Formatter('%(levelname)-8s %(message)s')
@@ -88,8 +93,7 @@ def main() -> int:
     rules = RulesCollection(rulesdirs)
 
     if options.listrules:
-        formatted_rules = rules if options.format == 'plain' else rules_as_rst(
-            rules)
+        formatted_rules = rules if options.format == 'plain' else rules_as_rst(rules)
         print(formatted_rules)
         return 0
 
@@ -114,9 +118,9 @@ def main() -> int:
     matches = list()
     checked_files: Set[str] = set()
     for playbook in playbooks:
-        runner = Runner(rules, playbook, options.tags, options.skip_list,
-                        options.exclude_paths, options.verbosity,
-                        checked_files)
+        runner = Runner(rules, playbook, options.tags,
+                        options.skip_list, options.exclude_paths,
+                        options.verbosity, checked_files)
         matches.extend(runner.run())
 
     for match in sorted(set(matches)):

--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -24,6 +24,7 @@ import errno
 import logging
 import pathlib
 import sys
+from argparse import Namespace
 from typing import Any, Set
 
 from ansiblelint import cli, formatters
@@ -56,6 +57,20 @@ def initialize_logger(level: int = 0) -> None:
     _logger.debug("Logging initialized to level %s", logging_level)
 
 
+def initalize_formatter_factory(options_list: Namespace):
+    """Apply options from command line arguments to the formatter_factory."""
+    formatter_factory: Any = formatters.Formatter
+    if options_list.quiet:
+        formatter_factory = formatters.QuietFormatter
+
+    if options_list.parseable:
+        formatter_factory = formatters.ParseableFormatter
+
+    if options_list.parseable_severity:
+        formatter_factory = formatters.ParseableSeverityFormatter
+    return formatter_factory
+
+
 def main() -> int:
     """Linter CLI entry point."""
     cwd = pathlib.Path.cwd()
@@ -65,16 +80,7 @@ def main() -> int:
     initialize_logger(options.verbosity)
     _logger.debug("Options: %s", options)
 
-    formatter_factory: Any = formatters.Formatter
-    if options.quiet:
-        formatter_factory = formatters.QuietFormatter
-
-    if options.parseable:
-        formatter_factory = formatters.ParseableFormatter
-
-    if options.parseable_severity:
-        formatter_factory = formatters.ParseableSeverityFormatter
-
+    formatter_factory = initalize_formatter_factory(options)
     formatter = formatter_factory(cwd, options.display_relative_path)
 
     if options.use_default_rules:

--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -24,7 +24,7 @@ import errno
 import logging
 import pathlib
 import sys
-from typing import Any, Set, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Set
 
 if TYPE_CHECKING:
     from argparse import Namespace

--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -24,7 +24,7 @@ import errno
 import logging
 import pathlib
 import sys
-from typing import TYPE_CHECKING, Any, Set
+from typing import TYPE_CHECKING, Set, Type
 
 if TYPE_CHECKING:
     from argparse import Namespace
@@ -59,7 +59,7 @@ def initialize_logger(level: int = 0) -> None:
     _logger.debug("Logging initialized to level %s", logging_level)
 
 
-def choose_formatter_factory(options_list: Namespace) -> Type[formatters.BaseFormatter]:
+def choose_formatter_factory(options_list: "Namespace") -> Type[formatters.BaseFormatter]:
     """Select an output formatter based on the incoming command line arguments."""
     formatter_factory = formatters.Formatter
     if options_list.quiet:

--- a/lib/ansiblelint/formatters/__init__.py
+++ b/lib/ansiblelint/formatters/__init__.py
@@ -1,15 +1,17 @@
 """Output formatters."""
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Generic, TypeVar, Union
 
 from ansiblelint.color import Color, colorize
 
 if TYPE_CHECKING:
     from ansiblelint.errors import MatchError
 
+T = TypeVar('T', bound='BaseFormatter')
 
-class BaseFormatter:
+
+class BaseFormatter(Generic[T]):
     """Formatter of ansible-lint output.
 
     Base class for output formatters.
@@ -41,6 +43,9 @@ class BaseFormatter:
             return path
         # Use os.path.relpath 'cause Path.relative_to() misbehaves
         return os.path.relpath(path, start=self._base_dir)
+
+    def format(self, match: "MatchError", colored: bool = False) -> str:
+        return str(match)
 
 
 class Formatter(BaseFormatter):


### PR DESCRIPTION
Ref #931 - Refactor main function to reduce branching complexity ( and 
thus  quiet flake8 ) by moving the formatter_factory into a separate function.
Import argparse.Namespace for mypy static check requirement.

Signed-off-by: Daniel Pendolino <daniel@counterhack.com>