### PR TITLE
Make pre-commit hook use auto-detect mode

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -6,7 +6,7 @@
 -   id: ansible-lint
     name: Ansible-lint
     description: This hook runs ansible-lint.
-    entry: ansible-lint --force-color .
+    entry: ansible-lint --force-color
     language: python
     # do not pass files to ansible-lint, see:
     # https://github.com/ansible/ansible-lint/issues/611


### PR DESCRIPTION
Switches hook configuration to make use of auto-detection mode
instead of feeding the current directory as a parameter.

Fixes: #649