### PR TITLE
Prefer pylint instead over unittest

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,3 +1,7 @@
+[IMPORTS]
+preferred-modules =
+    unittest:pytest,
+
 [MESSAGES CONTROL]
 
 disable =

--- a/test/TestAlwaysRunRule.py
+++ b/test/TestAlwaysRunRule.py
@@ -1,3 +1,4 @@
+# pylint: disable=preferred-module  # FIXME: remove once migrated per GH-725
 import unittest
 
 from ansiblelint.rules import RulesCollection

--- a/test/TestBecomeUserWithoutBecome.py
+++ b/test/TestBecomeUserWithoutBecome.py
@@ -1,3 +1,4 @@
+# pylint: disable=preferred-module  # FIXME: remove once migrated per GH-725
 import unittest
 
 from ansiblelint.rules import RulesCollection

--- a/test/TestCliRolePaths.py
+++ b/test/TestCliRolePaths.py
@@ -1,3 +1,4 @@
+# pylint: disable=preferred-module  # FIXME: remove once migrated per GH-725
 import os
 import unittest
 from pathlib import Path

--- a/test/TestCommandHasChangesCheck.py
+++ b/test/TestCommandHasChangesCheck.py
@@ -1,3 +1,4 @@
+# pylint: disable=preferred-module  # FIXME: remove once migrated per GH-725
 import unittest
 
 from ansiblelint.rules import RulesCollection

--- a/test/TestComparisonToEmptyString.py
+++ b/test/TestComparisonToEmptyString.py
@@ -1,3 +1,4 @@
+# pylint: disable=preferred-module  # FIXME: remove once migrated per GH-725
 import unittest
 
 from ansiblelint.rules import RulesCollection

--- a/test/TestComparisonToLiteralBool.py
+++ b/test/TestComparisonToLiteralBool.py
@@ -1,3 +1,4 @@
+# pylint: disable=preferred-module  # FIXME: remove once migrated per GH-725
 import unittest
 
 from ansiblelint.rules import RulesCollection

--- a/test/TestDeprecatedModule.py
+++ b/test/TestDeprecatedModule.py
@@ -1,3 +1,4 @@
+# pylint: disable=preferred-module  # FIXME: remove once migrated per GH-725
 import unittest
 
 import pytest

--- a/test/TestEnvVarsInCommand.py
+++ b/test/TestEnvVarsInCommand.py
@@ -1,3 +1,4 @@
+# pylint: disable=preferred-module  # FIXME: remove once migrated per GH-725
 import unittest
 
 from ansiblelint.rules import RulesCollection

--- a/test/TestFormatter.py
+++ b/test/TestFormatter.py
@@ -17,6 +17,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
+# pylint: disable=preferred-module  # FIXME: remove once migrated per GH-725
 import pathlib
 import unittest
 

--- a/test/TestLineTooLong.py
+++ b/test/TestLineTooLong.py
@@ -1,3 +1,4 @@
+# pylint: disable=preferred-module  # FIXME: remove once migrated per GH-725
 import unittest
 
 from ansiblelint.rules import RulesCollection

--- a/test/TestLintRule.py
+++ b/test/TestLintRule.py
@@ -18,6 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+# pylint: disable=preferred-module  # FIXME: remove once migrated per GH-725
 import unittest
 
 from .rules import EMatcherRule, UnsetVariableMatcherRule

--- a/test/TestMetaChangeFromDefault.py
+++ b/test/TestMetaChangeFromDefault.py
@@ -1,3 +1,4 @@
+# pylint: disable=preferred-module  # FIXME: remove once migrated per GH-725
 import unittest
 
 from ansiblelint.rules import RulesCollection

--- a/test/TestMetaMainHasInfo.py
+++ b/test/TestMetaMainHasInfo.py
@@ -1,3 +1,4 @@
+# pylint: disable=preferred-module  # FIXME: remove once migrated per GH-725
 import unittest
 
 from ansiblelint.rules import RulesCollection

--- a/test/TestMetaVideoLinks.py
+++ b/test/TestMetaVideoLinks.py
@@ -1,3 +1,4 @@
+# pylint: disable=preferred-module  # FIXME: remove once migrated per GH-725
 import unittest
 
 from ansiblelint.rules import RulesCollection

--- a/test/TestNoFormattingInWhenRule.py
+++ b/test/TestNoFormattingInWhenRule.py
@@ -1,3 +1,4 @@
+# pylint: disable=preferred-module  # FIXME: remove once migrated per GH-725
 import unittest
 
 from ansiblelint.rules import RulesCollection

--- a/test/TestOctalPermissions.py
+++ b/test/TestOctalPermissions.py
@@ -1,3 +1,4 @@
+# pylint: disable=preferred-module  # FIXME: remove once migrated per GH-725
 import unittest
 
 from ansiblelint.rules import RulesCollection

--- a/test/TestPackageIsNotLatest.py
+++ b/test/TestPackageIsNotLatest.py
@@ -1,3 +1,4 @@
+# pylint: disable=preferred-module  # FIXME: remove once migrated per GH-725
 import unittest
 
 from ansiblelint.rules import RulesCollection

--- a/test/TestRoleHandlers.py
+++ b/test/TestRoleHandlers.py
@@ -1,3 +1,4 @@
+# pylint: disable=preferred-module  # FIXME: remove once migrated per GH-725
 import unittest
 
 from ansiblelint.rules import RulesCollection

--- a/test/TestRoleRelativePath.py
+++ b/test/TestRoleRelativePath.py
@@ -1,3 +1,4 @@
+# pylint: disable=preferred-module  # FIXME: remove once migrated per GH-725
 import unittest
 
 from ansiblelint.rules import RulesCollection

--- a/test/TestShellWithoutPipefail.py
+++ b/test/TestShellWithoutPipefail.py
@@ -1,3 +1,4 @@
+# pylint: disable=preferred-module  # FIXME: remove once migrated per GH-725
 import unittest
 
 from ansiblelint.rules import RulesCollection

--- a/test/TestSudoRule.py
+++ b/test/TestSudoRule.py
@@ -1,3 +1,4 @@
+# pylint: disable=preferred-module  # FIXME: remove once migrated per GH-725
 import unittest
 
 from ansiblelint.rules import RulesCollection

--- a/test/TestTaskHasName.py
+++ b/test/TestTaskHasName.py
@@ -1,3 +1,4 @@
+# pylint: disable=preferred-module  # FIXME: remove once migrated per GH-725
 import unittest
 
 from ansiblelint.rules import RulesCollection

--- a/test/TestTaskNoLocalAction.py
+++ b/test/TestTaskNoLocalAction.py
@@ -1,3 +1,4 @@
+# pylint: disable=preferred-module  # FIXME: remove once migrated per GH-725
 import unittest
 
 from ansiblelint.rules import RulesCollection

--- a/test/TestUseCommandInsteadOfShell.py
+++ b/test/TestUseCommandInsteadOfShell.py
@@ -1,3 +1,4 @@
+# pylint: disable=preferred-module  # FIXME: remove once migrated per GH-725
 import unittest
 
 from ansiblelint.rules import RulesCollection

--- a/test/TestUseHandlerRatherThanWhenChanged.py
+++ b/test/TestUseHandlerRatherThanWhenChanged.py
@@ -1,3 +1,4 @@
+# pylint: disable=preferred-module  # FIXME: remove once migrated per GH-725
 import unittest
 
 from ansiblelint.rules import RulesCollection

--- a/test/TestUsingBareVariablesIsDeprecated.py
+++ b/test/TestUsingBareVariablesIsDeprecated.py
@@ -1,3 +1,4 @@
+# pylint: disable=preferred-module  # FIXME: remove once migrated per GH-725
 import unittest
 
 from ansiblelint.rules import RulesCollection

--- a/test/TestVariableHasSpaces.py
+++ b/test/TestVariableHasSpaces.py
@@ -1,3 +1,4 @@
+# pylint: disable=preferred-module  # FIXME: remove once migrated per GH-725
 import unittest
 
 from ansiblelint.rules import RulesCollection

--- a/test/TestWithSkipTagId.py
+++ b/test/TestWithSkipTagId.py
@@ -1,3 +1,4 @@
+# pylint: disable=preferred-module  # FIXME: remove once migrated per GH-725
 import unittest
 
 from ansiblelint.rules import RulesCollection


### PR DESCRIPTION
This change supports the goal of #725 to improve the pytest
compatibility of the existing tests and enforce it in the new tests.