### PR TITLE
E208: Improve MissingFilePermissionsRule detection

### DIFF
--- a/lib/ansiblelint/rules/MissingFilePermissionsRule.py
+++ b/lib/ansiblelint/rules/MissingFilePermissionsRule.py
@@ -48,5 +48,8 @@ class MissingFilePermissionsRule(AnsibleLintRule):
         if task["action"]["__ansible_module__"] not in self._modules:
             return False
 
+        if task['action'].get('state', None) == "absent":
+            return False
+
         mode = task['action'].get('mode', None)
-        return not isinstance(mode, str)
+        return mode is None

--- a/test/TestMissingFilePermissionsRule.py
+++ b/test/TestMissingFilePermissionsRule.py
@@ -26,10 +26,18 @@ SUCCESS_TASKS = '''
 ---
 - hosts: hosts
   tasks:
-    - name: permissions not missing
+    - name: permissions not missing and string
       file:
         path: foo
         mode: preserve
+    - name: permissions not missing and numeric
+      file:
+        path: foo
+        mode: 0600
+    - name: permissions missing while state is absent is fine
+      file:
+        path: foo
+        state: absent
 '''
 
 FAIL_TASKS = '''


### PR DESCRIPTION
Improve [rule 208](https://github.com/ansible/ansible-lint/pull/943) by avoiding to trigger it when `state: absent` is found or when any mode is present. This fixed bug where rule was triggered when mode was numeric.