### PR TITLE
Reorganize test requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -78,6 +78,14 @@ install_requires =
   # NOTE: per issue #509 0.15.34 included in debian backports
   typing-extensions; python_version < "3.8"
 
+[options.extras_require]
+test =
+  pytest >= 6.0.1
+  pytest-cov >= 2.10.1
+  pytest-xdist >= 2.1.0
+  # Needed to avoid DeprecationWarning errors in pytest:
+  setuptools >= 49.6.0
+
 [options.entry_points]
 console_scripts =
   ansible-lint = ansiblelint.__main__:main

--- a/tox.ini
+++ b/tox.ini
@@ -20,15 +20,8 @@ deps =
   # https://github.com/ansible/ansible/issues/70705
   ansibledevel: ansible>=2.10.0a1,<2.11
   ansibledevel: ansible-base @ git+https://github.com/ansible/ansible.git
-  ruamel.yaml==0.16.5  # NOTE: 0.15.34 has issues with py37
-  flake8
-  pep8-naming
-  pytest
-  pytest-cov
-  pytest-xdist
-  # Needed to avoid DeprecationWarning errors in pytest:
-  setuptools >= 40.4.3
-  wheel
+extras =
+  test
 commands =
   # safety measure to assure we do not accidentaly run tests with broken dependencies
   python -m pip check


### PR DESCRIPTION
- Move test requirements from tox.ini to a test extra
- Removes unused test requirements
- Bumps test requirements to decrease change of running outdated
  version while developing. Avoids  https://github.com/pytest-dev/pytest-cov/issues/422

This enables running of tests w/o tox, with just `pip install -e .[test]` or similar, something that was not possible before.

Update: Please check https://discuss.python.org/t/is-it-preferable-to-add-test-dependensies-as-an-extra-require-instead-of-tox-ini/4984 thread if you have doubts if this approach may not be good.