### PR TITLE
E501: Add become_user and become inheritance

### DIFF
--- a/lib/ansiblelint/rules/BecomeUserWithoutBecomeRule.py
+++ b/lib/ansiblelint/rules/BecomeUserWithoutBecomeRule.py
@@ -19,10 +19,50 @@
 # THE SOFTWARE.
 
 from ansiblelint.rules import AnsibleLintRule
+from functools import reduce
 
 
-def _become_user_without_become(data):
-    return 'become_user' in data and 'become' not in data
+def _get_subtasks(data):
+    result = []
+    block_names = [
+            'tasks',
+            'pre_tasks',
+            'post_tasks',
+            'handlers',
+            'block',
+            'always',
+            'rescue']
+    for name in block_names:
+        if name in data:
+            result += (data[name] or [])
+    return result
+
+
+def _nested_search(term, data):
+    return ((term in data) or
+            reduce((lambda x, y: x or _nested_search(term, y)), _get_subtasks(data), False))
+
+
+def _become_user_without_become(becomeuserabove, data):
+    if 'become' in data:
+        # If become is in lineage of tree then correct
+        return False
+    if ('become_user' in data and _nested_search('become', data)):
+        # If 'become_user' on tree and become somewhere below
+        # we must check for a case of a second 'become_user' without a
+        # 'become' in its lineage
+        subtasks = _get_subtasks(data)
+        return (reduce((lambda x, y: x or _become_user_without_become(False, y)), subtasks, False))
+    if _nested_search('become_user', data):
+        # Keep searching down if 'become_user' exists in the tree below current task
+        subtasks = _get_subtasks(data)
+        return (len(subtasks) == 0 or
+                reduce((lambda x, y: x or
+                        _become_user_without_become(
+                            becomeuserabove or 'become_user' in data, y)), subtasks, False))
+    # If at bottom of tree, flag up if 'become_user' existed in the lineage of the tree and
+    # 'become' was not. This is an error if any lineage has a 'become_user' but no become
+    return becomeuserabove
 
 
 class BecomeUserWithoutBecomeRule(AnsibleLintRule):
@@ -34,8 +74,5 @@ class BecomeUserWithoutBecomeRule(AnsibleLintRule):
     version_added = 'historic'
 
     def matchplay(self, file, data):
-        if file['type'] == 'playbook' and _become_user_without_become(data):
+        if file['type'] == 'playbook' and _become_user_without_become(False, data):
             return ({'become_user': data}, self.shortdesc)
-
-    def matchtask(self, file, task):
-        return _become_user_without_become(task)

--- a/lib/ansiblelint/rules/BecomeUserWithoutBecomeRule.py
+++ b/lib/ansiblelint/rules/BecomeUserWithoutBecomeRule.py
@@ -18,8 +18,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from ansiblelint.rules import AnsibleLintRule
 from functools import reduce
+
+from ansiblelint.rules import AnsibleLintRule
 
 
 def _get_subtasks(data):
@@ -52,7 +53,7 @@ def _become_user_without_become(becomeuserabove, data):
         # we must check for a case of a second 'become_user' without a
         # 'become' in its lineage
         subtasks = _get_subtasks(data)
-        return (reduce((lambda x, y: x or _become_user_without_become(False, y)), subtasks, False))
+        return reduce((lambda x, y: x or _become_user_without_become(False, y)), subtasks, False)
     if _nested_search('become_user', data):
         # Keep searching down if 'become_user' exists in the tree below current task
         subtasks = _get_subtasks(data)

--- a/test/TestSkipInsideYaml.py
+++ b/test/TestSkipInsideYaml.py
@@ -108,13 +108,7 @@ def test_role_tasks_with_block(default_text_runner):
     ('playbook_src', 'results_num'),
     (
         (PLAYBOOK, 7),
-        pytest.param(
-            ROLE_TASKS_WITH_BLOCK_BECOME, 0,
-            marks=pytest.mark.xfail(
-                reason="Bug: "
-                "https://github.com/ansible/ansible-lint/issues/705",
-            ),
-        ),
+        (ROLE_TASKS_WITH_BLOCK_BECOME, 0),
     ),
     ids=('generic', 'with block become inheritance'),
 )

--- a/test/become-user-without-become-failure.yml
+++ b/test/become-user-without-become-failure.yml
@@ -14,9 +14,13 @@
     become_user: postgres
 
 - hosts: localhost
-  become: true
 
   tasks:
-  - name: won't work, needs to be explicit
-    command: whoami
-    become_user: postgres
+  - name: a block with become and become_user on different tasks
+    block:
+    - name: become
+      become: true
+      command: whoami
+    - name: become_user
+      become_user: postgres
+      command: whoami

--- a/test/become-user-without-become-success.yml
+++ b/test/become-user-without-become-success.yml
@@ -12,3 +12,19 @@
   - command: whoami
     become_user: postgres
     become: true
+
+- hosts: localhost
+  become: true
+
+  tasks:
+  - name: Accepts a become from higher scope
+    command: whoami
+    become_user: postgres
+
+- hosts: localhost
+  become_user: postgres
+
+  tasks:
+  - name: Accepts a become from a lower scope
+    command: whoami
+    become: true


### PR DESCRIPTION
Fixes #705 

Changed the function for checking if `become` is used when `become_user` is used to check beyond just the individual task. Instead the tree of tasks/blocks etc. is now traversed and relevant decisions made as to whether there is an error or not. 

I have added a couple of tests in to check for correctness.

It's my first time contributing to this, so if I've missed anything let me know!