### PR TITLE
Indicate how to skip rules on failures

### DIFF
--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -25,7 +25,10 @@ import logging
 import os
 import pathlib
 import sys
-from typing import TYPE_CHECKING, Set, Type
+from typing import TYPE_CHECKING, List, Set, Type
+
+from rich.console import Console
+from rich.markdown import Markdown
 
 from ansiblelint import cli, formatters
 from ansiblelint.constants import DEFAULT_RULESDIR
@@ -37,7 +40,10 @@ from ansiblelint.utils import get_playbooks_and_roles
 if TYPE_CHECKING:
     from argparse import Namespace
 
+    from ansiblelint.errors import MatchError
+
 _logger = logging.getLogger(__name__)
+console = Console()
 
 
 def initialize_logger(level: int = 0) -> None:
@@ -72,6 +78,21 @@ def choose_formatter_factory(
     elif options_list.parseable_severity:
         r = formatters.ParseableSeverityFormatter
     return r
+
+
+def hint_about_skips(matches: List["MatchError"]):
+    """Display information about how to skip found rules."""
+    msg = """\
+If you would prefer to skip some rules, then use the following configuration:
+```yaml
+# .ansible-lint
+skip_list:
+"""
+    matched_rules = {match.rule.id: match.rule.shortdesc for match in matches}
+    for id in sorted(matched_rules.keys()):
+        msg += f"  - '{id}'  # {matched_rules[id]}'\n"
+    msg += "```"
+    console.print(Markdown(msg))
 
 
 def main() -> int:
@@ -136,6 +157,7 @@ def main() -> int:
             print(formatter.format(match))
 
     if matches:
+        hint_about_skips(matches)
         return 2
     else:
         return 0

--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -83,7 +83,7 @@ def choose_formatter_factory(
 def hint_about_skips(matches: List["MatchError"]):
     """Display information about how to skip found rules."""
     msg = """\
-If you would prefer to skip some rules, then use the following configuration:
+You can skip specific rules by adding them to the skip_list section of your configuration file:
 ```yaml
 # .ansible-lint
 skip_list:

--- a/mypy.ini
+++ b/mypy.ini
@@ -27,6 +27,9 @@ ignore_missing_imports = True
 [mypy-importlib_metadata]
 ignore_missing_imports = True
 
+[mypy-rich.*]
+ignore_missing_imports = True
+
 [mypy-ruamel.*]
 ignore_missing_imports = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,6 +72,7 @@ setup_requires =
 install_requires =
   ansible >= 2.8
   pyyaml
+  rich
   ruamel.yaml >= 0.15.34,<1; python_version < "3.7"
   ruamel.yaml >= 0.15.37,<1; python_version >= "3.7"
   # NOTE: per issue #509 0.15.34 included in debian backports


### PR DESCRIPTION
Make it easier for users to disable rules that they do not find fit by displaying a sample configuration file after the execution.

![example-output](https://sbarnea.com/ss/Screen-Shot-2020-08-18-20-09-25.png)

Note that his change adds [rich](https://github.com/willmcgugan/rich) library as a dependency as we also plan to use it for improve terminal output in other areas like rule listing or more detailed explanation about why a rule was added (#936). Library is MIT and under good maintenance.