### PR TITLE
E106: Role name should be the parent dir of tasks

### DIFF
--- a/lib/ansiblelint/rules/RoleNames.py
+++ b/lib/ansiblelint/rules/RoleNames.py
@@ -48,8 +48,8 @@ class RoleNames(AnsibleLintRule):
     def match(self, file, text):
 
         path = file['path'].split("/")
-        if "roles" in path:
-            role_name = path[path.index("roles") + 1]
+        if "tasks" in path:
+            role_name = path[path.index("tasks") - 1]
             if role_name in self.done:
                 return False
             self.done.append(role_name)


### PR DESCRIPTION
For E106: Identify the rolename as the parent directory of tasks.

The `roles` directory is not reliable since it can be overridden with
`roles_path`. On the other hand, a role always have a `tasks`
subdirectory.