### PR TITLE
E208: Do not trigger on symlinks

### DIFF
--- a/lib/ansiblelint/rules/MissingFilePermissionsRule.py
+++ b/lib/ansiblelint/rules/MissingFilePermissionsRule.py
@@ -51,5 +51,8 @@ class MissingFilePermissionsRule(AnsibleLintRule):
         if task['action'].get('state', None) == "absent":
             return False
 
+        if task['action'].get('state', None) == "link":
+            return False
+
         mode = task['action'].get('mode', None)
         return mode is None

--- a/test/TestMissingFilePermissionsRule.py
+++ b/test/TestMissingFilePermissionsRule.py
@@ -38,6 +38,11 @@ SUCCESS_TASKS = '''
       file:
         path: foo
         state: absent
+    - name: permissions missing while state is link is fine
+      file:
+        path: foo2
+        src: foo
+        state: link
 '''
 
 FAIL_TASKS = '''


### PR DESCRIPTION
Improve rule 208 by avoiding a trigger when `state: link` is found. 

Fixes: #981.
Fixes: #994