### PR TITLE
Add ability to only warn about some rules

### DIFF
--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -79,19 +79,31 @@ def choose_formatter_factory(
     return r
 
 
-def hint_about_skips(matches: List["MatchError"]):
-    """Display information about how to skip found rules."""
+def report_outcome(matches: List["MatchError"], options) -> int:
+    """Display information about how to skip found rules.
+
+    Returns exit code, 2 if erros were found, 0 when only warnings were found.
+    """
+    failure = False
     msg = """\
 You can skip specific rules by adding them to the skip_list section of your configuration file:
 ```yaml
 # .ansible-lint
-skip_list:
+warn_list:  # or 'skip_list' to silence them completely
 """
     matched_rules = {match.rule.id: match.rule.shortdesc for match in matches}
     for id in sorted(matched_rules.keys()):
-        msg += f"  - '{id}'  # {matched_rules[id]}'\n"
+        if id not in options.warn_list:
+            msg += f"  - '{id}'  # {matched_rules[id]}'\n"
+            failure = True
     msg += "```"
-    console.print(Markdown(msg))
+
+    if failure:
+        if not options.quiet and not options.parseable:
+            console.print(Markdown(msg))
+        return 2
+    else:
+        return 0
 
 
 def main() -> int:
@@ -154,9 +166,7 @@ def main() -> int:
             print(formatter.format(match))
 
     if matches:
-        if not options.quiet and not options.parseable:
-            hint_about_skips(matches)
-        return 2
+        return report_outcome(matches, options=options)
     else:
         return 0
 

--- a/lib/ansiblelint/cli.py
+++ b/lib/ansiblelint/cli.py
@@ -134,6 +134,8 @@ def get_cli_parser() -> argparse.ArgumentParser:
     parser.add_argument('-x', dest='skip_list', default=[], action='append',
                         help="only check rules whose id/tags do not "
                         "match these values")
+    parser.add_argument('-w', dest='warn_list', default=[], nargs="+",
+                        help="only warn about these rules")
     parser.add_argument('--nocolor', dest='colored',
                         default=hasattr(sys.stdout, 'isatty') and sys.stdout.isatty(),
                         action='store_false',
@@ -173,6 +175,7 @@ def merge_config(file_config, cli_config) -> NamedTuple:
         'rulesdir',
         'skip_list',
         'tags',
+        'warn_list',
     )
 
     if not file_config:


### PR DESCRIPTION
Adds a `warn_list` option were user can add rules that should not
affect the outcome of the linting, while they will still be identified.

This softer option makes linter easier to adopt while still reminding
users about issues they should seek to address.