### PR TITLE
Avoid non parsable output on stdout

### DIFF
--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -153,7 +153,7 @@ def main() -> int:
         for match in matches:
             print(formatter.format(match))
 
-    if matches:
+    if matches and not (options.quiet or options.parseable or options.parseable_severity):
         hint_about_skips(matches)
         return 2
     else:

--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -155,6 +155,8 @@ def main() -> int:
 
     if matches and not (options.quiet or options.parseable or options.parseable_severity):
         hint_about_skips(matches)
+    
+    if matches:
         return 2
     else:
         return 0

--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -153,10 +153,9 @@ def main() -> int:
         for match in matches:
             print(formatter.format(match))
 
-    if matches and not (options.quiet or options.parseable or options.parseable_severity):
-        hint_about_skips(matches)
-
-    if matches:
+    if matches :
+        if not options.quiet and not options.parseable:
+            hint_about_skips(matches)
         return 2
     else:
         return 0

--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -153,7 +153,7 @@ def main() -> int:
         for match in matches:
             print(formatter.format(match))
 
-    if matches :
+    if matches:
         if not options.quiet and not options.parseable:
             hint_about_skips(matches)
         return 2

--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -155,7 +155,7 @@ def main() -> int:
 
     if matches and not (options.quiet or options.parseable or options.parseable_severity):
         hint_about_skips(matches)
-    
+
     if matches:
         return 2
     else:


### PR DESCRIPTION
hint_about_skips breaks behavior of  quiet, parseable, and parsable_severity by adding non complaint lines. This quick fix will not add the hint_about_skips when one of those flags is specified