### PR TITLE
E208: Improve detection logic for mode (permissions)

### DIFF
--- a/lib/ansiblelint/rules/MissingFilePermissionsRule.py
+++ b/lib/ansiblelint/rules/MissingFilePermissionsRule.py
@@ -35,17 +35,28 @@ class MissingFilePermissionsRule(AnsibleLintRule):
     version_added = 'v4.3.0'
 
     _modules = (
+        'assemble',
+        'archive',
         'copy',
         'file',
-        'ini_file',
-        'lineinfile',
         'replace',
         'template',
         'unarchive',
     )
 
+    _modules_with_create = (
+        'blockinfile',
+        'ini_file',
+        'lineinfile'
+    )
+
     def matchtask(self, file, task):
-        if task["action"]["__ansible_module__"] not in self._modules:
+        if task["action"]["__ansible_module__"] not in self._modules and \
+                task["action"]["__ansible_module__"] not in self._modules_with_create:
+            return False
+
+        if task["action"]["__ansible_module__"] in self._modules_with_create and \
+                not task["action"].get("create", False):
             return False
 
         if task['action'].get('state', None) == "absent":

--- a/test/TestMissingFilePermissionsRule.py
+++ b/test/TestMissingFilePermissionsRule.py
@@ -43,6 +43,10 @@ SUCCESS_TASKS = '''
         path: foo2
         src: foo
         state: link
+    - name: file edit when create is false
+      lineinfile:
+        path: foo
+        line: some content here
 '''
 
 FAIL_TASKS = '''
@@ -52,6 +56,10 @@ FAIL_TASKS = '''
     - name: permissions missing
       file:
         path: foo
+    - name: permissions needed if create is possible
+      ini_file:
+        path: foo
+        create: true
 '''
 
 
@@ -66,4 +74,4 @@ def test_success(rule_runner):
 def test_fail(rule_runner):
     """Validate that missing mode triggers the rule."""
     results = rule_runner.run_playbook(FAIL_TASKS)
-    assert len(results) == 1
+    assert len(results) == 2


### PR DESCRIPTION
When files are not being created by the module call, then we should not
be forcing "mode" to be set. Also, add a few modules which were missed.

Fixes #995