### PR TITLE
Allow use of file key inside include_tasks

### DIFF
--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -219,6 +219,10 @@ def play_children(basedir, item, parent_type, playbook_dir):
 
 
 def _include_children(basedir, k, v, parent_type):
+    # handle special case include_tasks: name=filename.yml
+    if k == 'include_tasks' and isinstance(v, dict) and 'file' in v:
+        v = v['file']
+
     # handle include: filename.yml tags=blah
     (command, args, kwargs) = tokenize("{0}: {1}".format(k, v))
 

--- a/test/role-with-included-imported-tasks/tasks/main.yml
+++ b/test/role-with-included-imported-tasks/tasks/main.yml
@@ -1,2 +1,6 @@
 - include_tasks: included_tasks.yml
 - import_tasks: imported_tasks.yml
+- include_tasks:
+    file: included_tasks.yml
+    apply:
+      tags: sometag


### PR DESCRIPTION
This PR fixes an already closed but not really fixed issue.
As outlined in https://github.com/ansible/ansible-lint/issues/507#issuecomment-663729455 the following example causes an error:
```yaml
- include_tasks:
    file: included_tasks.yml
    apply:
      tags: sometag
```
Error output (taken from the comment):
```
Traceback (most recent call last):
  File "/usr/local/bin/ansible-lint", line 10, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.7/dist-packages/ansiblelint/__main__.py", line 115, in main
    matches.extend(runner.run())
  File "/usr/local/lib/python3.7/dist-packages/ansiblelint/runner.py", line 74, in run
    for child in ansiblelint.utils.find_children(arg, self.playbook_dir):
  File "/usr/local/lib/python3.7/dist-packages/ansiblelint/utils.py", line 163, in find_children
    basedir, item, playbook[1], playbook_dir):
  File "/usr/local/lib/python3.7/dist-packages/ansiblelint/utils.py", line 141, in func_wrapper
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/ansiblelint/utils.py", line 215, in play_children
    return delegate_map[k](basedir, k, v, parent_type)
  File "/usr/local/lib/python3.7/dist-packages/ansiblelint/utils.py", line 225, in _include_children
    result = path_dwim(os.path.join(os.path.dirname(basedir)), v)
  File "/usr/local/lib/python3.7/dist-packages/ansiblelint/utils.py", line 73, in path_dwim
    return dl.path_dwim(given)
  File "/usr/local/lib/python3.7/dist-packages/ansible/parsing/dataloader.py", line 186, in path_dwim
    given = unquote(given)
  File "/usr/local/lib/python3.7/dist-packages/ansible/parsing/quoting.py", line 29, in unquote
    if is_quoted(data):
  File "/usr/local/lib/python3.7/dist-packages/ansible/parsing/quoting.py", line 24, in is_quoted
    return len(data) > 1 and data[0] == data[-1] and data[0] in ('"', "'") and data[-2] != '\\'
KeyError: 0
```

The actual issue here is not the _apply_ statement. It just causes ansible-lint to crash while without it ansible-lint silently behaves strangely.
The root cause is that ansible-lint always expects a single string value for _include_tasks_.
As seen in the example that is not always the case.

I fixed that by checking for a dict value and extracting its _file_ value for further processing.
Also I expanded an existing test case to cover this kind of include_tasks.

Fixes: #507