### PR TITLE
Replace module should not trigger rule violation

### DIFF
--- a/lib/ansiblelint/rules/MissingFilePermissionsRule.py
+++ b/lib/ansiblelint/rules/MissingFilePermissionsRule.py
@@ -39,7 +39,6 @@ class MissingFilePermissionsRule(AnsibleLintRule):
         'archive',
         'copy',
         'file',
-        'replace',
         'template',
         'unarchive',
     )


### PR DESCRIPTION
Only copy and template modules support preserve mode permissions:
https://github.com/ansible/ansible/issues/56839#issuecomment-680082091

Documentation was fixed in the above MR, but not published yet:
https://github.com/ansible/ansible/pull/71486

Also replace module uses `atomic_move` function that preserves permissions by default,
so we can safely remove this module from a check list.

Fixes: #1023