### PR TITLE
E208: Corrected file mode checking

### DIFF
--- a/test/nomatchestest.yml
+++ b/test/nomatchestest.yml
@@ -6,4 +6,4 @@
       action: debug msg="Hello!"
 
     - name: this should be fine too
-      action: file state=touch dest=./wherever mode=preserve
+      action: file state=touch dest=./wherever mode=0600

--- a/test/unicode.yml
+++ b/test/unicode.yml
@@ -6,4 +6,4 @@
 
   tasks:
   - name: bonjour, ça va?
-    file: state=touch dest=/tmp/naïve.yml mode=preserve
+    file: state=touch dest=/tmp/naïve.yml mode=0600


### PR DESCRIPTION
Takes care of incorrect Ansible documentation which misleads users about support for `mode: preserve` on modules which do not accept it.

Fixes: #1007