### PR TITLE
Use NamedTemporaryFile for run_playbook

### DIFF
--- a/lib/ansiblelint/testing/__init__.py
+++ b/lib/ansiblelint/testing/__init__.py
@@ -31,11 +31,10 @@ class RunFromText(object):
 
     def run_playbook(self, playbook_text):
         """Lints received text as a playbook."""
-        play_root = tempfile.mkdtemp()
-        with open(os.path.join(play_root, 'playbook.yml'), 'w') as fp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", prefix="playbook") as fp:
             fp.write(playbook_text)
-        results = self._call_runner(fp.name)
-        shutil.rmtree(play_root)
+            fp.flush()
+            results = self._call_runner(fp.name)
         return results
 
     def run_role_tasks_main(self, tasks_main_text):


### PR DESCRIPTION
Avoid lower level functions and creation of temporary directory when we just want to test a simple playbook.