### PR TITLE
Improve violation avoidance hints

### DIFF
--- a/lib/ansiblelint/color.py
+++ b/lib/ansiblelint/color.py
@@ -1,4 +1,5 @@
 """Console coloring and terminal support."""
+import sys
 from enum import Enum
 
 from rich.console import Console
@@ -11,6 +12,7 @@ _theme = Theme({
     "title": "yellow"
 })
 console = Console(theme=_theme)
+console_stderr = Console(file=sys.stderr, theme=_theme)
 
 
 class Color(Enum):


### PR DESCRIPTION
- Assure hints are sent on stderr in order to avoid messing parseable output
- Hints are not printed on quiet mode
- If an experimental rule violation is found, it includes example on how to disable experimental rules
- Fixes wrong single quote at the end of the rule comment

![sample-output](https://sbarnea.com/ss/Screen-Shot-2020-09-04-16-00-16.22.png)

Related: #1031