### PR TITLE
Ignore experimental violations for final result

### DIFF
--- a/lib/ansiblelint/rules/MissingFilePermissionsRule.py
+++ b/lib/ansiblelint/rules/MissingFilePermissionsRule.py
@@ -31,7 +31,7 @@ class MissingFilePermissionsRule(AnsibleLintRule):
         "https://github.com/ansible/ansible/issues/71200"
     )
     severity = 'VERY_HIGH'
-    tags = ['unpredictability']
+    tags = ['unpredictability', 'experimental']
     version_added = 'v4.3.0'
 
     _modules = (


### PR DESCRIPTION
Implement changes documented in #1031:
- include `experimental` tag in `warn_list` unless user specify other value inside the config file.
- assures final report (hint) is displayed whenever we have any violations, regardless the result code.
- tag E208 as experimental

Fixes: #1031