### PR TITLE
Enable retries on IOErrors

### DIFF
--- a/lib/ansiblelint/rules/__init__.py
+++ b/lib/ansiblelint/rules/__init__.py
@@ -6,6 +6,7 @@ import os
 import re
 from collections import defaultdict
 from importlib.abc import Loader
+from time import sleep
 from typing import List
 
 import ansiblelint.utils
@@ -210,14 +211,20 @@ class RulesCollection(object):
         text = ""
         matches: List = list()
 
-        try:
-            with open(playbookfile['path'], mode='r', encoding='utf-8') as f:
-                text = f.read()
-        except IOError as e:
-            _logger.warning(
-                "Couldn't open %s - %s",
-                playbookfile['path'],
-                e.strerror)
+        for i in range(3):
+            try:
+                with open(playbookfile['path'], mode='r', encoding='utf-8') as f:
+                    text = f.read()
+                break
+            except IOError as e:
+                _logger.warning(
+                    "Couldn't open %s - %s [try:%s]",
+                    playbookfile['path'],
+                    e.strerror,
+                    i)
+                sleep(1)
+                continue
+        if i and not text:
             return matches
 
         for rule in self.rules:

--- a/test/TestIncludeMissFileWithRole.py
+++ b/test/TestIncludeMissFileWithRole.py
@@ -93,7 +93,7 @@ def test_cases_warning_message(runner, caplog):
         if "Couldn't open" in str(record):
             noexist_message_count += 1
 
-    assert noexist_message_count == 1
+    assert noexist_message_count == 3  # 3 retries
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
As we observed random IOErrors while running tests on MacOS, it is better to include a minimal set of retries, so we can resume IO flakiness.