### PR TITLE
Avoid failing build due to log upload

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -196,6 +196,8 @@ jobs:
       with:
         name: logs.zip
         path: .tox/**/log/
+      # https://github.com/actions/upload-artifact/issues/123
+      continue-on-error: true
     - name: Report junit failures
       uses: shyim/junit-report-annotations-action@3d2e5374f2b13e70f6f3209a21adfdbc42c466ae
       with:


### PR DESCRIPTION
Logs upload seems to be flaky and we do not want to fail an entire job due to it, as this would forces us to rerun the entire workflow again. Linked to upstream bug for traceability.