### PR TITLE
E106: Don't use relative paths for meta/main.yml

### DIFF
--- a/lib/ansiblelint/rules/RoleNames.py
+++ b/lib/ansiblelint/rules/RoleNames.py
@@ -54,8 +54,9 @@ class RoleNames(AnsibleLintRule):
     def match(self, file, text):
         path = file['path'].split("/")
         if "tasks" in path:
-            meta = Path(file['path']).parent.parent / "meta" / "main.yml"
             role_name = _remove_prefix(path[path.index("tasks") - 1], "ansible-role-")
+            role_root = path[:path.index("tasks")]
+            meta = Path("/".join(role_root)) / "meta" / "main.yml"
 
             if meta.is_file():
                 meta_data = parse_yaml_from_file(str(meta))

--- a/test/TestCliRolePaths.py
+++ b/test/TestCliRolePaths.py
@@ -95,7 +95,6 @@ class TestCliRolePaths(unittest.TestCase):
         assert len(result.stderr) == 0
         assert result.returncode == 0
 
-    @pytest.mark.xfail
     def test_run_role_name_from_meta(self):
         cwd = self.local_test_dir
         role_path = 'roles/valid-due-to-meta'

--- a/test/TestCliRolePaths.py
+++ b/test/TestCliRolePaths.py
@@ -95,6 +95,7 @@ class TestCliRolePaths(unittest.TestCase):
         assert len(result.stderr) == 0
         assert result.returncode == 0
 
+    @pytest.mark.xfail
     def test_run_role_name_from_meta(self):
         cwd = self.local_test_dir
         role_path = 'roles/valid-due-to-meta'

--- a/test/roles/valid-due-to-meta/tasks/debian/main.yml
+++ b/test/roles/valid-due-to-meta/tasks/debian/main.yml
@@ -1,0 +1,2 @@
+# This empty task file is here to test that roles with tasks organized in subdirectories
+# are handled correctly by ansible-lint.


### PR DESCRIPTION
This change calculates the role's root directory by finding the
"tasks" directory first, rather than using the parent of the parent of
the current file. The problem with using the parent/parent scheme is
that roles which organize their tasks into subdirectories would cause
ansible-lint to erroneously raise E106 for an invalid role name.

---

Fixes https://github.com/ansible/ansible-lint/issues/1001