### PR TITLE
Avoid crash with None tasks

### DIFF
--- a/examples/example.yml
+++ b/examples/example.yml
@@ -47,3 +47,6 @@
     - name: always run
       debug: msg="always_run is deprecated"
       always_run: true
+
+    # empty task is currently accepted by ansible as valid code:
+    -

--- a/lib/ansiblelint/rules/BecomeUserWithoutBecomeRule.py
+++ b/lib/ansiblelint/rules/BecomeUserWithoutBecomeRule.py
@@ -34,14 +34,15 @@ def _get_subtasks(data):
             'always',
             'rescue']
     for name in block_names:
-        if name in data:
+        if data and name in data:
             result += (data[name] or [])
     return result
 
 
 def _nested_search(term, data):
-    return ((term in data) or
-            reduce((lambda x, y: x or _nested_search(term, y)), _get_subtasks(data), False))
+    if data and term in data:
+        return True
+    return reduce((lambda x, y: x or _nested_search(term, y)), _get_subtasks(data), False)
 
 
 def _become_user_without_become(becomeuserabove, data):

--- a/lib/ansiblelint/rules/IncludeMissingFileRule.py
+++ b/lib/ansiblelint/rules/IncludeMissingFileRule.py
@@ -27,8 +27,9 @@ class IncludeMissingFileRule(AnsibleLintRule):
         # avoid failing with a playbook having tasks: null
         for task in (data.get('tasks', []) or []):
 
-            # check if the id of the current rule is not in list of skipped rules for this play
-            if self.id in task.get('skipped_rules', ()):
+            # ignore None tasks or
+            # if the id of the current rule is not in list of skipped rules for this play
+            if not task or self.id in task.get('skipped_rules', ()):
                 continue
 
             # collect information which file was referenced for include / import

--- a/lib/ansiblelint/skip_utils.py
+++ b/lib/ansiblelint/skip_utils.py
@@ -110,6 +110,11 @@ def _append_skipped_rules(pyyaml_data: Sequence, file_text: str, file_type: File
 
     # append skipped_rules for each task
     for ruamel_task, pyyaml_task in zip(ruamel_tasks, pyyaml_tasks):
+
+        # ignore empty tasks
+        if not pyyaml_task and not ruamel_task:
+            continue
+
         if pyyaml_task.get('name') != ruamel_task.get('name'):
             raise RuntimeError('Error in matching skip comment to a task')
         pyyaml_task['skipped_rules'] = _get_rule_skips_from_yaml(ruamel_task)
@@ -147,7 +152,7 @@ def _get_tasks_from_blocks(task_blocks: Sequence) -> Generator:
     def get_nested_tasks(task: Any) -> Generator[Any, None, None]:
         return (
             subtask
-            for k in NESTED_TASK_KEYS if k in task
+            for k in NESTED_TASK_KEYS if task and k in task
             for subtask in task[k]
         )
 

--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -235,6 +235,11 @@ def _include_children(basedir, k, v, parent_type):
 def _taskshandlers_children(basedir, k, v, parent_type: FileType) -> List:
     results = []
     for th in v:
+
+        # ignore empty tasks, `-`
+        if not th:
+            continue
+
         with contextlib.suppress(LookupError):
             children = _get_task_handler_children_for_tasks_or_playbooks(
                 th, basedir, k, parent_type,
@@ -267,9 +272,16 @@ def _get_task_handler_children_for_tasks_or_playbooks(
 ) -> dict:
     """Try to get children of taskhandler for include/import tasks/playbooks."""
     child_type = k if parent_type == 'playbook' else parent_type
+
     task_include_keys = 'include', 'include_tasks', 'import_playbook', 'import_tasks'
     for task_handler_key in task_include_keys:
+
         with contextlib.suppress(KeyError):
+
+            # ignore empty tasks
+            if not task_handler:
+                continue
+
             return {
                 'path': path_dwim(basedir, task_handler[task_handler_key]),
                 'type': child_type,
@@ -546,6 +558,9 @@ def extract_from_list(blocks, candidates):
 def add_action_type(actions, action_type):
     results = list()
     for action in actions:
+        # ignore empty task
+        if not action:
+            continue
         action['__ansible_action_type__'] = BLOCK_NAME_TO_ACTION_TYPE_MAP[action_type]
         results.append(action)
     return results


### PR DESCRIPTION
As ansible allows tasks to be None, we should also avoid crashing when
encountering them.

Includes regression prevention by assuring we can parse files
with empty tasks.

Fixes: #468