### PR TITLE
Add progressive mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ pip-wheel-metadata
 
 # mypy
 .mypy_cache
+
+# .cache is used by progressive mode
+.cache

--- a/README.rst
+++ b/README.rst
@@ -94,6 +94,8 @@ The following is the output from ``ansible-lint --help``, providing an overview 
       -q                    quieter, although not silent output
       -p                    parseable output in the format of pep8
       --parseable-severity  parseable output including severity of rule
+      --progressive         Return success if it detects a reduction in number of violations compared with
+                            previous git commit. This feature works only on git repository clones.
       -r RULESDIR           Specify custom rule directories. Add -R to keep using embedded rules from
                             /usr/local/lib/python3.8/site-packages/ansiblelint/rules
       -R                    Keep default rules when using -r
@@ -110,6 +112,23 @@ The following is the output from ``ansible-lint --help``, providing an overview 
                             path to directories or files to skip. This option is repeatable.
       -c CONFIG_FILE        Specify configuration file to use. Defaults to ".ansible-lint"
       --version             show program's version number and exit
+
+Progressive mode
+----------------
+
+In order to ease tool adoption, git users can enable the progressive mode using
+``--progressive`` option. This makes the linter return a success even if
+some failures are found, as long the total number of violations did not
+increase since the previous commit.
+
+As expected, this mode makes the linter run twice if it finds any violations.
+The second run is performed against a temporary git working copy that contains
+the previous commit. All the violations that were already present are removed
+from the list and the final result is displayed.
+
+The most notable benefit introduced by this mode it does not prevent merging
+new code while allowing developer to address historical violation at his own
+speed.
 
 CI/CD
 -----

--- a/lib/ansiblelint/cli.py
+++ b/lib/ansiblelint/cli.py
@@ -111,6 +111,12 @@ def get_cli_parser() -> argparse.ArgumentParser:
                         default=False,
                         action='store_true',
                         help="parseable output including severity of rule")
+    parser.add_argument('--progressive', dest='progressive',
+                        default=False,
+                        action='store_true',
+                        help="Return success if it detects a reduction in number"
+                        " of violations compared with previous git commit. This "
+                        "feature works only in git repositories.")
     parser.add_argument('-r', action=AbspathArgAction, dest='rulesdir',
                         default=[], type=Path,
                         help="Specify custom rule directories. Add -R "

--- a/lib/ansiblelint/errors.py
+++ b/lib/ansiblelint/errors.py
@@ -41,6 +41,7 @@ class MatchError(ValueError):
         self.details = details
         self.filename = normpath(filename) if filename else None
         self.rule = rule
+        self.ignored = False  # If set it will be displayed but not counted as failure
 
     def __repr__(self):
         """Return a MatchError instance representation."""

--- a/lib/ansiblelint/file_utils.py
+++ b/lib/ansiblelint/file_utils.py
@@ -1,5 +1,6 @@
 """Utility functions related to file operations."""
 import os
+from contextlib import contextmanager
 
 
 def normpath(path) -> str:
@@ -11,3 +12,14 @@ def normpath(path) -> str:
     """
     # convertion to string in order to allow receiving non string objects
     return os.path.relpath(str(path))
+
+
+@contextmanager
+def cwd(path):
+    """Context manager for temporary changing current working directory."""
+    old_pwd = os.getcwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(old_pwd)


### PR DESCRIPTION
Adds a new option --progressive that ease adoption of the linter as it will only report failure if it detects an increase number of violations since previous commit.

An example of the output when run in progressive mode can be seen below:
```
WARNING  Total violation(s) reduced from 165 to 0 since previous commit. Will mark result as success
WARNING  Marked 99 previously known violation(s) as ignored due to progressive mode.
WARNING  Listing 99 violation(s) marked as ignored, likely already known
```