### PR TITLE
only run from pre-commit when a yaml file changed

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -11,4 +11,4 @@
     # do not pass files to ansible-lint, see:
     # https://github.com/ansible/ansible-lint/issues/611
     pass_filenames: false
-    always_run: true
+    types: [yaml]


### PR DESCRIPTION
Files names are still not passed to the script (because of pass_filenames: false),
but pre-commit does not call ansible-lint when no matching file has changed.

improves #1066