### PR TITLE
Prevent rule 208 matche in nomaches example

### DIFF
--- a/examples/nomatches.yml
+++ b/examples/nomatches.yml
@@ -6,4 +6,4 @@
       action: debug msg="Hello!"
 
     - name: this should be fine too
-      action: file state=touch dest=./wherever
+      action: file state=touch mode=0644 dest=./wherever


### PR DESCRIPTION
Hello,

While packaging the latest release on Debian I noticed one of our CI tests started failing due to the example nomatches.yml throwing a finding.

It's a small issue that got triggered on 4.3.0 due to #949.

This change merely sets `mode` for the file.

commit description:
The file nomatches.yml started triggering a finding on 4.3.0 due to
 missing file permissions.