### PR TITLE
Avoid 208 rule with unarchive module

### DIFF
--- a/lib/ansiblelint/rules/MissingFilePermissionsRule.py
+++ b/lib/ansiblelint/rules/MissingFilePermissionsRule.py
@@ -48,7 +48,7 @@ class MissingFilePermissionsRule(AnsibleLintRule):
         'file',
         'replace',  # implicit preserve behavior but mode: preserve is invalid
         'template',  # supports preserve
-        'unarchive',
+        # 'unarchive',  # disabled because .tar.gz files can have permissions inside
     }
 
     _modules_with_create = {


### PR DESCRIPTION
As archives can also contain permissions (like tar ones), we should avoid triggering 208 rule when unarchive module is used.

Fixes: #1064