### PR TITLE
Avoid rule 208 with file module and recursive

### DIFF
--- a/lib/ansiblelint/rules/MissingFilePermissionsRule.py
+++ b/lib/ansiblelint/rules/MissingFilePermissionsRule.py
@@ -81,6 +81,10 @@ class MissingFilePermissionsRule(AnsibleLintRule):
         if task['action'].get('state', None) == "link":
             return False
 
+        # Recurse on a directory does not allow for an uniform mode
+        if task['action'].get('recurse', None):
+            return False
+
         # The file module does not create anything when state==file (default)
         if module == "file" and \
                 task['action'].get('state', 'file') == 'file':

--- a/test/TestMissingFilePermissionsRule.py
+++ b/test/TestMissingFilePermissionsRule.py
@@ -50,6 +50,10 @@ SUCCESS_TASKS = '''
     - name: replace should not require mode
       replace:
         path: foo
+    - name: file with recursive does not require mode
+      file:
+        state: directory
+        recurse: yes
 '''
 
 FAIL_TASKS = '''


### PR DESCRIPTION
If the file module is applied recursively on a directory, for example to change
ownership of files mode should not be enforced.
The same mode is seldom fitting for both the directory and the files contained within.