### PR TITLE
Fix rotten github actions

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -42,24 +42,24 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - name: set PY_SHA256
-      run: echo "::set-env name=PY_SHA256::$(python -VV | sha256sum | cut -d' ' -f1)"
-    - name: Pre-commit cache
-      uses: actions/cache@v1
-      with:
-        path: ~/.cache/pre-commit
-        key: ${{ runner.os }}-pre-commit-${{ env.PY_SHA256 }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('tox.ini') }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('.pre-commit-config.yaml') }}-${{ hashFiles('pytest.ini') }}
-    - name: Pip cache
-      uses: actions/cache@v1
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ env.PY_SHA256 }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('tox.ini') }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('.pre-commit-config.yaml') }}-${{ hashFiles('pytest.ini') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
-          ${{ runner.os }}-
+    # - name: set PY_SHA256
+    #   run: echo "::set-env name=PY_SHA256::$(python -VV | sha256sum | cut -d' ' -f1)"
+    # - name: Pre-commit cache
+    #   uses: actions/cache@v1
+    #   with:
+    #     path: ~/.cache/pre-commit
+    #     key: ${{ runner.os }}-pre-commit-${{ env.PY_SHA256 }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('tox.ini') }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('.pre-commit-config.yaml') }}-${{ hashFiles('pytest.ini') }}
+    # - name: Pip cache
+    #   uses: actions/cache@v1
+    #   with:
+    #     path: ~/.cache/pip
+    #     key: ${{ runner.os }}-pip-${{ env.PY_SHA256 }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('tox.ini') }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('.pre-commit-config.yaml') }}-${{ hashFiles('pytest.ini') }}
+    #     restore-keys: |
+    #       ${{ runner.os }}-pip-
+    #       ${{ runner.os }}-
     - name: Install tox
       run: |
-        python -m pip install --upgrade tox
+        python3 -m pip install --upgrade tox
     - name: Log installed dists
       run: >-
         python -m pip freeze --all
@@ -102,6 +102,7 @@ jobs:
         - 3.6
         - 3.7
         - 3.8
+        - 3.9
         # NOTE: Installing ansible under 3.10-dev is currently not
         # NOTE: possible because compiling cffi explodes.
         os:
@@ -111,7 +112,7 @@ jobs:
         # - windows-2016
         include:
         - os: ubuntu-20.04
-          python-version: 3.9-dev
+          python-version: 3.9
         - os: macOS-latest
           python-version: 3.6
         - os: macOS-latest
@@ -126,42 +127,30 @@ jobs:
       run: |
         git fetch --prune --unshallow
         git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-    - name: Set up stock Python ${{ matrix.python-version }} from GitHub
-      if: >-
-        !endsWith(matrix.python-version, '-dev')
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Set up Python ${{ matrix.python-version }} from deadsnakes
-      if: >-
-        endsWith(matrix.python-version, '-dev')
-      uses: deadsnakes/action@v1.0.0
-      with:
-        python-version: ${{ matrix.python-version }}
     - name: >-
         Log the currently selected Python
         version info (${{ matrix.python-version }})
       run: |
         python --version --version
         which python
-    - name: Pip cache
-      uses: actions/cache@v1
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ env.PY_SHA256 }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('tox.ini') }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('.pre-commit-config.yaml') }}-${{ hashFiles('pytest.ini') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
-          ${{ runner.os }}-
+    # - name: Pip cache
+    #   uses: actions/cache@v1
+    #   with:
+    #     path: ~/.cache/pip
+    #     key: ${{ runner.os }}-pip-${{ env.PY_SHA256 }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('tox.ini') }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('.pre-commit-config.yaml') }}-${{ hashFiles('pytest.ini') }}
+    #     restore-keys: |
+    #       ${{ runner.os }}-pip-
+    #       ${{ runner.os }}-
     - name: Install tox
       run: |
-        python -m pip install --upgrade tox
+        python3 -m pip install --upgrade tox
     - name: Log installed dists
       run: >-
         python -m pip freeze --all
     - name: >-
         Initialize tox envs
       run: >-
-        python -m
+        python3 -m
         tox
         --parallel auto
         --parallel-live
@@ -172,23 +161,23 @@ jobs:
         TOXENV: ansible28,ansible29,ansible210,ansibledevel
     - name: "Test with tox: ansible28"
       run: |
-        python -m tox
+        python3 -m tox
       env:
         TOXENV: ansible28
     # sequential run improves browsing experience (almost no speed impact)
     - name: "Test with tox: ansible29"
       run: |
-        python -m tox
+        python3 -m tox
       env:
         TOXENV: ansible29
     - name: "Test with tox: ansible210"
       run: |
-        python -m tox
+        python3 -m tox
       env:
         TOXENV: ansible210
     - name: "Test with tox: ansibledevel"
       run: |
-        python -m tox
+        python3 -m tox
       env:
         TOXENV: ansibledevel
     - name: Archive logs
@@ -223,7 +212,7 @@ jobs:
         python-version: 3.8
     - name: Install tox
       run: >-
-        python -m
+        python3 -m
         pip install
         --user
         tox

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ from pathlib import Path
 # https://github.com/readthedocs/readthedocs.org/issues/7182
 sys.path.insert(0, str(Path(__file__).parent.resolve()))
 
-# pip install sphinx_rtd_theme
+# pip3 install sphinx_rtd_theme
 # import sphinx_rtd_theme
 # html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,6 @@
 [aliases]
 dists = clean --all sdist bdist_wheel
 
-[bdist_wheel]
-universal = 1
-
 [metadata]
 name = ansible-lint
 url = https://github.com/ansible/ansible-lint

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ deps =
   -c test-requirements.txt
 commands =
   # safety measure to assure we do not accidentaly run tests with broken dependencies
-  python -m pip check
+  {envpython} -m pip check
   {envpython} -m pytest \
   --cov "{envsitepackagesdir}/ansiblelint" \
   --junitxml "{toxworkdir}/junit.{envname}.xml" \
@@ -84,7 +84,7 @@ deps = {[testenv:lint]deps}
 envdir = {toxworkdir}/lint
 skip_install = true
 commands =
-  python -m pre_commit run --all-files flake8
+  {envpython} -m pre_commit run --all-files flake8
 
 [testenv:lint]
 basepython = python3
@@ -92,7 +92,7 @@ deps =
   pre-commit>=2.6.0
 skip_install = true
 commands =
-  python -m pre_commit run {posargs:--all-files --hook-stage manual -v}
+  {envpython} -m pre_commit run {posargs:--all-files --hook-stage manual -v}
 passenv =
   {[testenv]passenv}
   PRE_COMMIT_HOME


### PR DESCRIPTION
Disable broken caching on github-actions: as Github finally disabled
set-env due to security issues we are forced to disable our caching
implementation until we find a solution that works.

Switches to native py39 testing as we no longer need deadsnakes,
which are not dead for good due to the same security fix.

Related: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/