### PR TITLE
Replace deprecated pre-commit hook option

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
         examples/playbooks/example.yml
       )$
   - id: mixed-line-ending
-  - id: check-byte-order-marker
+  - id: fix-byte-order-marker
   - id: check-executables-have-shebangs
   - id: check-merge-conflict
   - id: debug-statements


### PR DESCRIPTION
As per https://github.com/pre-commit/pre-commit-hooks#deprecated--replaced-hooks
`check-byte-order-marker` is deprecated and replaced by fix-byte-order-marker