### PR TITLE
chore: fix pre-commit.ci config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,18 @@
 ---
+ci:
+  # format compatible with commitlint
+  autoupdate_commit_msg: "chore: pre-commit autoupdate"
+  autoupdate_schedule: monthly
+  autofix_commit_msg: |
+    chore: auto fixes from pre-commit.com hooks
+
+    for more information, see https://pre-commit.ci
+  skip:
+  # https://github.com/pre-commit-ci/issues/issues/55
+  - pip-compile
+  - pip-compile-docs
+  - pip-compile-docs-upgrade
+  - pip-compile-upgrade
 repos:
 - repo: local
   hooks:


### PR DESCRIPTION
Sorts pre-commit.ci which cannot run all our hooks. While our own job is running all, we still want to use that service as it is able to auto-fix minor mistakes in pull-requests.