### PR TITLE
Accept yum clean as a valid command

### DIFF
--- a/src/ansiblelint/rules/CommandsInsteadOfModulesRule.py
+++ b/src/ansiblelint/rules/CommandsInsteadOfModulesRule.py
@@ -101,7 +101,7 @@ class CommandsInsteadOfModulesRule(AnsibleLintRule):
         return False
 
 
-if "pytest" in sys.modules:
+if "pytest" in sys.modules:  # noqa: C901
     import pytest
 
     from ansiblelint.testing import RunFromText  # pylint: disable=ungrouped-imports


### PR DESCRIPTION
- Adds `yum clean` to the list of commands that's allowed since the yum module does not support clearing yum cache.
- Ref #369

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>
Closes #1737