### PR TITLE
"internal-error" description text typo correction

### DIFF
--- a/src/ansiblelint/_internal/rules.py
+++ b/src/ansiblelint/_internal/rules.py
@@ -89,8 +89,8 @@ class RuntimeErrorRule(BaseRule):
     shortdesc = 'Unexpected internal error'
     description = (
         'This error can be caused by internal bugs but also by '
-        'custom rules. Instead of just stopping linter we generate there errors and '
-        'continue processing. This allows users to add this rule to warn list until '
+        'custom rules. Instead of just stopping linter we generate the errors and '
+        'continue processing. This allows users to add this rule to their warn list until '
         'the root cause is fixed.'
     )
     severity = 'VERY_HIGH'


### PR DESCRIPTION
Corrected what I believe to be a couple of typos in the description text for "internal-error". I did not create before/after tests for this.

I assume that the `there` in line 92 was supposed to be `the`, and that the `there` was actually supposed to be in line 93 but, as the possessive `their`.

Feel free to reject if I have this wrong.
Thanks for taking the time to review this.