### PR TITLE
Add MatchError.task to save the normalized task for transforms

### DIFF
--- a/src/ansiblelint/errors.py
+++ b/src/ansiblelint/errors.py
@@ -1,6 +1,6 @@
 """Exceptions and error representations."""
 import functools
-from typing import Any, Optional, Union
+from typing import Any, Dict, Optional, Union
 
 from ansiblelint._internal.rules import BaseRule, RuntimeErrorRule
 from ansiblelint.file_utils import Lintable, normpath
@@ -73,6 +73,8 @@ class MatchError(ValueError):
 
         # optional indicator on how this error was found
         self.match_type: Optional[str] = None
+        # for task matches, save the normalized task object (useful for transforms)
+        self.task: Optional[Dict[str, Any]] = None
 
     def __repr__(self) -> str:
         """Return a MatchError instance representation."""

--- a/src/ansiblelint/rules/__init__.py
+++ b/src/ansiblelint/rules/__init__.py
@@ -157,6 +157,7 @@ class AnsibleLintRule(BaseRule):
                 details=task_msg,
                 filename=file,
             )
+            m.task = task
             matches.append(m)
         return matches
 


### PR DESCRIPTION
This PR is another step towards adding Rule Transforms.

Transforms that work on tasks will need the normalized (ansible-parsed) copy of the task. This allows the Transforms to navigate the full YAML document to find the appropriate place(s) to modify. So, we save it on the MatchError instance.

For example, if a Transform needs to modify some module parameters, it needs to know the name of the module to do `task[module_name]`. It will get that from the normalized version.
