### PR TITLE
Adds more yamllint configuration paths

### DIFF
--- a/src/ansiblelint/rules/yaml.py
+++ b/src/ansiblelint/rules/yaml.py
@@ -17,7 +17,7 @@ _logger = logging.getLogger(__name__)
 DESCRIPTION = """\
 Rule violations reported by YamlLint when this is installed.
 
-Yamllint configuration will be loaded following yamllint's configuration file 
+Yamllint configuration will be loaded following yamllint's configuration file
 resolution order.
 
 You can fully disable all of them by adding 'yaml' to the 'skip_list'.

--- a/src/ansiblelint/rules/yaml.py
+++ b/src/ansiblelint/rules/yaml.py
@@ -17,6 +17,9 @@ _logger = logging.getLogger(__name__)
 DESCRIPTION = """\
 Rule violations reported by YamlLint when this is installed.
 
+Yamllint configuration will be loaded following yamllint's configuration file 
+resolution order.
+
 You can fully disable all of them by adding 'yaml' to the 'skip_list'.
 
 Specific tag identifiers that are printed at the end of rule name,

--- a/src/ansiblelint/yaml_utils.py
+++ b/src/ansiblelint/yaml_utils.py
@@ -68,7 +68,13 @@ def load_yamllint_config() -> YamlLintConfig:
     config = YamlLintConfig(content=YAMLLINT_CONFIG)
     # if we detect local yamllint config we use it but raise a warning
     # as this is likely to get out of sync with our internal config.
-    for file in [".yamllint", ".yamllint.yaml", ".yamllint.yml"]:
+    for file in [
+        ".yamllint",
+        ".yamllint.yaml",
+        ".yamllint.yml",
+        os.getenv('YAMLLINT_CONFIG_FILE', ''),
+        os.getenv("XDG_CONFIG_HOME", os.path.expanduser('~/.config')) + "/yamllint/config"
+    ]:
         if os.path.isfile(file):
             _logger.warning(
                 "Loading custom %s config file, this extends our "

--- a/src/ansiblelint/yaml_utils.py
+++ b/src/ansiblelint/yaml_utils.py
@@ -72,8 +72,9 @@ def load_yamllint_config() -> YamlLintConfig:
         ".yamllint",
         ".yamllint.yaml",
         ".yamllint.yml",
-        os.getenv('YAMLLINT_CONFIG_FILE', ''),
-        os.getenv("XDG_CONFIG_HOME", os.path.expanduser('~/.config')) + "/yamllint/config"
+        os.getenv("YAMLLINT_CONFIG_FILE", ""),
+        os.getenv("XDG_CONFIG_HOME", os.path.expanduser("~/.config"))
+        + "/yamllint/config",
     ]:
         if os.path.isfile(file):
             _logger.warning(


### PR DESCRIPTION
This follows the [documentation of yamllint](https://yamllint.readthedocs.io/en/stable/configuration.html#configuration).

I didn't find tests for the affected function, so I didn't add any. Is there a file that contains such tests?