### PR TITLE
Resolve click+black incompatibility

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -99,7 +99,7 @@ repos:
           # https://github.com/pre-commit/mirrors-isort/issues/9#issuecomment-624404082
           - --filter-files
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
         language_version: python3


### PR DESCRIPTION
click v8.1.0 was just released which breaks black v22.1.0.
black v22.3.0 fixes the incompatibility.

See: https://github.com/psf/black/issues/2964
