### PR TITLE
Propagate error message to user on systemexit

### DIFF
--- a/src/ansiblelint/__main__.py
+++ b/src/ansiblelint/__main__.py
@@ -257,7 +257,7 @@ def _run_cli_entrypoint() -> None:
     except KeyboardInterrupt:
         sys.exit(EXIT_CONTROL_C_RC)
     except RuntimeError as exc:
-        raise SystemExit from exc
+        raise SystemExit(exc) from exc
 
 
 def path_inject() -> None:

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -188,7 +188,7 @@ def find_children(lintable: Lintable) -> List[Lintable]:  # noqa: C901
         try:
             playbook_ds = parse_yaml_from_file(str(lintable.path))
         except AnsibleError as exc:
-            raise SystemExit from exc
+            raise SystemExit(exc) from exc
     results = []
     basedir = os.path.dirname(str(lintable.path))
     # playbook_ds can be an AnsibleUnicode string, which we consider invalid


### PR DESCRIPTION
A [previous PR](https://github.com/ansible/ansible-lint/pull/1984) added 'raise x from y" syntax, but consequently stopped raising
the useful error message content up the stack to the user.

This keeps the 'raise from' syntax, but just adds the error message back in.

Fixes: https://github.com/ansible/ansible-lint/issues/2057