### PR TITLE
Fix loading ansible-lint.yml in git projects

### DIFF
--- a/src/ansiblelint/cli.py
+++ b/src/ansiblelint/cli.py
@@ -101,11 +101,11 @@ def get_config_path(config_file: Optional[str] = None) -> Optional[str]:
             filename = os.path.abspath(os.path.join(parent, project_filename))
             if os.path.exists(filename):
                 return filename
-            if os.path.exists(os.path.abspath(os.path.join(parent, ".git"))):
-                # Avoid looking outside .git folders as we do not want end-up
-                # picking config files from upper level projects if current
-                # project has no config.
-                return None
+        if os.path.exists(os.path.abspath(os.path.join(parent, ".git"))):
+            # Avoid looking outside .git folders as we do not want end-up
+            # picking config files from upper level projects if current
+            # project has no config.
+            return None
         (parent, tail) = os.path.split(parent)
     return None
 


### PR DESCRIPTION
The bug was introduced in 64d29aba925b31372be8d89cf2761ee873d9f526, but
didn't affect anything until 1013149988e0959312c3a6f7fb22f2fe98ba33ad
added a second possible config file name

Fixes: #2045