### PR TITLE
Add only-builtins rule to check compatibility with core

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -156,7 +156,7 @@ jobs:
       WSLENV: FORCE_COLOR:PYTEST_REQPASS:TOXENV:TOX_PARALLEL_NO_SPINNER
       # Number of expected test passes, safety measure for accidental skip of
       # tests. Update value if you add/remove tests.
-      PYTEST_REQPASS: 606
+      PYTEST_REQPASS: 608
 
     steps:
       - name: Activate WSL1

--- a/requirements.yml
+++ b/requirements.yml
@@ -3,3 +3,6 @@ collections:
   # that collection is used during ansible-lint testing for validating our
   # ability to import_playbook from a collection.
   - name: community.molecule
+  # that collection is used during ansible-lint testing for validating our
+  # ability to detect non-core modules.
+  - name: ansible.posix

--- a/src/ansiblelint/rules/only_builtins.py
+++ b/src/ansiblelint/rules/only_builtins.py
@@ -44,12 +44,10 @@ if "pytest" in sys.modules:
     FAIL_PLAY = """
 - hosts: localhost
   tasks:
-  - name: fake_namespace.fake_collection.fake_module
-    community.general.ini_file:
-      path: /etc/conf
-      section: drinks
-      option: fav
-      value: lemonade
+  - name: sysctl
+    ansible.posix.sysctl:
+      name: vm.swappiness
+      value: '5'
     """
 
     @pytest.mark.parametrize(

--- a/src/ansiblelint/rules/only_builtins.py
+++ b/src/ansiblelint/rules/only_builtins.py
@@ -1,0 +1,71 @@
+"""Rule definition for usage of builtin actions only."""
+import sys
+from typing import Any, Dict, Optional, Union
+
+from ansiblelint.file_utils import Lintable
+from ansiblelint.rules import AnsibleLintRule
+
+# fqcn_builtins was added in 5.1.0 as FQCNBuiltinsRule, renamed to fqcn_builtins in 6.0.0
+from ansiblelint.rules.fqcn_builtins import builtins
+
+
+class OnlyBuiltinsRule(AnsibleLintRule):
+    """Use only builtin actions."""
+
+    id = "only-builtins"
+    severity = "MEDIUM"
+    description = "Check whether the playbook uses anything but ``ansible.builtin``"
+    tags = ["opt-in", "experimental"]
+
+    def matchtask(
+        self, task: Dict[str, Any], file: Optional[Lintable] = None
+    ) -> Union[bool, str]:
+        fqcn_builtin = task["action"]["__ansible_module_original__"].startswith(
+            "ansible.builtin."
+        )
+        non_fqcn_builtin = task["action"]["__ansible_module_original__"] in builtins
+        return not fqcn_builtin and not non_fqcn_builtin
+
+
+# testing code to be loaded only with pytest or when executed the rule file
+if "pytest" in sys.modules:
+
+    import pytest
+
+    from ansiblelint.testing import RunFromText  # pylint: disable=ungrouped-imports
+
+    SUCCESS_PLAY = """
+- hosts: localhost
+  tasks:
+  - name: shell (fqcn)
+    ansible.builtin.shell: echo This rule should not get matched by the only-builtins rule
+    """
+
+    FAIL_PLAY = """
+- hosts: localhost
+  tasks:
+  - name: fake_namespace.fake_collection.fake_module
+    community.general.ini_file:
+      path: /etc/conf
+      section: drinks
+      option: fav
+      value: lemonade
+    """
+
+    @pytest.mark.parametrize(
+        "rule_runner", (OnlyBuiltinsRule,), indirect=["rule_runner"]
+    )
+    def test_only_builtin_fail(rule_runner: RunFromText) -> None:
+        """Test rule matches."""
+        results = rule_runner.run_playbook(FAIL_PLAY)
+        assert len(results) == 1
+        for result in results:
+            assert result.message == OnlyBuiltinsRule().shortdesc
+
+    @pytest.mark.parametrize(
+        "rule_runner", (OnlyBuiltinsRule,), indirect=["rule_runner"]
+    )
+    def test_only_builtin_pass(rule_runner: RunFromText) -> None:
+        """Test rule does not match."""
+        results = rule_runner.run_playbook(SUCCESS_PLAY)
+        assert len(results) == 0, results


### PR DESCRIPTION
sometimes it is useful to check if a playbook can be executed on plain ansible-core with no collections installed

type: feature