### PR TITLE
Add additional default search paths for the config file

### DIFF
--- a/docs/configuring.rst
+++ b/docs/configuring.rst
@@ -11,7 +11,9 @@ Configuration File
 ------------------
 
 Ansible-lint supports local configuration via a ``.ansible-lint`` or
-``.config/ansible-lint.yml`` configuration files. Ansible-lint checks the
+``.config/ansible-lint`` configuration file. It will also look for these files
+with ``.yml`` or ``.yaml`` extensions. The canonical location is
+``.config/ansible-lint.yml``. Ansible-lint checks the
 working directory for the presence of this file and applies any configuration
 found there. The configuration file location can also be overridden via the
 ``-c path/to/file`` CLI flag.

--- a/src/ansiblelint/cli.py
+++ b/src/ansiblelint/cli.py
@@ -94,7 +94,14 @@ def get_config_path(config_file: Optional[str] = None) -> Optional[str]:
     if config_file:
         project_filenames = [config_file]
     else:
-        project_filenames = [".ansible-lint", ".config/ansible-lint.yml"]
+        project_filenames = [
+            ".ansible-lint",
+            ".ansible-lint.yml",
+            ".ansible-lint.yaml",
+            ".config/ansible-lint",
+            ".config/ansible-lint.yml",
+            ".config/ansible-lint.yaml",
+        ]
     parent = tail = os.getcwd()
     while tail:
         for project_filename in project_filenames:
@@ -373,7 +380,7 @@ def get_cli_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "-c",
         dest="config_file",
-        help="Specify configuration file to use. By default it will look for '.ansible-lint' or '.config/ansible-lint.yml'",
+        help="Specify configuration file to use. By default it will look for '.ansible-lint[.yml/.yaml]' or '.config/ansible-lint[.yml/.yaml]'",
     )
     parser.add_argument(
         "--offline",


### PR DESCRIPTION
Resolves the feature request in https://github.com/ansible/ansible-lint/discussions/2056

I didn't change https://github.com/ansible/ansible-lint/blob/c058c6de39774411cf7905ed5efe320d6c48f844/src/ansiblelint/app.py#L167 and rather added a line in the documentation that this is the canonical location so other than the cli help text for `-c` it should be enough to only reference that location.