### PR TITLE
chore: remove summary line from eco pipeline output

### DIFF
--- a/test/eco/colsystem.result
+++ b/test/eco/colsystem.result
@@ -10,7 +10,6 @@ warn_list:  # or 'skip_list' to silence them completely
   - load-failure  # Failed to load or parse file.
   - yaml  # Violations reported by yamllint.
 
-Finished with 4 failure(s), 0 warning(s) on 330 files.
 
 
 STDOUT:

--- a/test/eco/debops.result
+++ b/test/eco/debops.result
@@ -10,7 +10,6 @@ You can skip specific rules or tags by adding them to your configuration file:
 warn_list:  # or 'skip_list' to silence them completely
   - var-spacing  # Variables should have spaces before and after: {{ var_name }}.
 
-Finished with 2 failure(s), 0 warning(s) on 4872 files.
 
 
 STDOUT:

--- a/test/eco/hardening.result
+++ b/test/eco/hardening.result
@@ -6,7 +6,6 @@ STDERR:
 WARNING  Loading custom .yamllint.yml config file, this extends our internal yamllint config.
 WARNING  Listing 4 violation(s) that are fatal
 
-Finished with 0 failure(s), 4 warning(s) on 120 files.
 
 
 STDOUT:

--- a/test/eco/mysql.result
+++ b/test/eco/mysql.result
@@ -10,7 +10,6 @@ You can skip specific rules or tags by adding them to your configuration file:
 warn_list:  # or 'skip_list' to silence them completely
   - internal-error  # Unexpected internal error.
 
-Finished with 1 failure(s), 0 warning(s) on 28 files.
 
 
 STDOUT:

--- a/test/eco/zuul-jobs.result
+++ b/test/eco/zuul-jobs.result
@@ -18,7 +18,6 @@ warn_list:  # or 'skip_list' to silence them completely
   - experimental  # all rules tagged as experimental
   - no-loop-var-prefix  # Role loop_var should use configured prefix.
 
-Finished with 1 failure(s), 15 warning(s) on 1258 files.
 
 
 STDOUT:


### PR DESCRIPTION
This should lower the number of eco pipeline failures cased by
external changes.
