### PR TITLE
Update package metadata for setuptools

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,10 +4,11 @@ name = ansible-lint
 url = https://github.com/ansible-community/ansible-lint
 project_urls =
   Bug Tracker = https://github.com/ansible-community/ansible-lint/issues
-  CI: GitHub = https://github.com/ansible-community/ansible-lint/actions?query=workflow:gh+branch:main+event:push
+  Release Management = https://github.com/ansible-community/ansible-lint/releases
+  CI: GitHub = https://github.com/ansible-community/ansible-lint/actions?query=workflow:tox+branch:main+event:push
   Code of Conduct = https://docs.ansible.com/ansible/latest/community/code_of_conduct.html
   Documentation = https://ansible-lint.readthedocs.io/en/latest/
-  Mailing lists = https://docs.ansible.com/ansible-community/latest/community/communication.html#mailing-list-information
+  Mailing lists = https://docs.ansible.com/ansible/latest/community/communication.html#asking-questions-over-email
   Source Code = https://github.com/ansible-community/ansible-lint
 description = Checks playbooks for practices and behavior that could potentially be improved
 long_description = file: README.rst
@@ -35,8 +36,6 @@ classifiers =
 
   Programming Language :: Python
   Programming Language :: Python :: 3
-  Programming Language :: Python :: 3.6
-  Programming Language :: Python :: 3.7
   Programming Language :: Python :: 3.8
   Programming Language :: Python :: 3.9
   Programming Language :: Python :: 3.10


### PR DESCRIPTION
PR #1850 removed support for python 3.6 and python 3.7 so this should be reflected in the package metadata for setuptools.

Also fixes a few links and adds a project URL to the list of releases.