### PR TITLE
Update test and typing deps and remove special code paths for py < 3.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ cffi==1.15.0
 charset-normalizer==2.0.12
 click==8.1.3
 commonmark==0.9.1
-coverage==6.2
+coverage==6.3.2
 cryptography==37.0.1
 dill==0.3.4
 docutils==0.16
@@ -81,7 +81,7 @@ sphinxcontrib-programoutput2==2.0a1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
 subprocess-tee==0.3.5
-tomli==1.2.3
+tomli==2.0.1
 typing-extensions==4.2.0
 urllib3==1.26.9
 wcmatch==8.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,7 +74,6 @@ install_requires =
   # The next version is planned to have breaking changes
   ruamel.yaml >= 0.15.34, < 0.18
   # NOTE: per issue #509 0.15.34 included in debian backports
-  typing-extensions; python_version < "3.8"
   wcmatch>=7.0  # MIT
   yamllint >= 1.25.0  # GPLv3
 
@@ -93,8 +92,8 @@ docs =
   sphinxcontrib-programoutput2 >= 2.0a1
   yamllint >= 1.26.3
 test =
-  coverage >= 6.2, < 6.3 # 6.3 dropped py37 support
-  tomli >= 1.2.3, < 2.0.0  # 2.0.0 dropped py37 support (needed by coverage))
+  coverage >= 6.3
+  tomli >= 2.0.0
   flaky >= 3.7.0
   pytest >= 6.0.1
   pytest-cov >= 2.10.1

--- a/src/ansiblelint/constants.py
+++ b/src/ansiblelint/constants.py
@@ -1,13 +1,6 @@
 """Constants used by AnsibleLint."""
 import os.path
-import sys
-
-# mypy/pylint idiom for py36-py38 compatibility
-# https://github.com/python/typeshed/issues/3500#issuecomment-560958608
-if sys.version_info >= (3, 8):
-    from typing import Literal  # pylint: disable=no-name-in-module
-else:
-    from typing_extensions import Literal
+from typing import Literal
 
 DEFAULT_RULESDIR = os.path.join(os.path.dirname(__file__), "rules")
 CUSTOM_RULESDIR_ENVVAR = "ANSIBLE_LINT_CUSTOM_RULESDIR"
@@ -71,12 +64,6 @@ FileType = Literal[
 # odict is the base class used to represent data model of Ansible
 # playbooks and tasks.
 odict = dict  # pylint: disable=invalid-name
-if sys.version_info[:2] < (3, 7):
-    try:
-        # pylint: disable=unused-import
-        from collections import OrderedDict as odict  # noqa: 401
-    except ImportError:
-        pass
 
 # Deprecated tags/ids and their newer names
 RENAMED_TAGS = {

--- a/src/ansiblelint/formatters/__init__.py
+++ b/src/ansiblelint/formatters/__init__.py
@@ -33,17 +33,9 @@ class BaseFormatter(Generic[T]):
         if base_dir:  # can be None
             base_dir = base_dir.absolute()
 
-        # Required 'cause os.path.relpath() does not accept Path before 3.6
-        if isinstance(base_dir, Path):
-            base_dir = str(base_dir)  # Drop when Python 3.5 is no longer supported
-
         self._base_dir = base_dir if display_relative_path else None
 
-    def _format_path(self, path: Union[str, Path]) -> str:
-        # Required 'cause os.path.relpath() does not accept Path before 3.6
-        if isinstance(path, Path):
-            path = str(path)  # Drop when Python 3.5 is no longer supported
-
+    def _format_path(self, path: Union[str, Path]) -> Union[str, Path]:
         if not self._base_dir or not path:
             return path
         # Use os.path.relpath 'cause Path.relative_to() misbehaves

--- a/test/test_formatter_base.py
+++ b/test/test_formatter_base.py
@@ -28,10 +28,12 @@ def test_base_formatter_when_base_dir(
     output_path = base_formatter._format_path(path)  # pylint: disable=protected-access
 
     # Then
-    assert isinstance(output_path, str)
+    assert isinstance(output_path, (str, Path))
     # pylint: disable=protected-access
-    assert base_formatter._base_dir is None or isinstance(base_formatter._base_dir, str)
-    assert output_path == str(path)
+    assert base_formatter._base_dir is None or isinstance(
+        base_formatter._base_dir, (str, Path)
+    )
+    assert output_path == path
 
 
 @pytest.mark.parametrize(
@@ -54,9 +56,9 @@ def test_base_formatter_when_base_dir_is_given_and_relative_is_true(
     output_path = base_formatter._format_path(path)
 
     # Then
-    assert isinstance(output_path, str)
+    assert isinstance(output_path, (str, Path))
     # pylint: disable=protected-access
-    assert isinstance(base_formatter._base_dir, str)
+    assert isinstance(base_formatter._base_dir, (str, Path))
     assert output_path == Path(path).name
 
 


### PR DESCRIPTION
Since PR #1850 removed support for python 3.6 and python 3.7 some special code paths can now be removed.

This also allows updating some test and typing dependencies which very pinned for python 3.6 and python 3.7 support.