### PR TITLE
Delete now superfluous filterwarnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -28,11 +28,6 @@ filterwarnings =
     # Ref: https://github.com/ansible-community/ansible-lint/pull/734
     ignore:the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses:DeprecationWarning:ansible.plugins.loader
 
-    # TODO: delete the following ignores once Ansible gets rid of direct
-    # imports from `collections`
-    ignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working:DeprecationWarning
-    ignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working:DeprecationWarning
-    ignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working:DeprecationWarning
 junit_duration_report = call
 # Our github annotation parser from .github/workflows/tox.yml requires xunit1 format. Ref:
 # https://github.com/shyim/junit-report-annotations-action/issues/3#issuecomment-663241378


### PR DESCRIPTION
Ansible no longer directly imports from `collections` so these ignored warnings can go.