### PR TITLE
remove superfluous flake8 rule ignores

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -47,19 +47,15 @@ extend-ignore =
 
 # Allow certain violations in certain files:
 per-file-ignores =
-  # FIXME: D100 Missing docstring in public module
-  # FIXME: D101 Missing docstring in public class
   # FIXME: D102 Missing docstring in public method
-  # FIXME: drop these once they're made simpler
-  # Ref: https://github.com/ansible-community/ansible-lint/issues/744
-  src/ansiblelint/cli.py: D101 D102
-  src/ansiblelint/formatters/__init__.py: D101 D102
-  src/ansiblelint/rules/*.py: D100 D101 D102
-  src/ansiblelint/rules/__init__.py: D100 D101 D102
+  src/ansiblelint/cli.py: D102
+  src/ansiblelint/formatters/__init__.py: D102
+  src/ansiblelint/rules/*.py: D102
+  src/ansiblelint/rules/__init__.py: D102
 
   # FIXME: drop these once they're fixed
   # Ref: https://github.com/ansible-community/ansible-lint/issues/725
-  test/*: D100 D101 D102
+  test/*: D102
 
 # flake8-pytest-style
 # PT001:


### PR DESCRIPTION
because some linting violations have been fixed in the meantime