### PR TITLE
Fix var-naming rule to show line numbers and apply noqa

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -156,7 +156,7 @@ jobs:
       WSLENV: FORCE_COLOR:PYTEST_REQPASS:TOXENV:TOX_PARALLEL_NO_SPINNER
       # Number of expected test passes, safety measure for accidental skip of
       # tests. Update value if you add/remove tests.
-      PYTEST_REQPASS: 608
+      PYTEST_REQPASS: 609
 
     steps:
       - name: Activate WSL1

--- a/src/ansiblelint/testing/__init__.py
+++ b/src/ansiblelint/testing/__init__.py
@@ -69,6 +69,17 @@ class RunFromText:
         shutil.rmtree(role_path)
         return results
 
+    def run_role_defaults_main(self, defaults_main_text: str) -> List[MatchError]:
+        """Lints received text as vars file in defaults."""
+        role_path = tempfile.mkdtemp(prefix="role_")
+        defaults_path = os.path.join(role_path, "defaults")
+        os.makedirs(defaults_path)
+        with open(os.path.join(defaults_path, "main.yml"), "w", encoding="utf-8") as fh:
+            fh.write(defaults_main_text)
+        results = self._call_runner(role_path)
+        shutil.rmtree(role_path)
+        return results
+
 
 def run_ansible_lint(
     *argv: str,

--- a/test/test_skiputils.py
+++ b/test/test_skiputils.py
@@ -34,4 +34,5 @@ def test_get_rule_skips_from_line(line: str, expected: str) -> None:
 def test_playbook_noqa(default_text_runner: RunFromText) -> None:
     """Check that noqa is properly taken into account on vars and tasks."""
     results = default_text_runner.run_playbook(PLAYBOOK_WITH_NOQA)
-    assert len(results) == 2
+    # Should raise error at "SOME_VAR".
+    assert len(results) == 1


### PR DESCRIPTION
Currently, `noqa` is not working for `vars` section in playbook and vars file.
This fix makes `noqa` working by getting line numbers from `AnsibleUnicode`.