### PR TITLE
Detect role argument_specs files as a lintable kind

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -156,7 +156,7 @@ jobs:
       WSLENV: FORCE_COLOR:PYTEST_REQPASS:TOXENV:TOX_PARALLEL_NO_SPINNER
       # Number of expected test passes, safety measure for accidental skip of
       # tests. Update value if you add/remove tests.
-      PYTEST_REQPASS: 608
+      PYTEST_REQPASS: 609
 
     steps:
       - name: Activate WSL1

--- a/src/ansiblelint/config.py
+++ b/src/ansiblelint/config.py
@@ -22,6 +22,7 @@ DEFAULT_KINDS = [
     {"handlers": "**/handlers/*.{yaml,yml}"},
     {"vars": "**/{host_vars,group_vars,vars,defaults}/**/*.{yaml,yml}"},
     {"meta": "**/meta/main.{yaml,yml}"},
+    {"arg_specs": "**/roles/**/meta/argument_specs.{yaml,yml}"},  # role argument specs
     {"yaml": ".config/molecule/config.{yaml,yml}"},  # molecule global config
     {
         "requirements": "**/molecule/*/{collections,requirements}.{yaml,yml}"

--- a/test/test_file_utils.py
+++ b/test/test_file_utils.py
@@ -165,6 +165,7 @@ def test_discover_lintables_umlaut(monkeypatch: MonkeyPatch) -> None:
             "roles/foo/molecule/scenario3/collections.yml",
             "requirements",
         ),  # requirements
+        ("roles/foo/meta/argument_specs.yml", "arg_specs"),  # role argument specs
         # tasks files:
         ("tasks/directory with spaces/main.yml", "tasks"),  # tasks
         ("tasks/requirements.yml", "tasks"),  # tasks


### PR DESCRIPTION
…based on argument specification

Beginning with Ansible version 2.11 role argument validation based on an argument specification was introduced. This specification is defined in the `meta/argument_specs.yml` file of a role.

This change enables the linter to detect this new format and for it to be used in future rules.

Fixes: #1688
Relates to: #1966