### PR TITLE
--write: Do not rewrite zero 0 as octal 00

### DIFF
--- a/src/ansiblelint/yaml_utils.py
+++ b/src/ansiblelint/yaml_utils.py
@@ -490,6 +490,9 @@ class CustomConstructor(RoundTripConstructor):
         """
         ret = super().construct_yaml_int(node)
         if self.resolver.processing_version == (1, 1) and isinstance(ret, int):
+            # Do not rewrite zero as octal.
+            if ret == 0:
+                return ret
             # see if we've got an octal we need to preserve.
             value_su = self.construct_scalar(node)
             try:

--- a/test/fixtures/formatting-after/fmt-2.yml
+++ b/test/fixtures/formatting-after/fmt-2.yml
@@ -16,3 +16,9 @@
 - octal:
     - 0o123 # YAML 1.2 octal
     - 0123 # YAML 1.1 octal
+
+- integer:
+    - 0 # Not an octal. See #2071
+    - 10
+    - 9999
+  zero: 0 # Not an octal. See #2071

--- a/test/fixtures/formatting-before/fmt-2.yml
+++ b/test/fixtures/formatting-before/fmt-2.yml
@@ -17,3 +17,8 @@
     - 0o123  # YAML 1.2 octal
     - 0123  # YAML 1.1 octal
 
+  - integer:
+    - 0  # Not an octal. See #2071
+    - 10
+    - 9999
+    zero: 0  # Not an octal. See #2071

--- a/test/fixtures/formatting-prettier/fmt-2.yml
+++ b/test/fixtures/formatting-prettier/fmt-2.yml
@@ -17,3 +17,8 @@
     - 0o123 # YAML 1.2 octal
     - 0123 # YAML 1.1 octal
 
+- integer:
+    - 0 # Not an octal. See #2071
+    - 10
+    - 9999
+  zero: 0 # Not an octal. See #2071


### PR DESCRIPTION
As `ruamel.yaml` only preserves the octal format for YAML 1.2, the effort was made to do the same for YAML 1.1 in `ansible-linter`, as `ruamel.yaml` converts the octal to an int. While the code was partially copied from `ruamel.yaml`, the check for an actual zero got lost, resulting in the behaviour seen in #2071.

Fixes: #2071