### PR TITLE
updating cspell config

### DIFF
--- a/.config/ansible-lint.spec
+++ b/.config/ansible-lint.spec
@@ -1,4 +1,4 @@
-# spell-checker:ignore bcond pkgversion buildrequires autosetup PYTHONPATH noarch buildroot bindir sitelib numprocesses
+# spell-checker:ignore bcond pkgversion buildrequires autosetup PYTHONPATH noarch buildroot bindir sitelib numprocesses clib
 # All tests require Internet access
 # to test in mock use:  --enable-network --with check
 # to test in a privileged environment use:

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -19,3 +19,4 @@ ignorePaths:
   - test/**/*.result
   # Other
   - "*.svg"
+allowCompoundWords: true

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -121,7 +121,7 @@ intersphinx_mapping = {
     "packaging": ("https://packaging.rtfd.io/en/latest", None),
     "pytest": ("https://docs.pytest.org/en/latest", None),
     "python": ("https://docs.python.org/3", None),
-    "rich": ("https://rich.rtfd.io/en/latest", None),
+    "rich": ("https://rich.rtfd.io/en/stable", None),
 }
 
 # The default replacements for |version| and |release|, also used in various


### PR DESCRIPTION
With the v5.20.0 release of cspell the updated python dictionary no longer sets `allowCompoundWords` to `true`. To retain the old behavior the documentation recommends to add to the `cspell.config.yaml`:

```
allowCompoundWords: true
```

The release notes also state:

  Note: setting `allowCompoundWords` to `true` hides many misspellings.

See: https://github.com/streetsidesoftware/cspell/releases/tag/v5.20.0