### PR TITLE
Ensure tags are escaped when printed

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -156,7 +156,7 @@ jobs:
       WSLENV: FORCE_COLOR:PYTEST_REQPASS:TOXENV:TOX_PARALLEL_NO_SPINNER
       # Number of expected test passes, safety measure for accidental skip of
       # tests. Update value if you add/remove tests.
-      PYTEST_REQPASS: 609
+      PYTEST_REQPASS: 610
 
     steps:
       - name: Activate WSL1

--- a/src/ansiblelint/formatters/__init__.py
+++ b/src/ansiblelint/formatters/__init__.py
@@ -59,7 +59,7 @@ class Formatter(BaseFormatter):  # type: ignore
         _id = getattr(match.rule, "id", "000")
         result = f"[error_code]{_id}[/][dim]:[/] [error_title]{self.escape(match.message)}[/]"
         if match.tag:
-            result += f" [dim][error_code]({match.tag})[/][/]"
+            result += f" [dim][error_code]({self.escape(match.tag)})[/][/]"
         result += (
             "\n"
             f"[filename]{self._format_path(match.filename or '')}[/]:{match.position}"
@@ -90,10 +90,10 @@ class ParseableFormatter(BaseFormatter[Any]):
         )
 
         if not options.quiet:
-            result += f" [dim]{match.message}[/]"
+            result += f": [dim]{match.message}[/]"
 
         if match.tag:
-            result += f" [dim][error_code]({match.tag})[/][/]"
+            result += f" [dim][error_code]({self.escape(match.tag)})[/][/]"
         return result
 
 

--- a/test/eco/colsystem.result
+++ b/test/eco/colsystem.result
@@ -13,7 +13,7 @@ warn_list:  # or 'skip_list' to silence them completely
 
 
 STDOUT:
-.ansible-lint:1: load-failure [Errno 2] No such file or directory: '~/.cache/ansible-lint-eco/colsystem/tests/ansible-lint.yml' (filenotfounderror)
-playbooks/molecule/sudo/molecule.yml:17: yaml line too long (576 > 160 characters) (line-length)
-roles/firewalld/defaults/main.yml:11: yaml missing starting space in comment (comments)
-roles/firewalld/defaults/main.yml:28: yaml missing starting space in comment (comments)
+.ansible-lint:1: load-failure: [Errno 2] No such file or directory: '~/.cache/ansible-lint-eco/colsystem/tests/ansible-lint.yml' (filenotfounderror)
+playbooks/molecule/sudo/molecule.yml:17: yaml: line too long (576 > 160 characters) (line-length)
+roles/firewalld/defaults/main.yml:11: yaml: missing starting space in comment (comments)
+roles/firewalld/defaults/main.yml:28: yaml: missing starting space in comment (comments)

--- a/test/eco/debops.result
+++ b/test/eco/debops.result
@@ -13,5 +13,5 @@ warn_list:  # or 'skip_list' to silence them completely
 
 
 STDOUT:
-ansible/roles/rspamd/defaults/main.yml:318: var-spacing Variables should have spaces before and after: { var_name }.
-roles/rspamd/defaults/main.yml:318: var-spacing Variables should have spaces before and after: { var_name }.
+ansible/roles/rspamd/defaults/main.yml:318: var-spacing: Variables should have spaces before and after: { var_name }.
+roles/rspamd/defaults/main.yml:318: var-spacing: Variables should have spaces before and after: { var_name }.

--- a/test/eco/hardening.result
+++ b/test/eco/hardening.result
@@ -9,7 +9,7 @@ WARNING  Listing 4 violation(s) that are fatal
 
 
 STDOUT:
-defaults/main/sshd.yml:20: yaml line too long (143 > 120 characters) (line-length)
-tasks/auditd.yml:21: yaml line too long (122 > 120 characters) (line-length)
-tasks/packagemgmt.yml:164: yaml line too long (129 > 120 characters) (line-length)
-tasks/packagemgmt.yml:192: yaml line too long (162 > 120 characters) (line-length)
+defaults/main/sshd.yml:20: yaml: line too long (143 > 120 characters) (line-length)
+tasks/auditd.yml:21: yaml: line too long (122 > 120 characters) (line-length)
+tasks/packagemgmt.yml:164: yaml: line too long (129 > 120 characters) (line-length)
+tasks/packagemgmt.yml:192: yaml: line too long (162 > 120 characters) (line-length)

--- a/test/eco/mysql.result
+++ b/test/eco/mysql.result
@@ -13,4 +13,4 @@ warn_list:  # or 'skip_list' to silence them completely
 
 
 STDOUT:
-molecule/default/converge.yml:7:7: internal-error the role 'geerlingguy.mysql' was not found in ~/.cache/ansible-lint-eco/mysql/molecule/default/roles:~/.cache/ansible-compat/430005/roles:~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles:~/.cache/ansible-lint-eco/mysql/molecule/default
+molecule/default/converge.yml:7:7: internal-error: the role 'geerlingguy.mysql' was not found in ~/.cache/ansible-lint-eco/mysql/molecule/default/roles:~/.cache/ansible-compat/430005/roles:~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles:~/.cache/ansible-lint-eco/mysql/molecule/default

--- a/test/eco/zuul-jobs.result
+++ b/test/eco/zuul-jobs.result
@@ -21,19 +21,19 @@ warn_list:  # or 'skip_list' to silence them completely
 
 
 STDOUT:
-roles/emit-job-header/tasks/main.yaml:26: ignore-errors Use failed_when and specify error conditions instead of using ignore_errors.
-roles/ensure-chart-testing/tasks/main.yaml:27: risky-file-permissions File permissions unset or incorrect.
-roles/ensure-dhall/tasks/main.yaml:15: risky-file-permissions File permissions unset or incorrect.
-roles/ensure-go/tasks/install-go.yaml:12: risky-file-permissions File permissions unset or incorrect.
-roles/ensure-packer/tasks/install-packer.yaml:21: risky-file-permissions File permissions unset or incorrect.
-roles/ensure-pip/tasks/Debian.yaml:17: ignore-errors Use failed_when and specify error conditions instead of using ignore_errors.
-roles/ensure-pip/tasks/source.yaml:7: risky-file-permissions File permissions unset or incorrect.
-roles/ensure-terraform/tasks/install-terraform.yaml:32: risky-file-permissions File permissions unset or incorrect.
-roles/phoronix-combine-results/tasks/fetch-result.yaml:8: risky-file-permissions File permissions unset or incorrect.
-test-playbooks/registry/roles/ensure-registry-cert/tasks/main.yaml:1: risky-file-permissions File permissions unset or incorrect.
-test-playbooks/registry/roles/ensure-registry-cert/tasks/main.yaml:6: risky-file-permissions File permissions unset or incorrect.
-test-playbooks/registry/roles/run-test-intermediate-registry/tasks/main.yaml:1: no-loop-var-prefix Role loop_var should use configured prefix.
-test-playbooks/registry/roles/run-test-intermediate-registry/tasks/main.yaml:1: risky-file-permissions File permissions unset or incorrect.
-test-playbooks/registry/roles/run-test-intermediate-registry/tasks/main.yaml:17: risky-file-permissions File permissions unset or incorrect.
-test-playbooks/registry/roles/run-test-intermediate-registry/tasks/main.yaml:25: risky-file-permissions File permissions unset or incorrect.
-test-playbooks/registry/roles/run-test-intermediate-registry/tasks/main.yaml:30: risky-file-permissions File permissions unset or incorrect.
+roles/emit-job-header/tasks/main.yaml:26: ignore-errors: Use failed_when and specify error conditions instead of using ignore_errors.
+roles/ensure-chart-testing/tasks/main.yaml:27: risky-file-permissions: File permissions unset or incorrect.
+roles/ensure-dhall/tasks/main.yaml:15: risky-file-permissions: File permissions unset or incorrect.
+roles/ensure-go/tasks/install-go.yaml:12: risky-file-permissions: File permissions unset or incorrect.
+roles/ensure-packer/tasks/install-packer.yaml:21: risky-file-permissions: File permissions unset or incorrect.
+roles/ensure-pip/tasks/Debian.yaml:17: ignore-errors: Use failed_when and specify error conditions instead of using ignore_errors.
+roles/ensure-pip/tasks/source.yaml:7: risky-file-permissions: File permissions unset or incorrect.
+roles/ensure-terraform/tasks/install-terraform.yaml:32: risky-file-permissions: File permissions unset or incorrect.
+roles/phoronix-combine-results/tasks/fetch-result.yaml:8: risky-file-permissions: File permissions unset or incorrect.
+test-playbooks/registry/roles/ensure-registry-cert/tasks/main.yaml:1: risky-file-permissions: File permissions unset or incorrect.
+test-playbooks/registry/roles/ensure-registry-cert/tasks/main.yaml:6: risky-file-permissions: File permissions unset or incorrect.
+test-playbooks/registry/roles/run-test-intermediate-registry/tasks/main.yaml:1: no-loop-var-prefix: Role loop_var should use configured prefix.
+test-playbooks/registry/roles/run-test-intermediate-registry/tasks/main.yaml:1: risky-file-permissions: File permissions unset or incorrect.
+test-playbooks/registry/roles/run-test-intermediate-registry/tasks/main.yaml:17: risky-file-permissions: File permissions unset or incorrect.
+test-playbooks/registry/roles/run-test-intermediate-registry/tasks/main.yaml:25: risky-file-permissions: File permissions unset or incorrect.
+test-playbooks/registry/roles/run-test-intermediate-registry/tasks/main.yaml:30: risky-file-permissions: File permissions unset or incorrect.

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -260,7 +260,7 @@ def test_cli_auto_detect(capfd: CaptureFixture[str]) -> None:
     # An expected rule match from our examples
     assert (
         "examples/playbooks/empty_playbook.yml:1: "
-        "syntax-check Empty playbook, nothing to do" in out
+        "syntax-check: Empty playbook, nothing to do" in out
     )
     # assures that our ansible-lint config exclude was effective in excluding github files
     assert "Identified: .github/" not in out


### PR DESCRIPTION
As rich uses [] for markup, we need to escape them when printing.

Fix fixes bug which prevented display of custom/extended rule tags,
like `schema[galaxy]`.
