### PR TITLE
Add rule to check key order

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -155,7 +155,7 @@ jobs:
       WSLENV: FORCE_COLOR:PYTEST_REQPASS:TOXENV:TOX_PARALLEL_NO_SPINNER
       # Number of expected test passes, safety measure for accidental skip of
       # tests. Update value if you add/remove tests.
-      PYTEST_REQPASS: 629
+      PYTEST_REQPASS: 631
 
     steps:
       - name: Activate WSL1

--- a/src/ansiblelint/rules/key_order.py
+++ b/src/ansiblelint/rules/key_order.py
@@ -17,9 +17,11 @@ class KeyOrderRule(AnsibleLintRule):
     version_added = "v6.2.0"
     needs_raw_task = True
 
-    def matchtask(self, task: Dict[str, Any], file: Optional[Lintable] = None) -> Union[bool, str]:
+    def matchtask(
+        self, task: Dict[str, Any], file: Optional[Lintable] = None
+    ) -> Union[bool, str]:
         raw_task = task["__raw_task__"]
-        if 'name' in raw_task:
+        if "name" in raw_task:
             attribute_list = [*raw_task]
             if bool(attribute_list[0] != "name"):
                 return "'name' key is not first"
@@ -71,17 +73,13 @@ if "pytest" in sys.modules:
       name: task with no_log on top
 """
 
-    @pytest.mark.parametrize(
-        "rule_runner", (KeyOrderRule,), indirect=["rule_runner"]
-    )
+    @pytest.mark.parametrize("rule_runner", (KeyOrderRule,), indirect=["rule_runner"])
     def test_task_name_has_name_first_rule_pass(rule_runner: RunFromText) -> None:
         """Test rule matches."""
         results = rule_runner.run_playbook(PLAY_SUCCESS)
         assert len(results) == 0
 
-    @pytest.mark.parametrize(
-        "rule_runner", (KeyOrderRule,), indirect=["rule_runner"]
-    )
+    @pytest.mark.parametrize("rule_runner", (KeyOrderRule,), indirect=["rule_runner"])
     def test_task_name_has_name_first_rule_fail(rule_runner: RunFromText) -> None:
         """Test rule matches."""
         results = rule_runner.run_playbook(PLAY_FAIL)

--- a/src/ansiblelint/rules/task_name_first.py
+++ b/src/ansiblelint/rules/task_name_first.py
@@ -9,6 +9,7 @@ from ansiblelint.testing import RunFromText
 
 class TaskHasNameFirstRule(AnsibleLintRule):
     """All tasks should be have name come first."""
+
     id = "task-name-first"
     shortdesc = __doc__
     severity = "LOW"
@@ -16,9 +17,7 @@ class TaskHasNameFirstRule(AnsibleLintRule):
     version_added = "v6.0.2"
     needs_raw_task = True
 
-    def matchtask(
-        self, task: Dict[str, Any], file: Optional[Lintable] = None
-    ) -> bool:
+    def matchtask(self, task: Dict[str, Any], file: Optional[Lintable] = None) -> bool:
         raw_task = task["__raw_task__"]
         attribute_list = [*raw_task]
 

--- a/src/ansiblelint/rules/task_name_first.py
+++ b/src/ansiblelint/rules/task_name_first.py
@@ -13,8 +13,8 @@ class TaskHasNameFirstRule(AnsibleLintRule):
     id = "task-name-first"
     shortdesc = __doc__
     severity = "LOW"
-    tags = ["opt-in", "formatting", "experimental"]
-    version_added = "v6.0.2"
+    tags = ["formatting", "experimental"]
+    version_added = "v6.2.0"
     needs_raw_task = True
 
     def matchtask(self, task: Dict[str, Any], file: Optional[Lintable] = None) -> bool:

--- a/src/ansiblelint/rules/task_name_first.py
+++ b/src/ansiblelint/rules/task_name_first.py
@@ -1,33 +1,33 @@
 """All tasks should be have name be the first attribute"""
 import sys
-from typing import TYPE_CHECKING, Any, Dict, Union, List
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
-from ansiblelint.rules import AnsibleLintRule
 from ansiblelint.file_utils import Lintable
+from ansiblelint.rules import AnsibleLintRule
 
-from typing import Optional
 
 class TaskHasNameFirstRule(AnsibleLintRule):
-    id = 'task-name-first'
+    id = "task-name-first"
     shortdesc = __doc__
-    severity = 'LOW'
-    tags = ['opt-in', 'formatting', 'experimental']
-    version_added = 'v6.0.2'
+    severity = "LOW"
+    tags = ["opt-in", "formatting", "experimental"]
+    version_added = "v6.0.2"
     needs_raw_task = True
 
     def matchtask(
         self, task: Dict[str, Any], file: Optional[Lintable] = None
     ) -> Union[bool, str]:
-        raw_task = task['__raw_task__']
+        raw_task = task["__raw_task__"]
         attribute_list = [*raw_task]
 
-        return attribute_list[0] != 'name'
+        return attribute_list[0] != "name"
 
 
 # testing code to be loaded only with pytest or when executed the rule file
 if "pytest" in sys.modules:
 
     import pytest
+
     from ansiblelint.testing import RunFromText
 
     PLAY_FAIL = """---
@@ -71,7 +71,7 @@ if "pytest" in sys.modules:
 """
 
     @pytest.mark.parametrize(
-        'rule_runner', (TaskHasNameFirstRule,), indirect=['rule_runner']
+        "rule_runner", (TaskHasNameFirstRule,), indirect=["rule_runner"]
     )
     def test_task_name_has_name_first_rule_pass(rule_runner: RunFromText) -> None:
         """Test rule matches."""
@@ -79,7 +79,7 @@ if "pytest" in sys.modules:
         assert len(results) == 0
 
     @pytest.mark.parametrize(
-        'rule_runner', (TaskHasNameFirstRule,), indirect=['rule_runner']
+        "rule_runner", (TaskHasNameFirstRule,), indirect=["rule_runner"]
     )
     def test_task_name_has_name_first_rule_fail(rule_runner: RunFromText) -> None:
         """Test rule matches."""

--- a/src/ansiblelint/rules/task_name_first.py
+++ b/src/ansiblelint/rules/task_name_first.py
@@ -1,0 +1,87 @@
+"""All tasks should be have name be the first attribute"""
+import sys
+from typing import TYPE_CHECKING, Any, Dict, Union, List
+
+from ansiblelint.rules import AnsibleLintRule
+from ansiblelint.file_utils import Lintable
+
+from typing import Optional
+
+class TaskHasNameFirstRule(AnsibleLintRule):
+    id = 'task-name-first'
+    shortdesc = __doc__
+    severity = 'LOW'
+    tags = ['opt-in', 'formatting', 'experimental']
+    version_added = 'v6.0.2'
+    needs_raw_task = True
+
+    def matchtask(
+        self, task: Dict[str, Any], file: Optional[Lintable] = None
+    ) -> Union[bool, str]:
+        raw_task = task['__raw_task__']
+        attribute_list = [*raw_task]
+
+        return attribute_list[0] != 'name'
+
+
+# testing code to be loaded only with pytest or when executed the rule file
+if "pytest" in sys.modules:
+
+    import pytest
+    from ansiblelint.testing import RunFromText
+
+    PLAY_FAIL = """---
+- hosts: localhost
+  tasks:
+    - no_log: true
+      shell: echo hello
+      name: task with no_log on top
+    - when: true
+      name: task with when on top
+      shell: echo hello
+    - delegate_to: localhost
+      name: delegate_to on top
+      shell: echo hello
+    - loop:
+        - 1
+        - 2
+      name: loopy
+      command: echo {{ item }}
+    - become: true
+      name: become first
+      shell: echo hello
+    - register: test
+      shell: echo hello
+      name: register first
+"""
+
+    PLAY_SUCCESS = """---
+- hosts: localhost
+  tasks:
+    - name: test
+      command: echo "test"
+    - name: test2
+      debug:
+        msg: "Debug without a name"
+    - name: Flush handlers
+      meta: flush_handlers
+    - no_log: true  # noqa task-name-first
+      shell: echo hello
+      name: task with no_log on top
+"""
+
+    @pytest.mark.parametrize(
+        'rule_runner', (TaskHasNameFirstRule,), indirect=['rule_runner']
+    )
+    def test_task_name_has_name_first_rule_pass(rule_runner: RunFromText) -> None:
+        """Test rule matches."""
+        results = rule_runner.run_playbook(PLAY_SUCCESS)
+        assert len(results) == 0
+
+    @pytest.mark.parametrize(
+        'rule_runner', (TaskHasNameFirstRule,), indirect=['rule_runner']
+    )
+    def test_task_name_has_name_first_rule_fail(rule_runner: RunFromText) -> None:
+        """Test rule matches."""
+        results = rule_runner.run_playbook(PLAY_FAIL)
+        assert len(results) == 6

--- a/src/ansiblelint/rules/task_name_first.py
+++ b/src/ansiblelint/rules/task_name_first.py
@@ -1,12 +1,14 @@
-"""All tasks should be have name be the first attribute"""
+"""All tasks should be have name come first."""
 import sys
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import Any, Dict, Optional
 
 from ansiblelint.file_utils import Lintable
 from ansiblelint.rules import AnsibleLintRule
+from ansiblelint.testing import RunFromText
 
 
 class TaskHasNameFirstRule(AnsibleLintRule):
+    """All tasks should be have name come first."""
     id = "task-name-first"
     shortdesc = __doc__
     severity = "LOW"
@@ -16,7 +18,7 @@ class TaskHasNameFirstRule(AnsibleLintRule):
 
     def matchtask(
         self, task: Dict[str, Any], file: Optional[Lintable] = None
-    ) -> Union[bool, str]:
+    ) -> bool:
         raw_task = task["__raw_task__"]
         attribute_list = [*raw_task]
 
@@ -27,8 +29,6 @@ class TaskHasNameFirstRule(AnsibleLintRule):
 if "pytest" in sys.modules:
 
     import pytest
-
-    from ansiblelint.testing import RunFromText
 
     PLAY_FAIL = """---
 - hosts: localhost

--- a/src/ansiblelint/rules/task_name_first.py
+++ b/src/ansiblelint/rules/task_name_first.py
@@ -21,7 +21,7 @@ class TaskHasNameFirstRule(AnsibleLintRule):
         raw_task = task["__raw_task__"]
         attribute_list = [*raw_task]
 
-        return attribute_list[0] != "name"
+        return bool(attribute_list[0] != "name")
 
 
 # testing code to be loaded only with pytest or when executed the rule file

--- a/test/eco/zuul-jobs.result
+++ b/test/eco/zuul-jobs.result
@@ -7,14 +7,14 @@ INFO     Set ANSIBLE_LIBRARY=~/.cache/ansible-compat/7f15ad/modules:~/.ansible/p
 INFO     Set ANSIBLE_COLLECTIONS_PATH=~/.cache/ansible-compat/7f15ad/collections:~/.ansible/collections:/usr/share/ansible/collections
 INFO     Set ANSIBLE_ROLES_PATH=~/.cache/ansible-compat/7f15ad/roles:roles:~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles
 WARNING  Loading custom .yamllint config file, this extends our internal yamllint config.
-INFO     Discovered files to lint using: git ls-files --cached --others --exclude-standard -z
-INFO     Excluded removed files using: git ls-files --deleted -z
-INFO     Discovered files to lint using: git ls-files --cached --others --exclude-standard -z
-INFO     Excluded removed files using: git ls-files --deleted -z
 INFO     Set ANSIBLE_LIBRARY=~/.cache/ansible-compat/7f15ad/modules:~/.ansible/plugins/modules:/usr/share/ansible/plugins/modules
 INFO     Set ANSIBLE_COLLECTIONS_PATH=~/.cache/ansible-compat/7f15ad/collections:~/.ansible/collections:/usr/share/ansible/collections
 INFO     Set ANSIBLE_ROLES_PATH=~/.cache/ansible-compat/7f15ad/roles:roles:~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles
-WARNING  Listing 62 violation(s) that are fatal
+INFO     Discovered files to lint using: git ls-files --cached --others --exclude-standard -z
+INFO     Excluded removed files using: git ls-files --deleted -z
+INFO     Discovered files to lint using: git ls-files --cached --others --exclude-standard -z
+INFO     Excluded removed files using: git ls-files --deleted -z
+WARNING  Listing 63 violation(s) that are fatal
 You can skip specific rules or tags by adding them to your configuration file:
 # .config/ansible-lint.yml
 warn_list:  # or 'skip_list' to silence them completely
@@ -43,6 +43,7 @@ roles/ensure-pip/tasks/RedHat.yaml:10: unnamed-task: All tasks should be named.
 roles/ensure-pip/tasks/source.yaml:7: risky-file-permissions: File permissions unset or incorrect.
 roles/ensure-shake/tasks/main.yaml:15: unnamed-task: All tasks should be named.
 roles/ensure-terraform/tasks/install-terraform.yaml:32: risky-file-permissions: File permissions unset or incorrect.
+roles/fetch-coverage-output/tasks/main.yaml:6: key-order: 'name' key is not first
 roles/fetch-coverage-output/tasks/main.yaml:13: unnamed-task: All tasks should be named.
 roles/fetch-javascript-tarball/tasks/main.yaml:12: unnamed-task: All tasks should be named.
 roles/fetch-sphinx-tarball/tasks/html.yaml:12: unnamed-task: All tasks should be named.

--- a/test/test_rules_collection.py
+++ b/test/test_rules_collection.py
@@ -159,4 +159,4 @@ def test_rules_id_format() -> None:
         assert rule_id_re.match(
             rule.id
         ), f"Rule id {rule.id} did not match our required format."
-    assert len(rules) == 41
+    assert len(rules) == 42


### PR DESCRIPTION
Adds a new rule that for the moment checks that name is the first key on tasks. In the future
we will add additional ordering rules to it.

Partial: https://github.com/ansible/ansible-lint/issues/578