### PR TITLE
Replace generic yamllint problem description with check name

### DIFF
--- a/src/ansiblelint/rules/yaml.py
+++ b/src/ansiblelint/rules/yaml.py
@@ -54,6 +54,7 @@ class YamllintRule(AnsibleLintRule):
         for problem in run_yamllint(
             file.content, YamllintRule.config, filepath=file.path
         ):
+            self.description = problem.desc
             self.severity = "VERY_LOW"
             if problem.level == "error":
                 self.severity = "MEDIUM"


### PR DESCRIPTION
This PR closes #2106 with by naively overwriting the `yamllint` `rule.description` with the name of the rule.

AFAICT this only impacts the codeclimate and sarif output formats. I considered replacing the `details` parameter with the generic `DESCRIPTION` text (which I think is now unused), but want to propose as small a change as possible (at least to start with).