### PR TITLE
Change custom yamllint config logging to debug

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -244,6 +244,8 @@ jobs:
 
   check: # This job does nothing and is only used for the branch protection
     if: always()
+    permissions:
+      issues: write # allow codenotify to comment on pull-request
 
     needs:
       - linters

--- a/src/ansiblelint/yaml_utils.py
+++ b/src/ansiblelint/yaml_utils.py
@@ -82,7 +82,7 @@ def load_yamllint_config() -> YamlLintConfig:
         + "/yamllint/config",
     ]:
         if os.path.isfile(file):
-            _logger.warning(
+            _logger.debug(
                 "Loading custom %s config file, this extends our "
                 "internal yamllint config.",
                 file,

--- a/test/eco/bootstrap.result
+++ b/test/eco/bootstrap.result
@@ -3,7 +3,6 @@ CMD: ansible-lint -f pep8 -x fqcn-builtins
 RC: 0
 
 STDERR:
-WARNING  Loading custom .yamllint config file, this extends our internal yamllint config.
 WARNING  Listing 3 violation(s) that are fatal
 You can skip specific rules or tags by adding them to your configuration file:
 # .config/ansible-lint.yml

--- a/test/eco/debops.result
+++ b/test/eco/debops.result
@@ -3,7 +3,6 @@ CMD: ansible-lint -f pep8 -x fqcn-builtins
 RC: 0
 
 STDERR:
-WARNING  Loading custom .yamllint config file, this extends our internal yamllint config.
 WARNING  Listing 6 violation(s) that are fatal
 You can skip specific rules or tags by adding them to your configuration file:
 # .config/ansible-lint.yml

--- a/test/eco/docker-rootless.result
+++ b/test/eco/docker-rootless.result
@@ -3,7 +3,6 @@ CMD: ansible-lint -f pep8 -x fqcn-builtins
 RC: 0
 
 STDERR:
-WARNING  Loading custom .yamllint.yml config file, this extends our internal yamllint config.
 WARNING  Listing 8 violation(s) that are fatal
 You can skip specific rules or tags by adding them to your configuration file:
 # .config/ansible-lint.yml

--- a/test/eco/hardening.result
+++ b/test/eco/hardening.result
@@ -3,7 +3,6 @@ CMD: ansible-lint -f pep8 -x fqcn-builtins
 RC: 2
 
 STDERR:
-WARNING  Loading custom .yamllint.yml config file, this extends our internal yamllint config.
 WARNING  Listing 49 violation(s) that are fatal
 You can skip specific rules or tags by adding them to your configuration file:
 # .config/ansible-lint.yml

--- a/test/eco/mysql.result
+++ b/test/eco/mysql.result
@@ -3,7 +3,6 @@ CMD: ansible-lint -f pep8 -x fqcn-builtins
 RC: 2
 
 STDERR:
-WARNING  Loading custom .yamllint config file, this extends our internal yamllint config.
 WARNING  Listing 1 violation(s) that are fatal
 You can skip specific rules or tags by adding them to your configuration file:
 # .config/ansible-lint.yml

--- a/test/eco/zuul-jobs.result
+++ b/test/eco/zuul-jobs.result
@@ -6,7 +6,6 @@ STDERR:
 INFO     Set ANSIBLE_LIBRARY=~/.cache/ansible-compat/7f15ad/modules:~/.ansible/plugins/modules:/usr/share/ansible/plugins/modules
 INFO     Set ANSIBLE_COLLECTIONS_PATH=~/.cache/ansible-compat/7f15ad/collections:~/.ansible/collections:/usr/share/ansible/collections
 INFO     Set ANSIBLE_ROLES_PATH=~/.cache/ansible-compat/7f15ad/roles:roles:~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles
-WARNING  Loading custom .yamllint config file, this extends our internal yamllint config.
 INFO     Set ANSIBLE_LIBRARY=~/.cache/ansible-compat/7f15ad/modules:~/.ansible/plugins/modules:/usr/share/ansible/plugins/modules
 INFO     Set ANSIBLE_COLLECTIONS_PATH=~/.cache/ansible-compat/7f15ad/collections:~/.ansible/collections:/usr/share/ansible/collections
 INFO     Set ANSIBLE_ROLES_PATH=~/.cache/ansible-compat/7f15ad/roles:roles:~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles

--- a/test/test_verbosity.py
+++ b/test/test_verbosity.py
@@ -17,7 +17,6 @@ from ansiblelint.testing import run_ansible_lint
         (
             "",
             [
-                ("WARNING  Loading custom .yamllint config file,", False),
                 ("WARNING  Listing 1 violation(s) that are fatal", False),
                 ("DEBUG ", True),
                 ("INFO ", True),
@@ -42,7 +41,6 @@ from ansiblelint.testing import run_ansible_lint
         (
             "-v",
             [
-                ("WARNING  Loading custom .yamllint config file,", False),
                 ("WARNING  Listing 1 violation(s) that are fatal", False),
                 ("INFO     Set ANSIBLE_LIBRARY=", False),
                 ("DEBUG ", True),
@@ -51,7 +49,7 @@ from ansiblelint.testing import run_ansible_lint
         (
             "-vv",
             [
-                ("WARNING  Loading custom .yamllint config file,", False),
+                ("DEBUG    Loading custom .yamllint config file,", False),
                 ("WARNING  Listing 1 violation(s) that are fatal", False),
                 ("INFO     Set ANSIBLE_LIBRARY=", False),
                 ("DEBUG    Effective yamllint rules used", False),
@@ -60,7 +58,7 @@ from ansiblelint.testing import run_ansible_lint
         (
             "-vvvvvvvvvvvvvvvvvvvvvvvvv",
             [
-                ("WARNING  Loading custom .yamllint config file,", False),
+                ("DEBUG    Loading custom .yamllint config file,", False),
                 ("WARNING  Listing 1 violation(s) that are fatal", False),
                 ("INFO     Set ANSIBLE_LIBRARY=", False),
                 ("DEBUG    Effective yamllint rules used", False),


### PR DESCRIPTION
This should make the linter output less verbose and also sort an
issue that caused the default output to vary a little bit across
platforms and affecting eco pipeline results.

Related: #2138
