### PR TITLE
Avoid using meta schema on ansible-test integration tests

### DIFF
--- a/src/ansiblelint/config.py
+++ b/src/ansiblelint/config.py
@@ -26,6 +26,7 @@ DEFAULT_KINDS = [
     {"tasks": "**/tasks/**/*.{yaml,yml}"},
     {"handlers": "**/handlers/*.{yaml,yml}"},
     {"vars": "**/{host_vars,group_vars,vars,defaults}/**/*.{yaml,yml}"},
+    {"test-meta": "**/tests/integration/targets/*/meta/main.{yaml,yml}"},
     {"meta": "**/meta/main.{yaml,yml}"},
     {"meta-runtime": "**/meta/runtime.{yaml,yml}"},
     {"arg_specs": "**/roles/**/meta/argument_specs.{yaml,yml}"},  # role argument specs

--- a/src/ansiblelint/skip_utils.py
+++ b/src/ansiblelint/skip_utils.py
@@ -97,7 +97,7 @@ def _append_skipped_rules(
     # parse file text using 2nd parser library
     ruamel_data = load_data(lintable.content)
 
-    if lintable.kind in ["yaml", "requirements", "vars", "meta", "reno"]:
+    if lintable.kind in ["yaml", "requirements", "vars", "meta", "reno", "test-meta"]:
         pyyaml_data[0]["skipped_rules"] = _get_rule_skips_from_yaml(ruamel_data)
         return pyyaml_data
 

--- a/src/ansiblelint/yaml_utils.py
+++ b/src/ansiblelint/yaml_utils.py
@@ -302,7 +302,7 @@ def get_path_to_task(
     if lintable.kind == "playbook":
         assert isinstance(ruamel_data, CommentedSeq)
         return _get_path_to_task_in_playbook(line_number, ruamel_data)
-    # if lintable.kind in ["yaml", "requirements", "vars", "meta", "reno"]:
+    # if lintable.kind in ["yaml", "requirements", "vars", "meta", "reno", "test-meta"]:
 
     return []
 


### PR DESCRIPTION
Fixes #2155.

It would be even cooler to have a schema for these files, but that can be added later. Usually they only contain `dependencies: [list of strings]` anyway.