### PR TITLE
Add test for no-loop-var prefix rule

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -155,7 +155,7 @@ jobs:
       WSLENV: FORCE_COLOR:PYTEST_REQPASS:TOXENV:TOX_PARALLEL_NO_SPINNER
       # Number of expected test passes, safety measure for accidental skip of
       # tests. Update value if you add/remove tests.
-      PYTEST_REQPASS: 652
+      PYTEST_REQPASS: 654
 
     steps:
       - name: Activate WSL1

--- a/examples/roles/loop_var_prefix/tasks/fail.yml
+++ b/examples/roles/loop_var_prefix/tasks/fail.yml
@@ -6,7 +6,7 @@
   loop:
     - foo
     - bar
-- name: that should fail due to wrong custom
+- name: that should fail due to wrong prefix
   ansible.builtin.debug:
     var: zz_item
   loop:

--- a/examples/roles/loop_var_prefix/tasks/fail.yml
+++ b/examples/roles/loop_var_prefix/tasks/fail.yml
@@ -1,0 +1,24 @@
+---
+# 3 expected no-loop-var-prefix failures at 3, 9, 19
+- name: that should trigger no-loop-var-prefix
+  ansible.builtin.debug:
+    var: item
+  loop:
+    - foo
+    - bar
+- name: that should fail due to wrong custom
+  ansible.builtin.debug:
+    var: zz_item
+  loop:
+    - foo
+    - bar
+  loop_control:
+    loop_var: zz_item
+- name: Using a block
+  block:
+    - name: that should also not pass
+      ansible.builtin.debug:
+        var: item
+      loop:
+        - apples
+        - oranges

--- a/examples/roles/loop_var_prefix/tasks/pass.yml
+++ b/examples/roles/loop_var_prefix/tasks/pass.yml
@@ -1,0 +1,20 @@
+---
+# 0 expected no-loop-var-prefix failures
+- name: that should pass
+  ansible.builtin.debug:
+    var: loop_var_prefix_item
+  loop:
+    - foo
+    - bar
+  loop_control:
+    loop_var: loop_var_prefix_item
+- name: Using a block
+  block:
+    - name: that should also pass
+      ansible.builtin.debug:
+        var: loop_var_prefix_item
+      loop:
+        - foo
+        - bar
+      loop_control:
+        loop_var: loop_var_prefix_item


### PR DESCRIPTION
A part of #2105.
Before refactoring, this PR adds some tests for the `no-loop-var-prefix` rule.