### PR TITLE
Fix Codenotify

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -8,7 +8,7 @@ on:
   push: # only publishes pushes to the main branch to TestPyPI
     branches: # any integration branch but not tag
       - "main"
-  pull_request:
+  pull_request_target:
   release:
     types:
       - published # It seems that you can publish directly without creating
@@ -246,7 +246,7 @@ jobs:
   check: # This job does nothing and is only used for the branch protection
     if: always()
     permissions:
-      issues: write # allow codenotify to comment on pull-request
+      pull-requests: write # allow codenotify to comment on pull-request
 
     needs:
       - linters


### PR DESCRIPTION
Changes
* Request write permission for pull requests (instead of issues)
* Codenotify needs to listen to [pull_request_target event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target) so that it can have a token with write permissions to the PR.
    * The only difference here should be that this event allows elevated token permissions and it runs even if there is a merge conflict. If this is going to cause an issue for the other steps in this file, my recommendation would be to split the config for codenotify into a separate yaml file. 

Note: If you want Codenotify to be able to mention teams, you will need to create a personal access token. See updated docs here: https://github.com/sourcegraph/codenotify#github_token

Related to https://github.com/sourcegraph/codenotify/issues/19
 