### PR TITLE
no-same-owner: refactor to use matchtask()

### DIFF
--- a/examples/roles/role_for_no_same_owner/tasks/fail.yml
+++ b/examples/roles/role_for_no_same_owner/tasks/fail.yml
@@ -19,6 +19,16 @@
           ansible.posix.synchronize:
             src: dummy
             dest: dummy
+  rescue:
+    - name: synchronize-in-rescue
+      ansible.posix.synchronize:
+        src: dummy
+        dest: dummy
+  always:
+    - name: synchronize-in-always
+      ansible.posix.synchronize:
+        src: dummy
+        dest: dummy
 
 - name: unarchive-bz2
   ansible.builtin.unarchive:


### PR DESCRIPTION
A part of https://github.com/ansible/ansible-lint/issues/2105.

This PR refactors the no_same_owner rule and resolves the following problem. Please refer to https://github.com/ansible/ansible-lint/issues/2105#issue-1226186054.

> - currently uses matchplay() with custom match methods: handle_play(), handle_playlist(), handle_task().
> - like no-loop-var-prefix this also misses rescue and always.
> - the handle_*() and matchplay() methods should be condensed into a single matchtask() (handle_unarchive() and 
> handle_synchronize() would probably stay as they are)