### PR TITLE
deprecated-local-action: refactor to use matchtask() 

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -155,7 +155,7 @@ jobs:
       WSLENV: FORCE_COLOR:PYTEST_REQPASS:TOXENV:TOX_PARALLEL_NO_SPINNER
       # Number of expected test passes, safety measure for accidental skip of
       # tests. Update value if you add/remove tests.
-      PYTEST_REQPASS: 654
+      PYTEST_REQPASS: 655
 
     steps:
       - name: Activate WSL1

--- a/src/ansiblelint/rules/deprecated_local_action.py
+++ b/src/ansiblelint/rules/deprecated_local_action.py
@@ -27,7 +27,7 @@ class TaskNoLocalAction(AnsibleLintRule):
     ) -> Union[bool, str]:
         """Return matches for a task."""
         if "old_style" in task.keys():
-            if task["old_style"] == "local_action":
+            if "local_action" in task["old_style"]:
                 return True
 
         return False

--- a/src/ansiblelint/rules/deprecated_local_action.py
+++ b/src/ansiblelint/rules/deprecated_local_action.py
@@ -3,8 +3,14 @@
 # Copyright (c) 2018, Ansible Project
 
 import sys
+from typing import TYPE_CHECKING, Any, Dict, Union
 
 from ansiblelint.rules import AnsibleLintRule
+
+if TYPE_CHECKING:
+    from typing import Optional
+
+    from ansiblelint.file_utils import Lintable
 
 
 class TaskNoLocalAction(AnsibleLintRule):
@@ -16,28 +22,44 @@ class TaskNoLocalAction(AnsibleLintRule):
     tags = ["deprecations"]
     version_added = "v4.0.0"
 
-    def match(self, line: str) -> bool:
-        if "local_action" in line:
+    def matchtask(
+        self, task: Dict[str, Any], file: "Optional[Lintable]" = None
+    ) -> Union[bool, str]:
+        """Return matches for a task."""
+        action = task.get("action")
+        if not isinstance(action, dict):
+            return False
+
+        if "local_action" in action.keys():
             return True
+
         return False
 
 
 # testing code to be loaded only with pytest or when executed the rule file
 if "pytest" in sys.modules:
+    import pytest
 
     from ansiblelint.rules import RulesCollection  # pylint: disable=ungrouped-imports
     from ansiblelint.testing import RunFromText
 
-    TASK_LOCAL_ACTION = """
+    FAIL_TASK = """
     - name: task example
       local_action:
         module: boto3_facts
     """
 
-    def test_local_action() -> None:
+    SUCCESS_TASK = """
+    - name: task example
+      boto3_facts:
+      delegate_to: localhost # local_action
+    """
+
+    @pytest.mark.parametrize(("text", "expected"), ((SUCCESS_TASK, 0), (FAIL_TASK, 1)))
+    def test_local_action(text: str, expected: int) -> None:
         """Positive test deprecated_local_action."""
         collection = RulesCollection()
         collection.register(TaskNoLocalAction())
         runner = RunFromText(collection)
-        results = runner.run_role_tasks_main(TASK_LOCAL_ACTION)
-        assert len(results) == 1
+        results = runner.run_role_tasks_main(text)
+        assert len(results) == expected

--- a/src/ansiblelint/rules/deprecated_local_action.py
+++ b/src/ansiblelint/rules/deprecated_local_action.py
@@ -26,12 +26,9 @@ class TaskNoLocalAction(AnsibleLintRule):
         self, task: Dict[str, Any], file: "Optional[Lintable]" = None
     ) -> Union[bool, str]:
         """Return matches for a task."""
-        action = task.get("action")
-        if not isinstance(action, dict):
-            return False
-
-        if "local_action" in action.keys():
-            return True
+        if "old_style" in task.keys():
+            if task["old_style"] == "local_action":
+                return True
 
         return False
 

--- a/src/ansiblelint/rules/deprecated_local_action.py
+++ b/src/ansiblelint/rules/deprecated_local_action.py
@@ -18,6 +18,7 @@ class TaskNoLocalAction(AnsibleLintRule):
 
     id = "deprecated-local-action"
     description = "Do not use ``local_action``, use ``delegate_to: localhost``"
+    needs_raw_task = True
     severity = "MEDIUM"
     tags = ["deprecations"]
     version_added = "v4.0.0"
@@ -26,9 +27,9 @@ class TaskNoLocalAction(AnsibleLintRule):
         self, task: Dict[str, Any], file: "Optional[Lintable]" = None
     ) -> Union[bool, str]:
         """Return matches for a task."""
-        if "old_style" in task.keys():
-            if "local_action" in task["old_style"]:
-                return True
+        raw_task = task["__raw_task__"]
+        if "local_action" in raw_task.keys():
+            return True
 
         return False
 

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -608,8 +608,7 @@ def normalize_task_v2(task: Dict[str, Any]) -> Dict[str, Any]:
     # check if invocated with old style module
     for k in ["action", "local_action"]:
         if k in sanitized_task.keys():
-            result["action"][k] = True
-
+            result["old_style"] = k
     return result
 
 

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -605,8 +605,9 @@ def normalize_task_v2(task: Dict[str, Any]) -> Dict[str, Any]:
 
     result["action"].update(arguments)
 
-    # check if invocated with old style module
-    for k in ["action", "local_action"]:
+    # check if module invocated with old style
+    old_style_keys = ["local_action"]
+    for k in old_style_keys:
         if k in sanitized_task.keys():
             result["old_style"] = k
     return result

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -541,22 +541,6 @@ def _extract_ansible_parsed_keys_from_task(
     return result
 
 
-def _extract_old_style_keys_from_task(
-    result: Dict[str, Any],
-    task: Dict[str, Any],
-    keys: Tuple[str, ...],
-) -> Dict[str, Any]:
-    """Return a dict with existing key in task."""
-    # check if module invocated with old style
-    for k in keys:
-        if k in task.keys():
-            if "old_style" in result.keys():
-                result["old_style"].append(k)
-            else:
-                result["old_style"] = [k]
-    return result
-
-
 def normalize_task_v2(task: Dict[str, Any]) -> Dict[str, Any]:
     """Ensure tasks have a normalized action key and strings are converted to python objects."""
     result: Dict[str, Any] = {}
@@ -620,11 +604,6 @@ def normalize_task_v2(task: Dict[str, Any]) -> Dict[str, Any]:
         del arguments["argv"]
 
     result["action"].update(arguments)
-
-    # check if module invocated with old style
-    old_style_keys = ("local_action",)
-    result = _extract_old_style_keys_from_task(result, sanitized_task, old_style_keys)
-
     return result
 
 

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -541,6 +541,22 @@ def _extract_ansible_parsed_keys_from_task(
     return result
 
 
+def _extract_old_style_keys_from_task(
+    result: Dict[str, Any],
+    task: Dict[str, Any],
+    keys: Tuple[str, ...],
+) -> Dict[str, Any]:
+    """Return a dict with existing key in task."""
+    # check if module invocated with old style
+    for k in keys:
+        if k in task.keys():
+            if "old_style" in result.keys():
+                result["old_style"].append(k)
+            else:
+                result["old_style"] = [k]
+    return result
+
+
 def normalize_task_v2(task: Dict[str, Any]) -> Dict[str, Any]:
     """Ensure tasks have a normalized action key and strings are converted to python objects."""
     result: Dict[str, Any] = {}
@@ -606,10 +622,9 @@ def normalize_task_v2(task: Dict[str, Any]) -> Dict[str, Any]:
     result["action"].update(arguments)
 
     # check if module invocated with old style
-    old_style_keys = ["local_action"]
-    for k in old_style_keys:
-        if k in sanitized_task.keys():
-            result["old_style"] = k
+    old_style_keys = ("local_action",)
+    result = _extract_old_style_keys_from_task(result, sanitized_task, old_style_keys)
+
     return result
 
 

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -604,6 +604,12 @@ def normalize_task_v2(task: Dict[str, Any]) -> Dict[str, Any]:
         del arguments["argv"]
 
     result["action"].update(arguments)
+
+    # check if invocated with old style module
+    for k in ["action", "local_action"]:
+        if k in sanitized_task.keys():
+            result["action"][k] = True
+
     return result
 
 


### PR DESCRIPTION
A part of #2105.

This PR fixes the following points for `deprecated-local-action`:
> - uses match() to look at each line
> - can get false positives in comments or strings
> - does not benefit from any of the additional info that gets added by other standard methods