### PR TITLE
Avoid warnings about use of ansible-core@devel branch

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -59,6 +59,8 @@ passenv =
   LC_CTYPE
 # recreate = True
 setenv =
+  # Avoid runtime warning that might affect our devel testing
+  devel: ANSIBLE_DEVEL_WARNING = false
   COVERAGE_FILE = {env:COVERAGE_FILE:{toxworkdir}/.coverage.{envname}}
   PIP_CONSTRAINT = {toxinidir}/requirements.txt
   devel: PIP_CONSTRAINT = /dev/null


### PR DESCRIPTION
As we use @devel branch on purpose, these warnings are only adding
noise and a source of test failures due to different output being
produced.
