### PR TITLE
Add ability to use use sub-rule matches on skip or warn lists

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -60,6 +60,7 @@ warn_list:
   - git-latest
   - experimental # experimental is included in the implicit list
   # - role-name
+  # yaml[document-start]  # you can also use sub-rule matches
 
 # Some rules can transform files to fix (or make it easier to fix) identified
 # errors. `ansible-lint --write` will reformat YAML files and run these transforms.

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -60,7 +60,7 @@ warn_list:
   - git-latest
   - experimental # experimental is included in the implicit list
   # - role-name
-  # yaml[document-start]  # you can also use sub-rule matches
+  # - yaml[document-start]  # you can also use sub-rule matches
 
 # Some rules can transform files to fix (or make it easier to fix) identified
 # errors. `ansible-lint --write` will reformat YAML files and run these transforms.

--- a/src/ansiblelint/app.py
+++ b/src/ansiblelint/app.py
@@ -104,7 +104,12 @@ class App:
         fixed_failures = 0
         fixed_warnings = 0
         for match in matches:
-            if {match.rule.id, *match.rule.tags}.isdisjoint(self.options.warn_list):
+            # tag is the potentially more details id such: `yaml[document-start]`
+            # id is the generic rule id, as `yaml`
+            # *tags is the list of tags assigned to rule (categories), such `style`
+            if {match.tag, match.rule.id, *match.rule.tags}.isdisjoint(
+                self.options.warn_list
+            ):
                 if match.fixed:
                     fixed_failures += 1
                 else:
@@ -129,7 +134,10 @@ class App:
     ) -> "Dict[str, BaseRule]":
         """Extract the list of matched rules, if skippable, from the list of matches."""
         matches_unignored = [match for match in matches if not match.ignored]
-        matched_rules = {match.rule.id: match.rule for match in matches_unignored}
+        # match.tag is more specialized than match.rule.id
+        matched_rules = {
+            match.tag or match.rule.id: match.rule for match in matches_unignored
+        }
         # remove unskippable rules from the list
         for rule_id in list(matched_rules.keys()):
             if "unskippable" in matched_rules[rule_id].tags:

--- a/src/ansiblelint/app.py
+++ b/src/ansiblelint/app.py
@@ -104,9 +104,9 @@ class App:
         fixed_failures = 0
         fixed_warnings = 0
         for match in matches:
-            # tag is the potentially more details id such: `yaml[document-start]`
-            # id is the generic rule id, as `yaml`
-            # *tags is the list of tags assigned to rule (categories), such `style`
+            # tag can include a sub-rule id: `yaml[document-start]`
+            # rule.id is the generic rule id: `yaml`
+            # *rule.tags is the list of the rule's tags (categories): `style`
             if {match.tag, match.rule.id, *match.rule.tags}.isdisjoint(
                 self.options.warn_list
             ):

--- a/src/ansiblelint/rules/yaml.md
+++ b/src/ansiblelint/rules/yaml.md
@@ -7,9 +7,13 @@ ansible-lint, not from yamllint.
 
 You can fully disable all yamllint violations by adding `yaml` to the `skip_list`.
 
-Specific tag identifiers that are printed at the end of rule name,
-like `yaml[trailing-spaces]` or `yaml[indentation]` can also be be skipped, allowing
-you to have a more fine control.
+Specific tag identifiers that are printed at the end of the rule name,
+like `yaml[trailing-spaces]` or `yaml[indentation]` can also be skipped, allowing
+you to have more control.
+
+Keep in mind that our tool does not take into consideration the warning level
+of yamllint and we consider all matches as errors. Still, if you want to treat
+some of these as warnings, you can add them to `warn_list`.
 
 ### Problematic code
 

--- a/src/ansiblelint/rules/yaml.md
+++ b/src/ansiblelint/rules/yaml.md
@@ -11,9 +11,9 @@ Specific tag identifiers that are printed at the end of the rule name,
 like `yaml[trailing-spaces]` or `yaml[indentation]` can also be skipped, allowing
 you to have more control.
 
-Keep in mind that our tool does not take into consideration the warning level
-of yamllint and we consider all matches as errors. Still, if you want to treat
-some of these as warnings, you can add them to `warn_list`.
+Keep in mind that `ansible-lint` does not take into consideration the warning level
+of yamllint; we treat all yamllint matches as errors. So, if you want to treat
+some of these as warnings, add them to `warn_list`.
 
 ### Problematic code
 


### PR DESCRIPTION
You can now add entries like `yaml[document-start]` to the `skip_list` or `warn_list`, instead of adding the entire rule, allowing you to have more granular filtering.

Closes: #2248
Closes: #1794