### PR TITLE
Upgrade jsonschema to 4.8.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -158,7 +158,7 @@ repos:
           - docutils
           - enrich
           - flaky
-          - jsonschema>=4.6.0
+          - jsonschema>=4.8.0
           - pytest
           - pyyaml
           - rich>=11.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ importlib-metadata==4.11.4
 iniconfig==1.1.1
 isort==5.10.1
 jinja2==3.1.2
-jsonschema==4.6.0
+jsonschema==4.8.0
 lazy-object-proxy==1.7.1
 markdown-it-py==2.1.0
 markupsafe==2.1.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,7 +67,7 @@ install_requires =
   ansible-compat>=2.2.0  # GPLv3
   ansible-core>=2.12.0  # GPLv3
   enrich>=1.2.6
-  jsonschema>=4.6.0  # MIT, first version to have ordered keys in output
+  jsonschema>=4.8.0  # MIT, first version to have ordered keys in output
   packaging
   pyyaml
   pytest

--- a/src/ansiblelint/rules/schema.py
+++ b/src/ansiblelint/rules/schema.py
@@ -103,7 +103,7 @@ if "pytest" in sys.modules:
             (
                 "examples/roles/invalid_requirements_schema/meta/requirements.yml",
                 "requirements",
-                ["'collections' is a required property"],
+                ["{'foo': 'bar'} is not valid under any of the given schemas"],
             ),
             (
                 "examples/roles/invalid_meta_schema/meta/main.yml",


### PR DESCRIPTION
Upgrades required version of jsonschema as newer version changed
some of the validation error messages and we want to be in full
control over the outcome.
