### PR TITLE
DNM: Attempt to address coverage warnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -7,7 +7,7 @@ addopts =
     # coverage is re-enabled in `tox.ini`. That approach is safer than
     # `--no-cov` which prevents activation from tox.ini and which also fails
     # when plugin is effectively missing.
-    -p no:pytest_cov
+    #-p no:pytest_cov
 
 doctest_optionflags = ALLOW_UNICODE ELLIPSIS
 filterwarnings =

--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,7 @@ commands =
   # We add coverage options but not making them mandatory as we do not want to force
   # pytest users to run coverage when they just want to run a single test with `pytest -k test`
   {envpython} -m pytest {posargs:\
+    -k test_var_spacing_vars \
     -n auto \
     -ra \
     --showlocals \
@@ -62,6 +63,10 @@ setenv =
   # Avoid runtime warning that might affect our devel testing
   devel: ANSIBLE_DEVEL_WARNING = false
   COVERAGE_FILE = {env:COVERAGE_FILE:{toxworkdir}/.coverage.{envname}}
+  # https://pytest-cov.readthedocs.io/en/latest/plugins.html
+  COV_CORE_SOURCE=
+  COV_CORE_CONFIG={toxinidir}/.coveragerc
+  COV_CORE_DATAFILE={toxinidir}/.coverage
   PIP_CONSTRAINT = {toxinidir}/requirements.txt
   devel: PIP_CONSTRAINT = /dev/null
   PIP_DISABLE_PIP_VERSION_CHECK = 1


### PR DESCRIPTION
That is a failed attempt to avoid multiple warnings such:

/Users/ssbarnea/c/a/ansible-lint/.tox/py/lib/python3.11/site-packages/coverage/inorout.py:535: CoverageWarning: Module ansiblelint was previously imported, but not measured (module-not-measured)
  self.warn(msg, slug="module-not-measured")

Apparently even with https://pytest-cov.readthedocs.io/en/latest/plugins.html
these are still visible. Note that a -k filter was added for speeding up the testing.
