### PR TITLE
Implement file locking on cache directory

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -131,6 +131,7 @@ repos:
           - ansible-compat>=2.2.0
           - ansible-core
           - enrich
+          - filelock
           - flaky
           - pytest
           - rich>=11.0.0
@@ -157,6 +158,7 @@ repos:
           - ansible-core
           - docutils
           - enrich
+          - filelock
           - flaky
           - jsonschema>=4.9.0
           - pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,13 +18,14 @@ cffi==1.15.1
 charset-normalizer==2.1.0
 click==8.1.3
 commonmark==0.9.1
-coverage==6.4.2
+coverage==6.4.3
 cryptography==37.0.4
 dill==0.3.5.1
 docutils==0.16
 enrich==1.2.7
 execnet==1.9.0
-flake8==5.0.2
+filelock==3.7.1
+flake8==5.0.4
 flaky==3.7.0
 idna==3.3
 imagesize==1.4.1
@@ -32,7 +33,7 @@ importlib-metadata==4.12.0
 iniconfig==1.1.1
 isort==5.10.1
 jinja2==3.1.2
-jsonschema==4.9.0
+jsonschema==4.9.1
 lazy-object-proxy==1.7.1
 markdown-it-py==2.1.0
 markupsafe==2.1.1
@@ -51,7 +52,7 @@ platformdirs==2.5.2
 pluggy==1.0.0
 psutil==5.9.1
 py==1.11.0
-pycodestyle==2.9.0
+pycodestyle==2.9.1
 pycparser==2.21
 pyflakes==2.5.0
 pygments==2.12.0
@@ -84,7 +85,7 @@ sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
 subprocess-tee==0.3.5
 tomli==2.0.1
-tomlkit==0.11.1
+tomlkit==0.11.2
 typing-extensions==4.3.0
 urllib3==1.26.11
 wcmatch==8.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,6 +70,7 @@ install_requires =
   ansible-compat>=2.2.0  # GPLv3
   ansible-core>=2.12.0  # GPLv3
   enrich>=1.2.6
+  filelock  # The Unlicense
   jsonschema>=4.9.0  # MIT, version needed for improved errors
   packaging
   pyyaml


### PR DESCRIPTION
This change should prevent concurrency problems related to use of the cache directory. This should sort some of the testing failures and probably also avoid similar issues with molecule
use in parallel.

Related: #2265