### PR TITLE
Refactor yaml data loading

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -17,6 +17,9 @@ disable =
     line-too-long,
     # TODO(ssbarnea): remove temporary skips adding during initial adoption:
     duplicate-code,
+    # unable to disable it inside tests
+    # https://github.com/PyCQA/pylint/issues/850
+    cyclic-import,
 
 [TYPECHECK]
 # pylint is unable to detect Namespace attributes and will throw a E1101

--- a/src/ansiblelint/file_utils.py
+++ b/src/ansiblelint/file_utils.py
@@ -144,6 +144,7 @@ class Lintable:
         self.filename: str = str(name)
         self.dir: str = ""
         self.kind: Optional[FileType] = None
+        self._data: Any = None
 
         if isinstance(name, str):
             self.name = normpath(name)
@@ -277,6 +278,22 @@ class Lintable:
     def __repr__(self) -> str:
         """Return user friendly representation of a lintable."""
         return f"{self.name} ({self.kind})"
+
+    @property
+    def data(self) -> Any:
+        """Return loaded data representation for current file, if possible."""
+        if not self._data:
+            if str(self.base_kind) == "text/yaml":
+                from ansiblelint.utils import (  # pylint: disable=import-outside-toplevel
+                    parse_yaml_linenumbers,
+                )
+
+                self._data = parse_yaml_linenumbers(self)
+            else:
+                raise NotImplementedError(
+                    f"We do not know how to load data from {self.path} {self.kind}[{self.base_kind}]"
+                )
+        return self._data
 
 
 # pylint: disable=redefined-outer-name

--- a/src/ansiblelint/rules/__init__.py
+++ b/src/ansiblelint/rules/__init__.py
@@ -193,7 +193,7 @@ class AnsibleLintRule(BaseRule):
         if not self.matchplay or str(file.base_kind) != "text/yaml":
             return matches
 
-        yaml = ansiblelint.utils.parse_yaml_linenumbers(file)
+        yaml = file.data
         # yaml returned can be an AnsibleUnicode (a string) when the yaml
         # file contains a single string. YAML spec allows this but we consider
         # this an fatal error.

--- a/src/ansiblelint/testing/__init__.py
+++ b/src/ansiblelint/testing/__init__.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     # https://github.com/PyCQA/pylint/issues/3240
     # pylint: disable=unsubscriptable-object
     CompletedProcess = subprocess.CompletedProcess[Any]
+    from ansiblelint.errors import MatchError  # noqa: E402
 else:
     CompletedProcess = subprocess.CompletedProcess
 
@@ -22,7 +23,6 @@ else:
 app = get_app(offline=True)
 
 # pylint: disable=wrong-import-position
-from ansiblelint.errors import MatchError  # noqa: E402
 from ansiblelint.runner import Runner  # noqa: E402
 
 
@@ -37,7 +37,7 @@ class RunFromText:
         runner = Runner(path, rules=self.collection)
         return runner.run()
 
-    def run_playbook(self, playbook_text: str) -> List[MatchError]:
+    def run_playbook(self, playbook_text: str) -> List["MatchError"]:
         """Lints received text as a playbook."""
         with tempfile.NamedTemporaryFile(
             mode="w", suffix=".yml", prefix="playbook"
@@ -47,7 +47,7 @@ class RunFromText:
             results = self._call_runner(fh.name)
         return results
 
-    def run_role_tasks_main(self, tasks_main_text: str) -> List[MatchError]:
+    def run_role_tasks_main(self, tasks_main_text: str) -> List["MatchError"]:
         """Lints received text as tasks."""
         role_path = tempfile.mkdtemp(prefix="role_")
         tasks_path = os.path.join(role_path, "tasks")
@@ -58,7 +58,7 @@ class RunFromText:
         shutil.rmtree(role_path)
         return results
 
-    def run_role_meta_main(self, meta_main_text: str) -> List[MatchError]:
+    def run_role_meta_main(self, meta_main_text: str) -> List["MatchError"]:
         """Lints received text as meta."""
         role_path = tempfile.mkdtemp(prefix="role_")
         meta_path = os.path.join(role_path, "meta")
@@ -69,7 +69,7 @@ class RunFromText:
         shutil.rmtree(role_path)
         return results
 
-    def run_role_defaults_main(self, defaults_main_text: str) -> List[MatchError]:
+    def run_role_defaults_main(self, defaults_main_text: str) -> List["MatchError"]:
         """Lints received text as vars file in defaults."""
         role_path = tempfile.mkdtemp(prefix="role_")
         defaults_path = os.path.join(role_path, "defaults")

--- a/src/ansiblelint/yaml_utils.py
+++ b/src/ansiblelint/yaml_utils.py
@@ -38,7 +38,7 @@ import ansiblelint.skip_utils
 from ansiblelint.constants import NESTED_TASK_KEYS, PLAYBOOK_TASK_KEYWORDS
 from ansiblelint.errors import MatchError
 from ansiblelint.file_utils import Lintable
-from ansiblelint.utils import get_action_tasks, normalize_task, parse_yaml_linenumbers
+from ansiblelint.utils import get_action_tasks, normalize_task
 
 if TYPE_CHECKING:
     # noinspection PyProtectedMember
@@ -121,7 +121,7 @@ def iter_tasks_in_file(
 
     :return: raw_task, normalized_task, skipped, error
     """
-    data = parse_yaml_linenumbers(lintable)
+    data = lintable.data
     if not data:
         return
     data = ansiblelint.skip_utils.append_skipped_rules(data, lintable)

--- a/test/test_yaml_utils.py
+++ b/test/test_yaml_utils.py
@@ -21,7 +21,7 @@ formatting_after_fixtures_dir = fixtures_dir / "formatting-after"
 @pytest.fixture(name="empty_lintable")
 def fixture_empty_lintable() -> Lintable:
     """Return a Lintable with no contents."""
-    lintable = Lintable("__empty_file__")
+    lintable = Lintable("__empty_file__.yaml")
     lintable._content = ""  # pylint: disable=protected-access
     return lintable
 


### PR DESCRIPTION
This change will keep loaded data directly into Lintable object,
making much easier to reuse.
