### PR TITLE
Implement PEP-563

### DIFF
--- a/examples/rules/task_has_tag.py
+++ b/examples/rules/task_has_tag.py
@@ -1,4 +1,6 @@
 """Example implementation of a rule requiring tasks to have tags set."""
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any, Dict, Union
 
 from ansiblelint.rules import AnsibleLintRule
@@ -17,7 +19,7 @@ class TaskHasTag(AnsibleLintRule):
     tags = ["productivity", "tags"]
 
     def matchtask(
-        self, task: Dict[str, Any], file: "Optional[Lintable]" = None
+        self, task: Dict[str, Any], file: Optional[Lintable] = None
     ) -> Union[bool, str]:
         """Task matching method."""
         if isinstance(task, str):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,9 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
+[tool.black]
+target-version = ["py38"]
+
 [tool.coverage.run]
 source = ["src"]
 branch = true
@@ -16,6 +19,7 @@ exclude_lines = ["pragma: no cover", "if TYPE_CHECKING:"]
 
 [tool.isort]
 profile = "black"
+add_imports = "from __future__ import annotations"
 
 [tool.setuptools_scm]
 local_scheme = "no-local-version"

--- a/src/ansiblelint/__init__.py
+++ b/src/ansiblelint/__init__.py
@@ -18,6 +18,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 """Main ansible-lint package."""
+from __future__ import annotations
+
 from ansiblelint.version import __version__
 
 __all__ = ("__version__",)

--- a/src/ansiblelint/__main__.py
+++ b/src/ansiblelint/__main__.py
@@ -20,6 +20,8 @@
 # THE SOFTWARE.
 """Command line implementation."""
 
+from __future__ import annotations
+
 import errno
 import logging
 import os
@@ -111,7 +113,7 @@ def initialize_options(arguments: Optional[List[str]] = None) -> None:
     options.cache_dir_lock.acquire()
 
 
-def _do_list(rules: "RulesCollection") -> int:
+def _do_list(rules: RulesCollection) -> int:
     # On purpose lazy-imports to avoid pre-loading Ansible
     # pylint: disable=import-outside-toplevel
     from ansiblelint.generate_docs import rules_as_md, rules_as_rich, rules_as_str
@@ -136,7 +138,7 @@ def _do_list(rules: "RulesCollection") -> int:
 
 
 # noinspection PyShadowingNames
-def _do_transform(result: "LintResult", opts: "Namespace") -> None:
+def _do_transform(result: LintResult, opts: Namespace) -> None:
     """Create and run Transformer."""
     if "yaml" in opts.skip_list:
         # The transformer rewrites yaml files, but the user requested to skip

--- a/src/ansiblelint/_internal/rules.py
+++ b/src/ansiblelint/_internal/rules.py
@@ -1,4 +1,6 @@
 """Internally used rule classes."""
+from __future__ import annotations
+
 import logging
 from typing import TYPE_CHECKING, Any, Dict, List, Union
 
@@ -51,7 +53,7 @@ class BaseRule:
         """Return the short description of the rule, basically the docstring."""
         return self.__doc__ or ""
 
-    def getmatches(self, file: "Lintable") -> List["MatchError"]:
+    def getmatches(self, file: Lintable) -> List[MatchError]:
         """Return all matches while ignoring exceptions."""
         matches = []
         if not file.path.is_dir():
@@ -69,13 +71,13 @@ class BaseRule:
             matches.extend(self.matchdir(file))
         return matches
 
-    def matchlines(self, file: "Lintable") -> List["MatchError"]:
+    def matchlines(self, file: Lintable) -> List[MatchError]:
         """Return matches found for a specific line."""
         return []
 
     def matchtask(
-        self, task: Dict[str, Any], file: "Optional[Lintable]" = None
-    ) -> Union[bool, str, "MatchError"]:
+        self, task: Dict[str, Any], file: Optional[Lintable] = None
+    ) -> Union[bool, str, MatchError]:
         """Confirm if current rule is matching a specific task.
 
         If ``needs_raw_task`` (a class level attribute) is ``True``, then
@@ -84,21 +86,19 @@ class BaseRule:
         """
         return False
 
-    def matchtasks(self, file: "Lintable") -> List["MatchError"]:
+    def matchtasks(self, file: Lintable) -> List[MatchError]:
         """Return matches for a tasks file."""
         return []
 
-    def matchyaml(self, file: "Lintable") -> List["MatchError"]:
+    def matchyaml(self, file: Lintable) -> List[MatchError]:
         """Return matches found for a specific YAML text."""
         return []
 
-    def matchplay(
-        self, file: "Lintable", data: "odict[str, Any]"
-    ) -> List["MatchError"]:
+    def matchplay(self, file: Lintable, data: odict[str, Any]) -> List[MatchError]:
         """Return matches found for a specific playbook."""
         return []
 
-    def matchdir(self, lintable: "Lintable") -> List["MatchError"]:
+    def matchdir(self, lintable: Lintable) -> List[MatchError]:
         """Return matches for lintable folders."""
         return []
 
@@ -110,7 +110,7 @@ class BaseRule:
         """Confirm if current rule matches the given string."""
         return False
 
-    def __lt__(self, other: "BaseRule") -> bool:
+    def __lt__(self, other: BaseRule) -> bool:
         """Enable us to sort rules by their id."""
         return (self._order, self.id) < (other._order, other.id)
 

--- a/src/ansiblelint/app.py
+++ b/src/ansiblelint/app.py
@@ -1,4 +1,6 @@
 """Application."""
+from __future__ import annotations
+
 import logging
 import os
 from dataclasses import dataclass
@@ -44,7 +46,7 @@ class SummarizedResults:
 class App:
     """App class represents an execution of the linter."""
 
-    def __init__(self, options: "Namespace"):
+    def __init__(self, options: Namespace):
         """Construct app run based on already loaded configuration."""
         options.skip_list = _sanitize_list_options(options.skip_list)
         options.warn_list = _sanitize_list_options(options.warn_list)
@@ -122,7 +124,7 @@ class App:
         return SummarizedResults(failures, warnings, fixed_failures, fixed_warnings)
 
     @staticmethod
-    def count_lintables(files: "Set[Lintable]") -> Tuple[int, int]:
+    def count_lintables(files: Set[Lintable]) -> Tuple[int, int]:
         """Count total and modified files."""
         files_count = len(files)
         changed_files_count = len([file for file in files if file.updated])
@@ -131,7 +133,7 @@ class App:
     @staticmethod
     def _get_matched_skippable_rules(
         matches: List[MatchError],
-    ) -> "Dict[str, BaseRule]":
+    ) -> Dict[str, BaseRule]:
         """Extract the list of matched rules, if skippable, from the list of matches."""
         matches_unignored = [match for match in matches if not match.ignored]
         # match.tag is more specialized than match.rule.id
@@ -144,9 +146,7 @@ class App:
                 matched_rules.pop(rule_id)
         return matched_rules
 
-    def report_outcome(
-        self, result: "LintResult", mark_as_success: bool = False
-    ) -> int:
+    def report_outcome(self, result: LintResult, mark_as_success: bool = False) -> int:
         """Display information about how to skip found rules.
 
         Returns exit code, 2 if errors were found, 0 when only warnings were found.
@@ -224,7 +224,7 @@ warn_list:  # or 'skip_list' to silence them completely
 
 
 def choose_formatter_factory(
-    options_list: "Namespace",
+    options_list: Namespace,
 ) -> Type[formatters.BaseFormatter[Any]]:
     """Select an output formatter based on the incoming command line arguments."""
     r: Type[formatters.BaseFormatter[Any]] = formatters.Formatter

--- a/src/ansiblelint/formatters/__init__.py
+++ b/src/ansiblelint/formatters/__init__.py
@@ -1,4 +1,6 @@
 """Output formatters."""
+from __future__ import annotations
+
 import hashlib
 import json
 import os
@@ -41,7 +43,7 @@ class BaseFormatter(Generic[T]):
         # Use os.path.relpath 'cause Path.relative_to() misbehaves
         return os.path.relpath(path, start=self._base_dir)
 
-    def format(self, match: "MatchError") -> str:
+    def format(self, match: MatchError) -> str:
         """Format a match error."""
         return str(match)
 
@@ -54,7 +56,7 @@ class BaseFormatter(Generic[T]):
 class Formatter(BaseFormatter):  # type: ignore
     """Default output formatter of ansible-lint."""
 
-    def format(self, match: "MatchError") -> str:
+    def format(self, match: MatchError) -> str:
         _id = getattr(match.rule, "id", "000")
         result = f"[error_code]{_id}[/][dim]:[/] [error_title]{self.escape(match.message)}[/]"
         if match.tag:
@@ -72,7 +74,7 @@ class Formatter(BaseFormatter):  # type: ignore
 class QuietFormatter(BaseFormatter[Any]):
     """Brief output formatter for ansible-lint."""
 
-    def format(self, match: "MatchError") -> str:
+    def format(self, match: MatchError) -> str:
         return (
             f"[error_code]{match.rule.id}[/] "
             f"[filename]{self._format_path(match.filename or '')}[/]:{match.position}"
@@ -82,7 +84,7 @@ class QuietFormatter(BaseFormatter[Any]):
 class ParseableFormatter(BaseFormatter[Any]):
     """Parseable uses PEP8 compatible format."""
 
-    def format(self, match: "MatchError") -> str:
+    def format(self, match: MatchError) -> str:
         result = (
             f"[filename]{self._format_path(match.filename or '')}[/]:{match.position}: "
             f"[error_code]{match.rule.id}[/]"
@@ -111,7 +113,7 @@ class AnnotationsFormatter(BaseFormatter):  # type: ignore
     Supported levels: debug, warning, error
     """
 
-    def format(self, match: "MatchError") -> str:
+    def format(self, match: MatchError) -> str:
         """Prepare a match instance for reporting as a GitHub Actions annotation."""
         level = self._severity_to_level(match.rule.severity)
         file_path = self._format_path(match.filename or "")
@@ -146,7 +148,7 @@ class CodeclimateJSONFormatter(BaseFormatter[Any]):
     https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md#user-content-data-types
     """
 
-    def format_result(self, matches: List["MatchError"]) -> str:
+    def format_result(self, matches: List[MatchError]) -> str:
         """Format a list of match errors as a JSON string."""
         if not isinstance(matches, list):
             raise RuntimeError(
@@ -211,7 +213,7 @@ class SarifFormatter(BaseFormatter[Any]):
         "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json"
     )
 
-    def format_result(self, matches: List["MatchError"]) -> str:
+    def format_result(self, matches: List[MatchError]) -> str:
         """Format a list of match errors as a JSON string."""
         if not isinstance(matches, list):
             raise RuntimeError(
@@ -253,7 +255,7 @@ class SarifFormatter(BaseFormatter[Any]):
         )
 
     def _extract_results(
-        self, matches: List["MatchError"]
+        self, matches: List[MatchError]
     ) -> Tuple[List[Any], List[Any]]:
         rules = {}
         results = []
@@ -263,7 +265,7 @@ class SarifFormatter(BaseFormatter[Any]):
             results.append(self._to_sarif_result(match))
         return list(rules.values()), results
 
-    def _to_sarif_rule(self, match: "MatchError") -> Dict[str, Any]:
+    def _to_sarif_rule(self, match: MatchError) -> Dict[str, Any]:
         rule: Dict[str, Any] = {
             "id": match.rule.id,
             "name": match.rule.id,
@@ -283,7 +285,7 @@ class SarifFormatter(BaseFormatter[Any]):
             rule["helpUri"] = match.rule.link
         return rule
 
-    def _to_sarif_result(self, match: "MatchError") -> Dict[str, Any]:
+    def _to_sarif_result(self, match: MatchError) -> Dict[str, Any]:
         result: Dict[str, Any] = {
             "ruleId": match.rule.id,
             "message": {

--- a/src/ansiblelint/rules/__init__.py
+++ b/src/ansiblelint/rules/__init__.py
@@ -115,7 +115,7 @@ class AnsibleLintRule(BaseRule):
         if match.linenumber < task[ansiblelint.utils.LINE_NUMBER_KEY]:
             match.linenumber = task[ansiblelint.utils.LINE_NUMBER_KEY]
 
-    def matchlines(self, file: "Lintable") -> List[MatchError]:
+    def matchlines(self, file: Lintable) -> List[MatchError]:
         matches: List[MatchError] = []
         if not self.match:
             return matches

--- a/src/ansiblelint/rules/command_instead_of_module.py
+++ b/src/ansiblelint/rules/command_instead_of_module.py
@@ -18,6 +18,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
+from __future__ import annotations
 
 import os
 import sys
@@ -75,7 +76,7 @@ class CommandsInsteadOfModulesRule(AnsibleLintRule):
     }
 
     def matchtask(
-        self, task: Dict[str, Any], file: "Optional[Lintable]" = None
+        self, task: Dict[str, Any], file: Optional[Lintable] = None
     ) -> Union[bool, str]:
 
         if task["action"]["__ansible_module__"] not in self._commands:

--- a/src/ansiblelint/rules/command_instead_of_shell.py
+++ b/src/ansiblelint/rules/command_instead_of_shell.py
@@ -18,6 +18,8 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
+from __future__ import annotations
+
 import sys
 from typing import TYPE_CHECKING, Any, Dict, Union
 
@@ -111,7 +113,7 @@ class UseCommandInsteadOfShellRule(AnsibleLintRule):
     version_added = "historic"
 
     def matchtask(
-        self, task: Dict[str, Any], file: "Optional[Lintable]" = None
+        self, task: Dict[str, Any], file: Optional[Lintable] = None
     ) -> Union[bool, str]:
         # Use unjinja so that we don't match on jinja filters
         # rather than pipes

--- a/src/ansiblelint/rules/deprecated_bare_vars.py
+++ b/src/ansiblelint/rules/deprecated_bare_vars.py
@@ -20,6 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+from __future__ import annotations
+
 import os
 import re
 from typing import TYPE_CHECKING, Any, Dict, Union
@@ -49,7 +51,7 @@ class UsingBareVariablesIsDeprecatedRule(AnsibleLintRule):
     _glob = re.compile("[][*?]")
 
     def matchtask(
-        self, task: Dict[str, Any], file: "Optional[Lintable]" = None
+        self, task: Dict[str, Any], file: Optional[Lintable] = None
     ) -> Union[bool, str]:
         loop_type = next((key for key in task if key.startswith("with_")), None)
         if loop_type:

--- a/src/ansiblelint/rules/deprecated_command_syntax.py
+++ b/src/ansiblelint/rules/deprecated_command_syntax.py
@@ -19,6 +19,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+from __future__ import annotations
+
 import os
 from typing import TYPE_CHECKING, Any, Dict, Union
 
@@ -55,7 +57,7 @@ class CommandsInsteadOfArgumentsRule(AnsibleLintRule):
     }
 
     def matchtask(
-        self, task: Dict[str, Any], file: "Optional[Lintable]" = None
+        self, task: Dict[str, Any], file: Optional[Lintable] = None
     ) -> Union[bool, str]:
         if task["action"]["__ansible_module__"] in self._commands:
             first_cmd_arg = get_first_cmd_arg(task)

--- a/src/ansiblelint/rules/deprecated_local_action.py
+++ b/src/ansiblelint/rules/deprecated_local_action.py
@@ -1,6 +1,7 @@
 """Implementation for deprecated-local-action rule."""
 # Copyright (c) 2016, Tsukinowa Inc. <info@tsukinowa.jp>
 # Copyright (c) 2018, Ansible Project
+from __future__ import annotations
 
 import sys
 from typing import TYPE_CHECKING, Any, Dict, Union
@@ -24,7 +25,7 @@ class TaskNoLocalAction(AnsibleLintRule):
     version_added = "v4.0.0"
 
     def matchtask(
-        self, task: Dict[str, Any], file: "Optional[Lintable]" = None
+        self, task: Dict[str, Any], file: Optional[Lintable] = None
     ) -> Union[bool, str]:
         """Return matches for a task."""
         raw_task = task["__raw_task__"]

--- a/src/ansiblelint/rules/deprecated_module.py
+++ b/src/ansiblelint/rules/deprecated_module.py
@@ -1,6 +1,8 @@
 """Implementation of deprecated-module rule."""
 # Copyright (c) 2018, Ansible Project
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any, Dict, Union
 
 from ansiblelint.rules import AnsibleLintRule
@@ -69,7 +71,7 @@ class DeprecatedModuleRule(AnsibleLintRule):
     ]
 
     def matchtask(
-        self, task: Dict[str, Any], file: "Optional[Lintable]" = None
+        self, task: Dict[str, Any], file: Optional[Lintable] = None
     ) -> Union[bool, str]:
         module = task["action"]["__ansible_module__"]
         if module in self._modules:

--- a/src/ansiblelint/rules/empty_string_compare.py
+++ b/src/ansiblelint/rules/empty_string_compare.py
@@ -2,6 +2,8 @@
 # Copyright (c) 2016, Will Thames and contributors
 # Copyright (c) 2018, Ansible Project
 
+from __future__ import annotations
+
 import re
 import sys
 from typing import TYPE_CHECKING, Any, Dict, Union
@@ -30,7 +32,7 @@ class ComparisonToEmptyStringRule(AnsibleLintRule):
     empty_string_compare = re.compile("[=!]= ?(\"{2}|'{2})")
 
     def matchtask(
-        self, task: Dict[str, Any], file: "Optional[Lintable]" = None
+        self, task: Dict[str, Any], file: Optional[Lintable] = None
     ) -> Union[bool, str]:
         for k, v, _ in nested_items_path(task):
             if k == "when":

--- a/src/ansiblelint/rules/git_latest.py
+++ b/src/ansiblelint/rules/git_latest.py
@@ -19,6 +19,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any, Dict, Union
 
 from ansiblelint.rules import AnsibleLintRule
@@ -42,7 +44,7 @@ class GitHasVersionRule(AnsibleLintRule):
     version_added = "historic"
 
     def matchtask(
-        self, task: Dict[str, Any], file: "Optional[Lintable]" = None
+        self, task: Dict[str, Any], file: Optional[Lintable] = None
     ) -> Union[bool, str]:
         return bool(
             task["action"]["__ansible_module__"] == "git"

--- a/src/ansiblelint/rules/hg_latest.py
+++ b/src/ansiblelint/rules/hg_latest.py
@@ -19,6 +19,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any, Dict, Union
 
 from ansiblelint.rules import AnsibleLintRule
@@ -42,7 +44,7 @@ class MercurialHasRevisionRule(AnsibleLintRule):
     version_added = "historic"
 
     def matchtask(
-        self, task: Dict[str, Any], file: "Optional[Lintable]" = None
+        self, task: Dict[str, Any], file: Optional[Lintable] = None
     ) -> Union[bool, str]:
         return bool(
             task["action"]["__ansible_module__"] == "hg"

--- a/src/ansiblelint/rules/ignore_errors.py
+++ b/src/ansiblelint/rules/ignore_errors.py
@@ -1,4 +1,6 @@
 """IgnoreErrorsRule used with ansible-lint."""
+from __future__ import annotations
+
 import sys
 from typing import TYPE_CHECKING, Any, Dict, Union
 
@@ -25,7 +27,7 @@ class IgnoreErrorsRule(AnsibleLintRule):
     version_added = "v5.0.7"
 
     def matchtask(
-        self, task: Dict[str, Any], file: "Optional[Lintable]" = None
+        self, task: Dict[str, Any], file: Optional[Lintable] = None
     ) -> Union[bool, str]:
         if (
             task.get("ignore_errors")

--- a/src/ansiblelint/rules/inline_env_var.py
+++ b/src/ansiblelint/rules/inline_env_var.py
@@ -18,6 +18,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
+from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Dict, Union
 
@@ -60,7 +61,7 @@ class EnvVarsInCommandRule(AnsibleLintRule):
     ]
 
     def matchtask(
-        self, task: Dict[str, Any], file: "Optional[Lintable]" = None
+        self, task: Dict[str, Any], file: Optional[Lintable] = None
     ) -> Union[bool, str]:
         if task["action"]["__ansible_module__"] in ["command"]:
             first_cmd_arg = get_first_cmd_arg(task)

--- a/src/ansiblelint/rules/jinja.py
+++ b/src/ansiblelint/rules/jinja.py
@@ -1,6 +1,7 @@
 """Rule for checking content of jinja template strings."""
 # Copyright (c) 2016, Will Thames and contributors
 # Copyright (c) 2018, Ansible Project
+from __future__ import annotations
 
 import re
 import sys
@@ -39,7 +40,7 @@ class JinjaRule(AnsibleLintRule):
 
     def matchtask(
         self, task: Dict[str, Any], file: Optional[Lintable] = None
-    ) -> Union[bool, str, "MatchError"]:
+    ) -> Union[bool, str, MatchError]:
         for _, v, _ in nested_items_path(task):
             if isinstance(v, str):
                 cleaned = self.exclude_json_re.sub("", v)
@@ -56,11 +57,11 @@ class JinjaRule(AnsibleLintRule):
                     )
         return False
 
-    def matchyaml(self, file: Lintable) -> List["MatchError"]:
+    def matchyaml(self, file: Lintable) -> List[MatchError]:
         """Return matches for variables defined in vars files."""
         data: Dict[str, Any] = {}
-        raw_results: List["MatchError"] = []
-        results: List["MatchError"] = []
+        raw_results: List[MatchError] = []
+        results: List[MatchError] = []
 
         if str(file.kind) == "vars":
             data = parse_yaml_from_file(str(file.path))
@@ -158,7 +159,7 @@ if "pytest" in sys.modules:  # noqa: C901
     @pytest.fixture(name="lint_error_results_varsfile")
     def fixture_lint_error_results_varsfile(
         test_varsfile_path: str,
-    ) -> List["MatchError"]:
+    ) -> List[MatchError]:
         """Get VarHasSpacesRules linting results on test_vars."""
         collection = RulesCollection()
         collection.register(JinjaRule())
@@ -169,7 +170,7 @@ if "pytest" in sys.modules:  # noqa: C901
     def test_var_spacing_vars(
         error_expected_details_varsfile: List[str],
         error_expected_lines_varsfile: List[int],
-        lint_error_results_varsfile: List["MatchError"],
+        lint_error_results_varsfile: List[MatchError],
     ) -> None:
         """Ensure that expected error details are matching found linting error details."""
         details = list(map(lambda item: item.details, lint_error_results_varsfile))

--- a/src/ansiblelint/rules/literal_compare.py
+++ b/src/ansiblelint/rules/literal_compare.py
@@ -2,6 +2,8 @@
 # Copyright (c) 2016, Will Thames and contributors
 # Copyright (c) 2018-2021, Ansible Project
 
+from __future__ import annotations
+
 import re
 from typing import TYPE_CHECKING, Any, Dict, Union
 
@@ -29,7 +31,7 @@ class ComparisonToLiteralBoolRule(AnsibleLintRule):
     literal_bool_compare = re.compile("[=!]= ?(True|true|False|false)")
 
     def matchtask(
-        self, task: Dict[str, Any], file: "Optional[Lintable]" = None
+        self, task: Dict[str, Any], file: Optional[Lintable] = None
     ) -> Union[bool, str]:
         for k, v, _ in nested_items_path(task):
             if k == "when":

--- a/src/ansiblelint/rules/meta_incorrect.py
+++ b/src/ansiblelint/rules/meta_incorrect.py
@@ -1,5 +1,6 @@
 """Implementation of meta-incorrect rule."""
 # Copyright (c) 2018, Ansible Project
+from __future__ import annotations
 
 from typing import TYPE_CHECKING, List
 
@@ -31,9 +32,7 @@ class MetaChangeFromDefaultRule(AnsibleLintRule):
     tags = ["metadata"]
     version_added = "v4.0.0"
 
-    def matchplay(
-        self, file: "Lintable", data: "odict[str, Any]"
-    ) -> List["MatchError"]:
+    def matchplay(self, file: Lintable, data: odict[str, Any]) -> List[MatchError]:
         if file.kind != "meta":
             return []
 

--- a/src/ansiblelint/rules/meta_no_info.py
+++ b/src/ansiblelint/rules/meta_no_info.py
@@ -1,6 +1,7 @@
 """Implementation of meta-no-info rule."""
 # Copyright (c) 2016, Will Thames and contributors
 # Copyright (c) 2018, Ansible Project
+from __future__ import annotations
 
 from typing import TYPE_CHECKING, Generator, List
 
@@ -25,7 +26,7 @@ META_INFO = tuple(
 
 
 def _platform_info_errors_itr(
-    platforms: "List[odict[str, str]]",
+    platforms: List[odict[str, str]],
 ) -> Generator[str, None, None]:
     if not isinstance(platforms, list):
         yield "Platforms should be a list of dictionaries"
@@ -39,9 +40,9 @@ def _platform_info_errors_itr(
 
 
 def _galaxy_info_errors_itr(
-    galaxy_info: "odict[str, Any]",
-    info_list: "Tuple[str, ...]" = META_INFO,
-    str_info_list: "Tuple[str, ...]" = META_STR_INFO,
+    galaxy_info: odict[str, Any],
+    info_list: Tuple[str, ...] = META_INFO,
+    str_info_list: Tuple[str, ...] = META_STR_INFO,
 ) -> Generator[str, None, None]:
     for info in info_list:
         g_info = galaxy_info.get(info, False)
@@ -66,7 +67,7 @@ class MetaMainHasInfoRule(AnsibleLintRule):
     tags = ["metadata"]
     version_added = "v4.0.0"
 
-    def matchplay(self, file: Lintable, data: "odict[str, Any]") -> List[MatchError]:
+    def matchplay(self, file: Lintable, data: odict[str, Any]) -> List[MatchError]:
         if file.kind != "meta":
             return []
 

--- a/src/ansiblelint/rules/meta_no_tags.py
+++ b/src/ansiblelint/rules/meta_no_tags.py
@@ -1,12 +1,14 @@
 """Implementation of meta-no-tags rule."""
-
-# Copyright (c) 2018, Ansible Project
+from __future__ import annotations
 
 import re
 import sys
 from typing import TYPE_CHECKING, List
 
 from ansiblelint.rules import AnsibleLintRule
+
+# Copyright (c) 2018, Ansible Project
+
 
 if TYPE_CHECKING:
     from typing import Any
@@ -30,9 +32,7 @@ class MetaTagValidRule(AnsibleLintRule):
 
     TAG_REGEXP = re.compile("^[a-z0-9]+$")
 
-    def matchplay(
-        self, file: "Lintable", data: "odict[str, Any]"
-    ) -> List["MatchError"]:
+    def matchplay(self, file: Lintable, data: odict[str, Any]) -> List[MatchError]:
         if file.kind != "meta":
             return []
 
@@ -101,7 +101,7 @@ if "pytest" in sys.modules:
     @pytest.mark.parametrize(
         "rule_runner", (MetaTagValidRule,), indirect=["rule_runner"]
     )
-    def test_valid_tag_rule(rule_runner: "Any") -> None:
+    def test_valid_tag_rule(rule_runner: Any) -> None:
         """Test rule matches."""
         results = rule_runner.run_role_meta_main(META_TAG_VALID)
         assert "Use 'galaxy_tags' rather than 'categories'" in str(results)

--- a/src/ansiblelint/rules/meta_video_links.py
+++ b/src/ansiblelint/rules/meta_video_links.py
@@ -1,5 +1,6 @@
 """Implementation of meta-video-links rule."""
 # Copyright (c) 2018, Ansible Project
+from __future__ import annotations
 
 import re
 from typing import TYPE_CHECKING, List
@@ -34,9 +35,7 @@ class MetaVideoLinksRule(AnsibleLintRule):
         "youtube": re.compile(r"https://youtu\.be/([0-9A-Za-z-_]+)"),
     }
 
-    def matchplay(
-        self, file: "Lintable", data: "odict[str, Any]"
-    ) -> List["MatchError"]:
+    def matchplay(self, file: Lintable, data: odict[str, Any]) -> List[MatchError]:
         if file.kind != "meta":
             return []
 

--- a/src/ansiblelint/rules/name.py
+++ b/src/ansiblelint/rules/name.py
@@ -1,4 +1,6 @@
 """Implementation of NameRule."""
+from __future__ import annotations
+
 import sys
 from typing import TYPE_CHECKING, Any, Dict, Union
 
@@ -25,7 +27,7 @@ class NameRule(AnsibleLintRule):
     version_added = "historic"
 
     def matchtask(
-        self, task: Dict[str, Any], file: "Optional[Lintable]" = None
+        self, task: Dict[str, Any], file: Optional[Lintable] = None
     ) -> Union[bool, str, MatchError]:
         name = task.get("name")
         if not name:

--- a/src/ansiblelint/rules/no_changed_when.py
+++ b/src/ansiblelint/rules/no_changed_when.py
@@ -19,6 +19,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+from __future__ import annotations
+
 import sys
 from typing import TYPE_CHECKING, Any, Dict, Union
 
@@ -65,7 +67,7 @@ handle the output of the ``command``.
     _commands = ["command", "shell", "raw"]
 
     def matchtask(
-        self, task: Dict[str, Any], file: "Optional[Lintable]" = None
+        self, task: Dict[str, Any], file: Optional[Lintable] = None
     ) -> Union[bool, str]:
         # tasks in a block are "meta" type
         if task["__ansible_action_type__"] in ["task", "meta"]:

--- a/src/ansiblelint/rules/no_handler.py
+++ b/src/ansiblelint/rules/no_handler.py
@@ -19,6 +19,8 @@
 # THE SOFTWARE.
 
 """UseHandlerRatherThanWhenChangedRule used with ansible-lint."""
+from __future__ import annotations
+
 import sys
 from typing import TYPE_CHECKING, Any, Dict, Union
 
@@ -62,7 +64,7 @@ class UseHandlerRatherThanWhenChangedRule(AnsibleLintRule):
     version_added = "historic"
 
     def matchtask(
-        self, task: Dict[str, Any], file: "Optional[Lintable]" = None
+        self, task: Dict[str, Any], file: Optional[Lintable] = None
     ) -> Union[bool, str]:
         if task["__ansible_action_type__"] != "task":
             return False

--- a/src/ansiblelint/rules/no_jinja_nesting.py
+++ b/src/ansiblelint/rules/no_jinja_nesting.py
@@ -22,6 +22,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+from __future__ import annotations
+
 import re
 from typing import TYPE_CHECKING, Any, Dict, Union
 
@@ -50,7 +52,7 @@ class NestedJinjaRule(AnsibleLintRule):
     pattern = re.compile(r"{{(?:[^{}]*)?[^'\"]{{")
 
     def matchtask(
-        self, task: Dict[str, Any], file: "Optional[Lintable]" = None
+        self, task: Dict[str, Any], file: Optional[Lintable] = None
     ) -> Union[bool, str]:
         command = "".join(
             str(value)

--- a/src/ansiblelint/rules/no_jinja_when.py
+++ b/src/ansiblelint/rules/no_jinja_when.py
@@ -1,4 +1,6 @@
 """Implementation of no-jinja-when rule."""
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any, Dict, List, Union
 
 from ansiblelint.rules import AnsibleLintRule
@@ -29,10 +31,8 @@ class NoFormattingInWhenRule(AnsibleLintRule):
             return True
         return when.find("{{") == -1 and when.find("}}") == -1
 
-    def matchplay(
-        self, file: "Lintable", data: "odict[str, Any]"
-    ) -> List["MatchError"]:
-        errors: List["MatchError"] = []
+    def matchplay(self, file: Lintable, data: odict[str, Any]) -> List[MatchError]:
+        errors: List[MatchError] = []
         if isinstance(data, dict):
             if "roles" not in data or data["roles"] is None:
                 return errors
@@ -53,6 +53,6 @@ class NoFormattingInWhenRule(AnsibleLintRule):
         return errors
 
     def matchtask(
-        self, task: Dict[str, Any], file: "Optional[Lintable]" = None
+        self, task: Dict[str, Any], file: Optional[Lintable] = None
     ) -> Union[bool, str]:
         return "when" in task and not self._is_valid(task["when"])

--- a/src/ansiblelint/rules/no_log_password.py
+++ b/src/ansiblelint/rules/no_log_password.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 """NoLogPasswordsRule used with ansible-lint."""
+from __future__ import annotations
+
 import sys
 from typing import TYPE_CHECKING, Any, Dict, Union
 
@@ -38,7 +40,7 @@ class NoLogPasswordsRule(AnsibleLintRule):
     version_added = "v5.0.9"
 
     def matchtask(
-        self, task: Dict[str, Any], file: "Optional[Lintable]" = None
+        self, task: Dict[str, Any], file: Optional[Lintable] = None
     ) -> Union[bool, str]:
 
         if task["action"]["__ansible_module__"] == "user" and (

--- a/src/ansiblelint/rules/no_loop_var_prefix.py
+++ b/src/ansiblelint/rules/no_loop_var_prefix.py
@@ -1,4 +1,6 @@
 """Optional Ansible-lint rule to enforce use of prefix on role loop vars."""
+from __future__ import annotations
+
 import sys
 from typing import TYPE_CHECKING, Any, Dict, Union
 
@@ -29,7 +31,7 @@ Looping inside roles has the risk of clashing with loops from user-playbooks.\
     severity = "MEDIUM"
 
     def matchtask(
-        self, task: Dict[str, Any], file: "Optional[Lintable]" = None
+        self, task: Dict[str, Any], file: Optional[Lintable] = None
     ) -> Union[bool, str]:
         """Return matches for a task."""
         if not file or not file.role or not options.loop_var_prefix:

--- a/src/ansiblelint/rules/no_prompting.py
+++ b/src/ansiblelint/rules/no_prompting.py
@@ -1,4 +1,6 @@
 """Implementation of no-prompting rule."""
+from __future__ import annotations
+
 import sys
 from typing import TYPE_CHECKING, Any, Dict, List, Union
 
@@ -25,9 +27,7 @@ class NoPromptingRule(AnsibleLintRule):
     severity = "VERY_LOW"
     version_added = "v6.0.3"
 
-    def matchplay(
-        self, file: "Lintable", data: "odict[str, Any]"
-    ) -> List["MatchError"]:
+    def matchplay(self, file: Lintable, data: odict[str, Any]) -> List[MatchError]:
         """Return matches found for a specific playbook."""
         # If the Play uses the 'vars_prompt' section to set variables
 
@@ -47,7 +47,7 @@ class NoPromptingRule(AnsibleLintRule):
         ]
 
     def matchtask(
-        self, task: Dict[str, Any], file: "Optional[Lintable]" = None
+        self, task: Dict[str, Any], file: Optional[Lintable] = None
     ) -> Union[bool, str]:
         """Return matches for ansible.builtin.pause tasks."""
         # We do not want to trigger this rule if pause has either seconds or

--- a/src/ansiblelint/rules/no_relative_paths.py
+++ b/src/ansiblelint/rules/no_relative_paths.py
@@ -2,6 +2,8 @@
 # Copyright (c) 2016, Tsukinowa Inc. <info@tsukinowa.jp>
 # Copyright (c) 2018, Ansible Project
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any, Dict, Union
 
 from ansiblelint.rules import AnsibleLintRule
@@ -31,7 +33,7 @@ class RoleRelativePath(AnsibleLintRule):
     }
 
     def matchtask(
-        self, task: Dict[str, Any], file: "Optional[Lintable]" = None
+        self, task: Dict[str, Any], file: Optional[Lintable] = None
     ) -> Union[bool, str]:
         module = task["action"]["__ansible_module__"]
         if module not in self._module_to_path_folder:

--- a/src/ansiblelint/rules/no_same_owner.py
+++ b/src/ansiblelint/rules/no_same_owner.py
@@ -1,4 +1,6 @@
 """Optional rule for avoiding keeping owner/group when transferring files."""
+from __future__ import annotations
+
 import re
 import sys
 from typing import TYPE_CHECKING, Any, Dict, Union
@@ -31,7 +33,7 @@ https://zuul-ci.org/docs/zuul-jobs/policy.html\
     tags = ["opt-in"]
 
     def matchtask(
-        self, task: Dict[str, Any], file: "Optional[Lintable]" = None
+        self, task: Dict[str, Any], file: Optional[Lintable] = None
     ) -> Union[bool, str]:
         """Return matches for a task."""
         action = task.get("action")

--- a/src/ansiblelint/rules/no_tabs.py
+++ b/src/ansiblelint/rules/no_tabs.py
@@ -1,6 +1,8 @@
 """Implementation of no-tabs rule."""
 # Copyright (c) 2016, Will Thames and contributors
 # Copyright (c) 2018, Ansible Project
+from __future__ import annotations
+
 import sys
 from typing import TYPE_CHECKING, Any, Dict, Union
 
@@ -29,7 +31,7 @@ class NoTabsRule(AnsibleLintRule):
     ]
 
     def matchtask(
-        self, task: Dict[str, Any], file: "Optional[Lintable]" = None
+        self, task: Dict[str, Any], file: Optional[Lintable] = None
     ) -> Union[bool, str]:
         for k, v, parent_path in nested_items_path(task):
             if isinstance(k, str) and "\t" in k:

--- a/src/ansiblelint/rules/package_latest.py
+++ b/src/ansiblelint/rules/package_latest.py
@@ -19,6 +19,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any, Dict, Union
 
 from ansiblelint.rules import AnsibleLintRule
@@ -72,7 +74,7 @@ class PackageIsNotLatestRule(AnsibleLintRule):
     ]
 
     def matchtask(
-        self, task: Dict[str, Any], file: "Optional[Lintable]" = None
+        self, task: Dict[str, Any], file: Optional[Lintable] = None
     ) -> Union[bool, str]:
         return (
             task["action"]["__ansible_module__"] in self._package_managers

--- a/src/ansiblelint/rules/partial_become.py
+++ b/src/ansiblelint/rules/partial_become.py
@@ -18,6 +18,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
+from __future__ import annotations
 
 import sys
 from functools import reduce
@@ -32,7 +33,7 @@ if TYPE_CHECKING:
     from ansiblelint.file_utils import Lintable
 
 
-def _get_subtasks(data: "odict[str, Any]") -> List[Any]:
+def _get_subtasks(data: odict[str, Any]) -> List[Any]:
     result: List[Any] = []
     block_names = [
         "tasks",
@@ -49,7 +50,7 @@ def _get_subtasks(data: "odict[str, Any]") -> List[Any]:
     return result
 
 
-def _nested_search(term: str, data: "odict[str, Any]") -> Any:
+def _nested_search(term: str, data: odict[str, Any]) -> Any:
     if data and term in data:
         return True
     return reduce(
@@ -57,7 +58,7 @@ def _nested_search(term: str, data: "odict[str, Any]") -> Any:
     )
 
 
-def _become_user_without_become(becomeuserabove: bool, data: "odict[str, Any]") -> Any:
+def _become_user_without_become(becomeuserabove: bool, data: odict[str, Any]) -> Any:
     if "become" in data:
         # If become is in lineage of tree then correct
         return False
@@ -96,9 +97,7 @@ class BecomeUserWithoutBecomeRule(AnsibleLintRule):
     tags = ["unpredictability"]
     version_added = "historic"
 
-    def matchplay(
-        self, file: "Lintable", data: "odict[str, Any]"
-    ) -> List["MatchError"]:
+    def matchplay(self, file: Lintable, data: odict[str, Any]) -> List[MatchError]:
         if file.kind == "playbook":
             result = _become_user_without_become(False, data)
             if result:

--- a/src/ansiblelint/rules/risky_file_permissions.py
+++ b/src/ansiblelint/rules/risky_file_permissions.py
@@ -18,6 +18,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 """MissingFilePermissionsRule used with ansible-lint."""
+from __future__ import annotations
+
 import sys
 from typing import TYPE_CHECKING, Any, Dict, Set, Union
 
@@ -86,7 +88,7 @@ class MissingFilePermissionsRule(AnsibleLintRule):
 
     # pylint: disable=too-many-return-statements
     def matchtask(
-        self, task: Dict[str, Any], file: "Optional[Lintable]" = None
+        self, task: Dict[str, Any], file: Optional[Lintable] = None
     ) -> Union[bool, str]:
         module = task["action"]["__ansible_module__"]
         mode = task["action"].get("mode", None)

--- a/src/ansiblelint/rules/risky_octal.py
+++ b/src/ansiblelint/rules/risky_octal.py
@@ -19,6 +19,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any, Dict, Union
 
 from ansiblelint.rules import AnsibleLintRule
@@ -90,7 +92,7 @@ class OctalPermissionsRule(AnsibleLintRule):
         )
 
     def matchtask(
-        self, task: Dict[str, Any], file: "Optional[Lintable]" = None
+        self, task: Dict[str, Any], file: Optional[Lintable] = None
     ) -> Union[bool, str]:
         if task["action"]["__ansible_module__"] in self._modules:
             mode = task["action"].get("mode", None)

--- a/src/ansiblelint/rules/risky_shell_pipe.py
+++ b/src/ansiblelint/rules/risky_shell_pipe.py
@@ -1,4 +1,6 @@
 """Implementation of risky-shell-pipe rule."""
+from __future__ import annotations
+
 import re
 from typing import TYPE_CHECKING, Any, Dict, Union
 
@@ -31,7 +33,7 @@ class ShellWithoutPipefail(AnsibleLintRule):
     _pipe_re = re.compile(r"(?<!\|)\|(?!\|)")
 
     def matchtask(
-        self, task: Dict[str, Any], file: "Optional[Lintable]" = None
+        self, task: Dict[str, Any], file: Optional[Lintable] = None
     ) -> Union[bool, str]:
         if task["__ansible_action_type__"] != "task":
             return False

--- a/src/ansiblelint/rules/role_name.py
+++ b/src/ansiblelint/rules/role_name.py
@@ -19,6 +19,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
+from __future__ import annotations
 
 import re
 from pathlib import Path
@@ -58,11 +59,11 @@ class RoleNames(AnsibleLintRule):
         """Save precompiled regex."""
         self._re = re.compile(ROLE_NAME_REGEX)
 
-    def matchdir(self, lintable: "Lintable") -> List["MatchError"]:
+    def matchdir(self, lintable: Lintable) -> List[MatchError]:
         return self.matchyaml(lintable)
 
-    def matchyaml(self, file: Lintable) -> List["MatchError"]:
-        result: List["MatchError"] = []
+    def matchyaml(self, file: Lintable) -> List[MatchError]:
+        result: List[MatchError] = []
 
         if file.kind not in ("meta", "role"):
             return result

--- a/src/ansiblelint/rules/var_naming.py
+++ b/src/ansiblelint/rules/var_naming.py
@@ -1,4 +1,6 @@
 """Implementation of var-naming rule."""
+from __future__ import annotations
+
 import keyword
 import re
 import sys
@@ -98,12 +100,10 @@ class VariableNamingRule(AnsibleLintRule):
         # safety measure.
         return not bool(self.re_pattern.match(ident))
 
-    def matchplay(
-        self, file: "Lintable", data: "odict[str, Any]"
-    ) -> List["MatchError"]:
+    def matchplay(self, file: Lintable, data: odict[str, Any]) -> List[MatchError]:
         """Return matches found for a specific playbook."""
-        results: List["MatchError"] = []
-        raw_results: List["MatchError"] = []
+        results: List[MatchError] = []
+        raw_results: List[MatchError] = []
 
         # If the Play uses the 'vars' section to set variables
         our_vars = data.get("vars", {})
@@ -155,10 +155,10 @@ class VariableNamingRule(AnsibleLintRule):
 
         return False
 
-    def matchyaml(self, file: Lintable) -> List["MatchError"]:
+    def matchyaml(self, file: Lintable) -> List[MatchError]:
         """Return matches for variables defined in vars files."""
-        results: List["MatchError"] = []
-        raw_results: List["MatchError"] = []
+        results: List[MatchError] = []
+        raw_results: List[MatchError] = []
         meta_data: Dict[AnsibleUnicode, Any] = {}
 
         if str(file.kind) == "vars":

--- a/src/ansiblelint/rules/yaml.py
+++ b/src/ansiblelint/rules/yaml.py
@@ -1,4 +1,6 @@
 """Implementation of yaml linting rule (yamllint integration)."""
+from __future__ import annotations
+
 import logging
 import sys
 from typing import TYPE_CHECKING, List
@@ -34,10 +36,10 @@ class YamllintRule(AnsibleLintRule):
         # customize id by adding the one reported by yamllint
         self.id = self.__class__.id
 
-    def matchyaml(self, file: Lintable) -> List["MatchError"]:
+    def matchyaml(self, file: Lintable) -> List[MatchError]:
         """Return matches found for a specific YAML text."""
-        matches: List["MatchError"] = []
-        filtered_matches: List["MatchError"] = []
+        matches: List[MatchError] = []
+        filtered_matches: List[MatchError] = []
         if str(file.base_kind) != "text/yaml":
             return matches
 

--- a/src/ansiblelint/runner.py
+++ b/src/ansiblelint/runner.py
@@ -1,4 +1,6 @@
 """Runner implementation."""
+from __future__ import annotations
+
 import logging
 import multiprocessing
 import multiprocessing.pool
@@ -38,12 +40,12 @@ class Runner:
     def __init__(
         self,
         *lintables: Union[Lintable, str],
-        rules: "RulesCollection",
+        rules: RulesCollection,
         tags: FrozenSet[Any] = frozenset(),
         skip_list: Optional[List[str]] = None,
         exclude_paths: Optional[List[str]] = None,
         verbosity: int = 0,
-        checked_files: Optional[Set[Lintable]] = None
+        checked_files: Optional[Set[Lintable]] = None,
     ) -> None:
         """Initialize a Runner instance."""
         self.rules = rules
@@ -201,7 +203,7 @@ class Runner:
                 visited.add(lintable)
 
 
-def _get_matches(rules: "RulesCollection", options: "Namespace") -> LintResult:
+def _get_matches(rules: RulesCollection, options: Namespace) -> LintResult:
 
     lintables = ansiblelint.utils.get_lintables(opts=options, args=options.lintables)
 
@@ -214,7 +216,7 @@ def _get_matches(rules: "RulesCollection", options: "Namespace") -> LintResult:
         skip_list=options.skip_list,
         exclude_paths=options.exclude_paths,
         verbosity=options.verbosity,
-        checked_files=checked_files
+        checked_files=checked_files,
     )
     matches.extend(runner.run())
 

--- a/src/ansiblelint/skip_utils.py
+++ b/src/ansiblelint/skip_utils.py
@@ -19,6 +19,8 @@
 # THE SOFTWARE.
 
 """Utils related to inline skipping of rules."""
+from __future__ import annotations
+
 import logging
 from functools import lru_cache
 from itertools import product
@@ -64,8 +66,8 @@ def get_rule_skips_from_line(line: str) -> List[str]:
 
 
 def append_skipped_rules(
-    pyyaml_data: "AnsibleBaseYAMLObject", lintable: Lintable
-) -> "AnsibleBaseYAMLObject":
+    pyyaml_data: AnsibleBaseYAMLObject, lintable: Lintable
+) -> AnsibleBaseYAMLObject:
     """Append 'skipped_rules' to individual tasks or single metadata block.
 
     For a file, uses 2nd parser (ruamel.yaml) to pull comments out of
@@ -105,8 +107,8 @@ def load_data(file_text: str) -> Any:
 
 
 def _append_skipped_rules(
-    pyyaml_data: "AnsibleBaseYAMLObject", lintable: Lintable
-) -> Optional["AnsibleBaseYAMLObject"]:
+    pyyaml_data: AnsibleBaseYAMLObject, lintable: Lintable
+) -> Optional[AnsibleBaseYAMLObject]:
     # parse file text using 2nd parser library
     ruamel_data = load_data(lintable.content)
 

--- a/src/ansiblelint/testing/__init__.py
+++ b/src/ansiblelint/testing/__init__.py
@@ -1,4 +1,5 @@
 """Test utils for ansible-lint."""
+from __future__ import annotations
 
 import os
 import shutil
@@ -33,11 +34,11 @@ class RunFromText:
         """Initialize a RunFromText instance with rules collection."""
         self.collection = collection
 
-    def _call_runner(self, path: str) -> List["MatchError"]:
+    def _call_runner(self, path: str) -> List[MatchError]:
         runner = Runner(path, rules=self.collection)
         return runner.run()
 
-    def run_playbook(self, playbook_text: str) -> List["MatchError"]:
+    def run_playbook(self, playbook_text: str) -> List[MatchError]:
         """Lints received text as a playbook."""
         with tempfile.NamedTemporaryFile(
             mode="w", suffix=".yml", prefix="playbook"
@@ -47,7 +48,7 @@ class RunFromText:
             results = self._call_runner(fh.name)
         return results
 
-    def run_role_tasks_main(self, tasks_main_text: str) -> List["MatchError"]:
+    def run_role_tasks_main(self, tasks_main_text: str) -> List[MatchError]:
         """Lints received text as tasks."""
         role_path = tempfile.mkdtemp(prefix="role_")
         tasks_path = os.path.join(role_path, "tasks")
@@ -58,7 +59,7 @@ class RunFromText:
         shutil.rmtree(role_path)
         return results
 
-    def run_role_meta_main(self, meta_main_text: str) -> List["MatchError"]:
+    def run_role_meta_main(self, meta_main_text: str) -> List[MatchError]:
         """Lints received text as meta."""
         role_path = tempfile.mkdtemp(prefix="role_")
         meta_path = os.path.join(role_path, "meta")
@@ -69,7 +70,7 @@ class RunFromText:
         shutil.rmtree(role_path)
         return results
 
-    def run_role_defaults_main(self, defaults_main_text: str) -> List["MatchError"]:
+    def run_role_defaults_main(self, defaults_main_text: str) -> List[MatchError]:
         """Lints received text as vars file in defaults."""
         role_path = tempfile.mkdtemp(prefix="role_")
         defaults_path = os.path.join(role_path, "defaults")
@@ -85,7 +86,7 @@ def run_ansible_lint(
     *argv: str,
     cwd: Optional[str] = None,
     executable: Optional[str] = None,
-    env: Optional[Dict[str, str]] = None
+    env: Optional[Dict[str, str]] = None,
 ) -> CompletedProcess:
     """Run ansible-lint on a given path and returns its output."""
     if not executable:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,4 +1,6 @@
 """PyTest fixtures for testing the project."""
+from __future__ import annotations
+
 import os
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Iterator
@@ -24,7 +26,7 @@ def cwd(path: str) -> Iterator[None]:
         os.chdir(old_pwd)
 
 
-def pytest_addoption(parser: "Parser") -> None:
+def pytest_addoption(parser: Parser) -> None:
     """Add --regenerate-formatting-fixtures option to pytest."""
     parser.addoption(
         "--regenerate-formatting-fixtures",
@@ -34,7 +36,7 @@ def pytest_addoption(parser: "Parser") -> None:
     )
 
 
-def pytest_collection_modifyitems(items: "List[nodes.Item]", config: "Config") -> None:
+def pytest_collection_modifyitems(items: List[nodes.Item], config: Config) -> None:
     """Skip tests based on --regenerate-formatting-fixtures option."""
     do_regenerate = config.getoption("--regenerate-formatting-fixtures")
     skip_other = pytest.mark.skip(

--- a/test/test_skiputils.py
+++ b/test/test_skiputils.py
@@ -1,4 +1,6 @@
 """Validate ansiblelint.skip_utils."""
+from __future__ import annotations
+
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict
 
@@ -174,8 +176,8 @@ def test_playbook_noqa(default_text_runner: RunFromText) -> None:
 )
 def test_append_skipped_rules(
     lintable: Lintable,
-    yaml: "AnsibleBaseYAMLObject",
-    expected_form: "AnsibleBaseYAMLObject",
+    yaml: AnsibleBaseYAMLObject,
+    expected_form: AnsibleBaseYAMLObject,
 ) -> None:
     """Check that it appends skipped_rules properly."""
     assert append_skipped_rules(yaml, lintable) == expected_form


### PR DESCRIPTION
As the minimal version of python is py38, we can now avoid having to quote type hint information.

Reference: https://adamj.eu/tech/2021/05/15/python-type-hints-future-annotations/
Partial-Fix: https://github.com/ansible/devtools/issues/65