### PR TITLE
Reimplement jinja[spacing] to avoid use of regex

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -180,8 +180,10 @@ unignored
 unimported
 unindented
 unjinja
+unlex
 unnormalized
 unskippable
+unspaced
 unsubscriptable
 untemplated
 uwsgi

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -165,7 +165,7 @@ jobs:
       WSLENV: FORCE_COLOR:PYTEST_REQPASS:TOXENV:TOX_PARALLEL_NO_SPINNER
       # Number of expected test passes, safety measure for accidental skip of
       # tests. Update value if you add/remove tests.
-      PYTEST_REQPASS: 660
+      PYTEST_REQPASS: 693
 
     steps:
       - name: Activate WSL1

--- a/examples/playbooks/jinja-spacing.yml
+++ b/examples/playbooks/jinja-spacing.yml
@@ -1,6 +1,7 @@
 ---
 # Should raise jinja[spacing] at tasks line 23, 26, 29, 54, 65
-- hosts: all
+- name: Fixture for testing jinja2[spacing]
+  hosts: all
   tasks:
     - name: Good variable format
       ansible.builtin.debug:
@@ -18,7 +19,7 @@
       ansible.builtin.debug:
         msg: "{{ '{{' }}"
     - name: Jinja escaping allowed
-      # noqa: 306
+      # noqa: risky-shell-pipe
       ansible.builtin.shell: docker info --format '{{ '{{' }}json .Swarm.LocalNodeState{{ '}}' }}' | tr -d '"'
       changed_when: false
     - name: Jinja whitespace control allowed
@@ -56,10 +57,10 @@
       vars:
         cases:
           case1: >-
-            http://example.com/{{
+            http://foo.com/{{
               case1 }}
           case2: >-
-            http://example.com/{{
+            http://bar.com/{{
             case2 }}
       ansible.builtin.debug:
         var: cases

--- a/examples/playbooks/vars/jinja-spacing.yml
+++ b/examples/playbooks/vars/jinja-spacing.yml
@@ -1,5 +1,5 @@
 ---
-# Should raise jinja[spacing] at line [12, 13, 14, 27, 33], at following variables.
+# Should raise jinja[spacing] at line [14, 15, 16, 17, 18, 19, 22, 32, 38], at following variables.
 # ".bad_var_1", ".bad_var_2", ".bad_var_3", ".invalid_multiline_nested_json", ".invalid_nested_json"
 good_var_1: "{{ good_format }}"
 good_var_2: "Value: {{ good_format }}"
@@ -11,12 +11,12 @@ jinja_whitespace_control: |
   {{ good_format }}/
   {{- good_format }}
   {{- good_format -}}
-bad_var_1: "{{bad_format}}"
-bad_var_2: "Value: {{ bad_format}}"
-bad_var_3: "{{bad_format }}"
-bad_var_4: "{{ bad_format|filter }}"
-bad_var_5: "Value: {{ bad_format |filter }}"
-bad_var_6: "{{ bad_format| filter }}"
+bad_var_1: "{{bad_format}}" # <-- 1
+bad_var_2: "Value: {{ bad_format}}" # <-- 2
+bad_var_3: "{{bad_format }}" # <-- 3
+bad_var_4: "{{ bad_format|filter }}" # <-- 4
+bad_var_5: "Value: {{ bad_format |filter }}" # <-- 5
+bad_var_6: "{{ bad_format| filter }}" # <-- 6
 # spell-checker: disable-next-line
 non_jinja_var: "data = ${lookup{$local_part}lsearch{/etc/aliases}}" # noqa: jinja[spacing]
 json_inside_jinja: "{{ {'test': {'subtest': variable}} }}"
@@ -29,13 +29,13 @@ multiline_vars: # Assert that no false positive on multiline exists
       http://example.com/{{
       case2 }}
 valid_nested_json: "{{ {'dummy_2': {'nested_dummy_1': 'value_1', 'nested_dummy_2': value_2}} | combine(dummy_1) }}"
-invalid_nested_json: "{{ {'dummy_2': {'nested_dummy_1': 'value_1', 'nested_dummy_2': value_2}} | combine(dummy_1)}}"
+invalid_nested_json: "{{ {'dummy_2': {'nested_dummy_1': 'value_1', 'nested_dummy_2': value_2}} | combine(dummy_1)}}" # <-- 7
 
 valid_multiline_nested_json: >-
   {{ {'dummy_2': {'nested_dummy_1': value_1,
                   'nested_dummy_2': value_2}} |
   combine(dummy_1) }}
-invalid_multiline_nested_json: >-
+invalid_multiline_nested_json: >- # <-- 8
   {{ {'dummy_2': {'nested_dummy_1': value_1,
                   'nested_dummy_2': value_2}} |
   combine(dummy_1)}}

--- a/src/ansiblelint/rules/jinja.md
+++ b/src/ansiblelint/rules/jinja.md
@@ -1,15 +1,26 @@
 ## jinja
 
 This rule can report problems related to jinja2 string templates. The current
-version can report `jinja[spacing]` when there are no spaces between variables
-and operators, including filters, like `{{ var_name | filter }}`. This
-improves readability and makes it less likely to introduce typos.
+version can report:
+
+- `jinja[spacing]` when there are no spaces between variables
+  and operators, including filters, like `{{ var_name | filter }}`. This
+  improves readability and makes it less likely to introduce typos.
+- `jinja[invalid]` when the jinja2 template is invalid
+
+As jinja2 syntax is closely following Python one we aim to follow
+[black](https://black.readthedocs.io/en/stable/) formatting rules. If you are
+curious how black would reformat a small sniped feel free to visit
+[online black formatter](https://black.vercel.app/) site. Keep in mind to not
+include the entire jinja2 template, so instead of `{{ 1+2==3 }}`, do paste
+only `1+2==3`.
 
 ### Problematic code
 
 ```yaml
 ---
-foo: "{{some|dict2items}}"
+foo: "{{some|dict2items}}" # <-- jinja[spacing]
+bar: "{{ & }}" # <-- jinja[invalid]
 ```
 
 ### Correct code
@@ -17,4 +28,5 @@ foo: "{{some|dict2items}}"
 ```yaml
 ---
 foo: "{{ some | dict2items }}"
+bar: "{{ '&' }}"
 ```

--- a/src/ansiblelint/rules/jinja.py
+++ b/src/ansiblelint/rules/jinja.py
@@ -1,27 +1,24 @@
 """Rule for checking content of jinja template strings."""
-# Copyright (c) 2016, Will Thames and contributors
-# Copyright (c) 2018, Ansible Project
 from __future__ import annotations
 
-import re
+import logging
 import sys
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
+import jinja2
 from ansible.parsing.yaml.objects import AnsibleUnicode
 
 from ansiblelint.file_utils import Lintable
 from ansiblelint.rules import AnsibleLintRule
 from ansiblelint.skip_utils import get_rule_skips_from_line
-from ansiblelint.utils import LINE_NUMBER_KEY, parse_yaml_from_file, task_to_str
+from ansiblelint.utils import LINE_NUMBER_KEY, parse_yaml_from_file
 from ansiblelint.yaml_utils import nested_items_path
 
 if TYPE_CHECKING:
     from ansiblelint.errors import MatchError
 
-# Please note that current implementation is only able to report
-# `jinja[spacing]` occurrences, formerly named `var-spacing`. We aim to refactor
-# the implementation to replace currently unreliable regex with use of jinja2
-# parser. That will also allow use to implement additional checks.
+
+_logger = logging.getLogger(__package__)
 
 
 class JinjaRule(AnsibleLintRule):
@@ -30,30 +27,31 @@ class JinjaRule(AnsibleLintRule):
     id = "jinja"
     severity = "LOW"
     tags = ["formatting"]
-    version_added = "v6.3.0"
+    version_added = "v6.5.0"
 
-    bracket_regex = re.compile(r"{{[^{\n' -]|[^ '\n}-]}}", re.MULTILINE | re.DOTALL)
-    exclude_json_re = re.compile(r"[^{]{'\w+': ?[^{]{.*?}}", re.MULTILINE | re.DOTALL)
-    pipe_spacing_regex = re.compile(
-        r"{{.*(?<=[^ \n\t])[|].*|.*[|](?=[^ \n\t]).*}}", re.MULTILINE | re.DOTALL
-    )
+    env = jinja2.Environment()
+    _tag2msg = {
+        "invalid": "Syntax error in jinja2 template: {value}",
+        "spacing": "Jinja2 spacing could be improved: {value} -> {reformatted}",
+    }
+
+    def _msg(self, tag: str, value: str, reformatted: str) -> str:
+        """Generate error message."""
+        return self._tag2msg[tag].format(value=value, reformatted=reformatted)
 
     def matchtask(
         self, task: Dict[str, Any], file: Optional[Lintable] = None
     ) -> Union[bool, str, MatchError]:
         for _, v, _ in nested_items_path(task):
             if isinstance(v, str):
-                cleaned = self.exclude_json_re.sub("", v)
-                if bool(self.bracket_regex.search(cleaned)) or bool(
-                    self.pipe_spacing_regex.search(cleaned)
-                ):
-                    task_msg = "Task/Handler: " + task_to_str(task)
+                reformatted, details, tag = self.check_whitespace(v)
+                if reformatted != v:
                     return self.create_matcherror(
-                        message=f"Jinja2 variables and filters should have spaces before and after. ({v})",
+                        message=self._msg(tag=tag, value=v, reformatted=reformatted),
                         linenumber=task[LINE_NUMBER_KEY],
-                        details=task_msg,
+                        details=details,
                         filename=file,
-                        tag=f"{self.id}[spacing]",
+                        tag=f"{self.id}[{tag}]",
                     )
         return False
 
@@ -65,22 +63,20 @@ class JinjaRule(AnsibleLintRule):
 
         if str(file.kind) == "vars":
             data = parse_yaml_from_file(str(file.path))
+            # pylint: disable=unused-variable
             for k, v, path in nested_items_path(data):
                 if isinstance(v, AnsibleUnicode):
-                    cleaned = self.exclude_json_re.sub("", v)
-                    if bool(self.bracket_regex.search(cleaned)) or bool(
-                        self.pipe_spacing_regex.search(cleaned)
-                    ):
-                        path_elem = [
-                            f"[{i}]" if isinstance(i, int) else i for i in path + [k]
-                        ]
-                        raw_results.append(
+                    reformatted, details, tag = self.check_whitespace(v)
+                    if reformatted != v:
+                        results.append(
                             self.create_matcherror(
-                                filename=file,
+                                message=self._msg(
+                                    tag=tag, value=v, reformatted=reformatted
+                                ),
                                 linenumber=v.ansible_pos[1],
-                                message=self.shortdesc.format(var_name=v),
-                                details=f".{'.'.join(path_elem)}",
-                                tag="jinja[spacing]",
+                                details=details,
+                                filename=file,
+                                tag=f"{self.id}[{tag}]",
                             )
                         )
             if raw_results:
@@ -94,6 +90,244 @@ class JinjaRule(AnsibleLintRule):
             results.extend(super().matchyaml(file))
         return results
 
+    def lex(self, text: str) -> List[Tuple[int, str, str]]:
+        """Parse jinja template."""
+        # https://github.com/pallets/jinja/issues/1711
+        self.env.keep_trailing_newline = True
+
+        self.env.lstrip_blocks = False
+        self.env.trim_blocks = False
+        tokens = list(self.env.lex(text))
+        new_text = self.unlex(tokens)
+        if text != new_text:
+            _logger.debug(
+                "Unable to perform full roundrip lex-unlex on jinja template (expected when '-' modifier is used): {text} -> {new_text}"
+            )
+        return tokens
+
+    def unlex(self, tokens: List[Any]) -> str:
+        """Return original text by compiling the lex output."""
+        result = ""
+        last_lineno = 1
+        last_value = ""
+        for lineno, _, value in tokens:
+            if lineno > last_lineno and "\n" not in last_value:
+                result += "\n"
+            result += value
+            last_lineno = lineno
+            last_value = value
+        return result
+
+    # pylint: disable=too-many-branches,too-many-statements,too-many-locals
+    def check_whitespace(  # noqa: max-complexity: 13
+        self, text: str
+    ) -> Tuple[str, str, str]:
+        """Check spacing inside given jinja2 template string.
+
+        We aim to match Python Black formatting rules.
+
+        :returns: (string, string, string)  reformatted text, detailed error, error tag
+        """
+        prev_token_type: str = ""
+        prev_value: str = ""
+        tokens = []
+        details = ""
+        begin_types = ("variable_begin", "comment_begin", "block_begin")
+        end_types = ("variable_end", "comment_end", "block_end")
+
+        spaced_operators = {
+            "+",
+            "-",
+            "/",
+            "//",
+            "*",
+            "%",
+            "**",
+            "~",
+            "==",
+            "!=",
+            ">",
+            ">=",
+            "<",
+            "<=",
+            "=",
+            "|",
+        }
+        unspaced_operators = {"[", "]", "(", ")", "{", "}", "."}
+        space_folowed_operators = {",", ";", ":"}
+        pre_spaced_operators = spaced_operators
+        post_spaced_operators = spaced_operators | space_folowed_operators
+
+        def in_expression(tokens: List[Any]) -> str:
+            """Check if tokens represent an unfinished expression.
+
+            Returns last unclosed {[( or empty string.
+            """
+            opened: List[str] = []
+            pairs = {
+                ")": "(",
+                "]": "[",
+                "}": "{",
+            }
+            for _, token_type, value in tokens:  # reverse order
+                if token_type == "operator":
+                    if value in ("(", "[", "{"):
+                        opened.append(value)
+                    elif value in (")", "]", "}"):
+                        opened.remove(pairs[value])
+            if opened:
+                return opened[0]
+            return ""
+
+        try:
+            previous_tokens = self.lex(text)
+        except jinja2.exceptions.TemplateSyntaxError as exc:
+            return "", str(exc.message), "invalid"
+
+        tokens = previous_tokens
+
+        # phase 1 : add missing whitespace
+        prev_token_type = ""
+        prev_value = ""
+        prev_lineno = 1
+        tokens = []
+        for lineno, token_type, value in previous_tokens:
+
+            if (
+                token_type in begin_types
+                and "-" in value
+                and prev_token_type == "data"
+                and not prev_value.endswith(" ")
+                and lineno == prev_lineno
+            ):
+                # "foo{%-" -> "foo {%-"
+                tokens[-1] = (tokens[-1][0], tokens[-1][1], tokens[-1][2] + " ")
+
+            if token_type in end_types and prev_token_type not in (
+                "whitespace",
+                "comment",
+            ):
+                tokens.append((lineno, "whitespace", " "))
+            elif prev_token_type in begin_types and token_type not in (
+                "whitespace",
+                "comment",
+            ):
+                tokens.append((lineno, "whitespace", " "))
+            if token_type in ("comment", "whitespace") and "\n" not in value:
+                # ensure comments/whitespace do not have more than one leading
+                # or trailing space in them, while not touching \n \r
+                stripped = " " + value.strip(" \t") + " "
+                if stripped == "  ":
+                    stripped = " "
+                if stripped != value:
+                    value = stripped
+            if (
+                token_type != "whitespace"
+                and token_type == "operator"
+                and value in pre_spaced_operators
+                and prev_token_type != "whitespace"
+            ):
+                tokens.append((lineno, "whitespace", " "))
+            if (
+                prev_token_type == "operator"
+                and prev_value in post_spaced_operators
+                and token_type != "whitespace"
+            ):
+                if not (
+                    prev_value == ":"
+                    and prev_token_type == "operator"
+                    and in_expression(tokens) == "["
+                ):
+                    avoid_spacing = False
+                    for token in tokens[:-1][::-1]:
+                        if token[1] in begin_types:
+                            avoid_spacing = True
+                            break
+                        if token[1] == "operator" and token[2] in (":", ""):
+                            avoid_spacing = True
+                            break
+                        if token[1] in ("operator", "integer", "string", "name"):
+                            avoid_spacing = False
+                            break
+                    if not avoid_spacing:
+                        tokens.append((lineno, "whitespace", " "))
+
+            tokens.append((lineno, token_type, value))
+            prev_token_type = token_type
+            prev_value = value
+            prev_lineno = lineno
+
+        # phase 2 : remove undesirable whitespace
+        prev_token_type = ""
+        prev_value = ""
+        previous_tokens = tokens
+        tokens = []
+        # pylint: disable=too-many-nested-blocks
+        for lineno, token_type, value in previous_tokens:
+
+            if prev_token_type == "whitespace" and "\n" not in prev_value:
+
+                if (
+                    token_type == "operator"
+                    and value == ":"
+                    and tokens[-2][1] == "operator"
+                    and tokens[-2][2] == "["
+                ):
+                    tokens.pop()
+                elif token_type == "operator" and value in {
+                    *unspaced_operators,
+                    "=",
+                    ":",
+                }:
+                    # effective removal of whitespace
+                    if value in ("=", "]", ")", "}") and in_expression(tokens):
+                        tokens.pop()
+                    elif tokens[-2][1] == "operator" and tokens[-2][2] in {
+                        *unspaced_operators,
+                        "=",
+                    }:
+                        if tokens[-2][2] not in ("=", ",") or (
+                            tokens[-2][2] in ("=", ":") and in_expression(tokens)
+                        ):
+                            tokens.pop()
+                elif in_expression(tokens):
+                    if tokens[-2][1] == "operator":
+                        if tokens[-2][2] in (
+                            "=",
+                            "[",
+                            "{",
+                            "(",
+                        ):
+                            tokens.pop()
+                        elif tokens[-2][2] == ":" and in_expression(tokens) == "[":
+                            tokens.pop()
+                else:
+                    if tokens[-2][1] == "operator" and tokens[-2][2] in ("-", "+"):
+                        avoid_spacing = False
+                        for token in tokens[:-2][::-1]:
+                            if token[1] in begin_types:
+                                avoid_spacing = True
+                                break
+                            if token[1] in ("operator", "integer", "string", "name"):
+                                avoid_spacing = False
+                                break
+                        if avoid_spacing:
+                            tokens.pop()
+
+            tokens.append((lineno, token_type, value))
+            prev_token_type = token_type
+            prev_value = value
+
+        # finalize
+        reformatted = self.unlex(tokens)
+        failed = reformatted != text
+        details = (
+            f"Jinja2 template rewrite recommendation: `{reformatted}`."
+            if failed
+            else ""
+        )
+        return reformatted, details, "spacing"
+
 
 if "pytest" in sys.modules:  # noqa: C901
 
@@ -105,23 +339,19 @@ if "pytest" in sys.modules:  # noqa: C901
     @pytest.fixture(name="error_expected_lines")
     def fixture_error_expected_lines() -> List[int]:
         """Return list of expected error lines."""
-        return [30, 33, 36, 39, 42, 45, 71, 82]
+        return [31, 34, 37, 40, 43, 46, 72, 83]
 
-    @pytest.fixture(name="test_playbook")
-    def fixture_test_playbook() -> str:
-        """Return test cases playbook path."""
-        return "examples/playbooks/jinja-spacing.yml"
-
+    # 21 68
     @pytest.fixture(name="lint_error_lines")
-    def fixture_lint_error_lines(test_playbook: str) -> List[int]:
+    def fixture_lint_error_lines() -> List[int]:
         """Get VarHasSpacesRules linting results on test_playbook."""
         collection = RulesCollection()
         collection.register(JinjaRule())
-        lintable = Lintable(test_playbook)
+        lintable = Lintable("examples/playbooks/jinja-spacing.yml")
         results = Runner(lintable, rules=collection).run()
         return list(map(lambda item: item.linenumber, results))
 
-    def test_var_spacing(
+    def test_jinja_spacing_playbook(
         error_expected_lines: List[int], lint_error_lines: List[int]
     ) -> None:
         """Ensure that expected error lines are matching found linting error lines."""
@@ -131,58 +361,175 @@ if "pytest" in sys.modules:  # noqa: C901
         )
         assert len(error_lines_difference) == 0
 
-    # Test for vars file
-    @pytest.fixture(name="error_expected_details_varsfile")
-    def fixture_error_expected_details_varsfile() -> List[str]:
-        """Return list of expected error details."""
-        return [
-            ".bad_var_1",
-            ".bad_var_2",
-            ".bad_var_3",
-            ".bad_var_4",
-            ".bad_var_5",
-            ".bad_var_6",
-            ".invalid_multiline_nested_json",
-            ".invalid_nested_json",
-        ]
-
-    @pytest.fixture(name="error_expected_lines_varsfile")
-    def fixture_error_expected_lines_varsfile() -> List[int]:
-        """Return list of expected error lines."""
-        return [14, 15, 16, 17, 18, 19, 32, 38]
-
-    @pytest.fixture(name="test_varsfile_path")
-    def fixture_test_varsfile_path() -> str:
-        """Return test cases vars file path."""
-        return "examples/playbooks/vars/jinja-spacing.yml"
-
-    @pytest.fixture(name="lint_error_results_varsfile")
-    def fixture_lint_error_results_varsfile(
-        test_varsfile_path: str,
-    ) -> List[MatchError]:
-        """Get VarHasSpacesRules linting results on test_vars."""
+    def test_jinja_spacing_vars() -> None:
+        """Ensure that expected error details are matching found linting error details."""
         collection = RulesCollection()
         collection.register(JinjaRule())
-        lintable = Lintable(test_varsfile_path)
+        lintable = Lintable("examples/playbooks/vars/jinja-spacing.yml")
         results = Runner(lintable, rules=collection).run()
-        return results
 
-    def test_var_spacing_vars(
-        error_expected_details_varsfile: List[str],
-        error_expected_lines_varsfile: List[int],
-        lint_error_results_varsfile: List[MatchError],
-    ) -> None:
-        """Ensure that expected error details are matching found linting error details."""
-        details = list(map(lambda item: item.details, lint_error_results_varsfile))
-        # list unexpected error details or non-matching error details
-        error_details_difference = list(
-            set(error_expected_details_varsfile).symmetric_difference(set(details))
-        )
-        assert len(error_details_difference) == 0
+        error_expected_lineno = [14, 15, 16, 17, 18, 19, 32, 38]
+        assert len(results) == len(error_expected_lineno)
+        for idx, err in enumerate(results):
+            assert err.linenumber == error_expected_lineno[idx]
 
-        lines = list(map(lambda item: item.linenumber, lint_error_results_varsfile))
-        # list unexpected error lines or non-matching error lines
-        error_lines_difference = list(
-            set(error_expected_lines_varsfile).symmetric_difference(set(lines))
-        )
-        assert len(error_lines_difference) == 0
+    @pytest.mark.parametrize(
+        ("text", "expected", "tag"),
+        (
+            pytest.param(
+                "{{-x}}{#a#}{%1%}",
+                "{{- x }}{# a #}{% 1 %}",
+                "spacing",
+                id="add-missing-space",
+            ),
+            pytest.param("", "", "spacing", id="1"),
+            pytest.param("foo", "foo", "spacing", id="2"),
+            pytest.param("{##}", "{# #}", "spacing", id="3"),
+            pytest.param("{#  #}", "{# #}", "spacing", id="4"),
+            pytest.param(
+                "{{-aaa|xx   }}foo\nbar{#some#}\n{%%}",
+                "{{- aaa | xx }}foo\nbar{# some #}\n{% %}",
+                "spacing",
+                id="5",
+            ),
+            pytest.param(
+                "Shell with jinja filter", "Shell with jinja filter", "spacing", id="6"
+            ),
+            pytest.param(
+                "{{{'dummy_2':1}|true}}",
+                "{{ {'dummy_2': 1} | true }}",
+                "spacing",
+                id="7",
+            ),
+            pytest.param("{{{foo:{}}}}", "{{ {foo: {}} }}", "spacing", id="8"),
+            pytest.param(
+                "{{ {'test': {'subtest': variable}} }}",
+                "{{ {'test': {'subtest': variable}} }}",
+                "spacing",
+                id="9",
+            ),
+            pytest.param(
+                "http://foo.com/{{\n  case1 }}",
+                "http://foo.com/{{\n  case1 }}",
+                "spacing",
+                id="10",
+            ),
+            pytest.param("{{foo(123)}}", "{{ foo(123) }}", "spacing", id="11"),
+            pytest.param("{{ foo(a.b.c) }}", "{{ foo(a.b.c) }}", "spacing", id="12"),
+            pytest.param(
+                "{{ foo | bool else [ ] }}",
+                "{{ foo | bool else [] }}",
+                "spacing",
+                id="13",
+            ),
+            pytest.param(
+                "{{foo(x =['server_options'])}}",
+                "{{ foo(x=['server_options']) }}",
+                "spacing",
+                id="14",
+            ),
+            pytest.param(
+                '{{ [ "host", "NA"] }}', '{{ ["host", "NA"] }}', "spacing", id="15"
+            ),
+            pytest.param(
+                "{{ {'dummy_2': {'nested_dummy_1': value_1,\n    'nested_dummy_2': value_2}} |\ncombine(dummy_1) }}",
+                "{{ {'dummy_2': {'nested_dummy_1': value_1,\n    'nested_dummy_2': value_2}} |\ncombine(dummy_1) }}",
+                "spacing",
+                id="17",
+            ),
+            pytest.param("{{ & }}", "", "invalid", id="18"),
+            pytest.param(
+                "{{ good_format }}/\n{{- good_format }}\n{{- good_format -}}\n",
+                "{{ good_format }}/\n{{- good_format }}\n{{- good_format -}}\n",
+                "spacing",
+                id="19",
+            ),
+            pytest.param(
+                "{{ {'a': {'b': 'x', 'c': y}} }}",
+                "{{ {'a': {'b': 'x', 'c': y}} }}",
+                "spacing",
+                id="20",
+            ),
+            pytest.param(
+                "2*(1+(3-1)) is {{ 2 * {{ 1 + {{ 3 - 1 }}}} }}",
+                "2*(1+(3-1)) is {{ 2 * {{1 + {{3 - 1}}}} }}",
+                "spacing",
+                id="21",
+            ),
+            pytest.param(
+                '{{ "absent"\nif (v is version("2.8.0", ">=")\nelse "present" }}',
+                "",
+                "invalid",
+                id="22",
+            ),
+            pytest.param(
+                '{{lookup("x",y+"/foo/"+z+".txt")}}',
+                '{{ lookup("x", y + "/foo/" + z + ".txt") }}',
+                "spacing",
+                id="23",
+            ),
+            pytest.param(
+                "{{ x | map(attribute='value') }}",
+                "{{ x | map(attribute='value') }}",
+                "spacing",
+                id="24",
+            ),
+            pytest.param(
+                "{{ r(a= 1,b= True,c= 0.0,d= '') }}",
+                "{{ r(a=1, b=True, c=0.0, d='') }}",
+                "spacing",
+                id="25",
+            ),
+            pytest.param("{{ r(1,[]) }}", "{{ r(1, []) }}", "spacing", id="26"),
+            pytest.param(
+                "{{ lookup([ddd ]) }}", "{{ lookup([ddd]) }}", "spacing", id="27"
+            ),
+            pytest.param(
+                "{{ [ x ] if x is string else x }}",
+                "{{ [x] if x is string else x }}",
+                "spacing",
+                id="28",
+            ),
+            pytest.param(
+                # "{% if a|int <= 8 -%} iptables {%- else -%} iptables-nft {%- endif %}",
+                "{% if a|int <= 8 -%} iptables {%- else -%} iptables-nft {%- endif %}",
+                "{% if a | int <= 8 -%} iptables {%- else -%} iptables-nft {%- endif %}",
+                "spacing",
+                id="29",
+            ),
+            pytest.param(
+                # "- 2" -> "-2", minus does not get separated when there is no left side
+                "{{ - 2 }}",
+                "{{ -2 }}",
+                "spacing",
+                id="30",
+            ),
+            pytest.param(
+                # "-2" -> "-2", minus does get an undesired spacing
+                "{{ -2 }}",
+                "{{ -2 }}",
+                "spacing",
+                id="31",
+            ),
+            pytest.param(
+                # array ranges do not have space added
+                "{{ foo[2:4] }}",
+                "{{ foo[2:4] }}",
+                "spacing",
+                id="32",
+            ),
+            pytest.param(
+                # array ranges have the extra space removed
+                "{{ foo[2: 4] }}",
+                "{{ foo[2:4] }}",
+                "spacing",
+                id="33",
+            ),
+        ),
+    )
+    def test_jinja(text: str, expected: str, tag: str) -> None:
+        """Tests our ability to spot spacing errors inside jinja2 templates."""
+        rule = JinjaRule()
+        reformatted, details, returned_tag = rule.check_whitespace(text)
+        assert tag == returned_tag, details
+        assert expected == reformatted


### PR DESCRIPTION
This change rewrites jinja2 rule to make it use jinaja lexer and
avoid use of regexes for parsing, as they cause too many false
positives.

Fixes: #2301
Fixes: #2285
Fixes: #2241
Fixes: #2209
Fixes: #2208
Fixes: #2120