### PR TITLE
Remove pytest from default dependencies

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -42,4 +42,5 @@ python:
       path: .
       extra_requirements:
         - docs
+        - test
   system_packages: false

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,7 +74,6 @@ install_requires =
   jsonschema>=4.9.0  # MIT, version needed for improved errors
   packaging
   pyyaml
-  pytest
   rich>=9.5.1
   # The next version is planned to have breaking changes
   ruamel.yaml >= 0.15.34, < 0.18

--- a/tox.ini
+++ b/tox.ini
@@ -132,7 +132,7 @@ commands =
 description = Builds docs
 basepython = python3
 deps =
-  --editable .[docs]
+  --editable .[docs,test]
 setenv =
   PIP_CONSTRAINT = {toxinidir}/requirements.txt
 commands =


### PR DESCRIPTION
While we need pytest for testing, we do not need it at runtime.
Fixes regression introduced in #2084
