### PR TITLE
Avoid early of splitting shorthand string

### DIFF
--- a/src/ansiblelint/rules/command_instead_of_shell.py
+++ b/src/ansiblelint/rules/command_instead_of_shell.py
@@ -40,11 +40,11 @@ FAIL_PLAY = """---
     changed_when: false
 
   - name: Shell with jinja filter
-    ansible.builtin.shell: echo {{ "hello"|upper }}
+    ansible.builtin.shell: echo {{ "hello" | upper }}
     changed_when: false
 
   - name: Sshell with jinja filter (fqcn)
-    ansible.builtin.shell: echo {{ "hello"|upper }}
+    ansible.builtin.shell: echo {{ "hello" | upper }}
     changed_when: false
 """
 
@@ -143,7 +143,13 @@ if "pytest" in sys.modules:
 
     from ansiblelint.testing import RunFromText  # pylint: disable=ungrouped-imports
 
-    @pytest.mark.parametrize(("text", "expected"), ((SUCCESS_PLAY, 0), (FAIL_PLAY, 3)))
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        (
+            pytest.param(SUCCESS_PLAY, 0, id="good"),
+            pytest.param(FAIL_PLAY, 3, id="bad"),
+        ),
+    )
     def test_rule_command_instead_of_shell(
         default_text_runner: RunFromText, text: str, expected: int
     ) -> None:

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -594,7 +594,9 @@ def normalize_task_v2(task: Dict[str, Any]) -> Dict[str, Any]:
     )
 
     if "_raw_params" in arguments:
-        result["action"]["__ansible_arguments__"] = arguments["_raw_params"].split(" ")
+        # Doing a split here is really bad as it would break jinja2 templating
+        # parsing of the template must happen before any kind of split.
+        result["action"]["__ansible_arguments__"] = [arguments["_raw_params"]]
         del arguments["_raw_params"]
     else:
         result["action"]["__ansible_arguments__"] = []
@@ -772,7 +774,7 @@ def get_first_cmd_arg(task: Dict[str, Any]) -> Any:
         if "cmd" in task["action"]:
             first_cmd_arg = task["action"]["cmd"].split()[0]
         else:
-            first_cmd_arg = task["action"]["__ansible_arguments__"][0]
+            first_cmd_arg = task["action"]["__ansible_arguments__"][0].split()[0]
     except IndexError:
         return None
     return first_cmd_arg
@@ -784,7 +786,7 @@ def get_second_cmd_arg(task: Dict[str, Any]) -> Any:
         if "cmd" in task["action"]:
             second_cmd_arg = task["action"]["cmd"].split()[1]
         else:
-            second_cmd_arg = task["action"]["__ansible_arguments__"][1]
+            second_cmd_arg = task["action"]["__ansible_arguments__"][0].split()[1]
     except IndexError:
         return None
     return second_cmd_arg


### PR DESCRIPTION
This should prevent errors with more complex jinja2 templates used
in shorthand string. We are likely to even add a rule that marks these
as errors due to the high chance of getting either errors or
unexpected results.
