### PR TITLE
Fix subprocess.run for progressive mode

### DIFF
--- a/src/ansiblelint/__main__.py
+++ b/src/ansiblelint/__main__.py
@@ -255,18 +255,18 @@ def _previous_revision() -> Iterator[None]:
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.DEVNULL,
-    ).stdout
+    ).stdout.strip()
     path = pathlib.Path(worktree_dir)
     path.mkdir(parents=True, exist_ok=True)
+    # Run check will fail if worktree_dir already exists
+    # pylint: disable=subprocess-run-check
     subprocess.run(
         ["git", "worktree", "add", "-f", worktree_dir],
-        shell=True,
         stderr=subprocess.DEVNULL,
-        check=True,
     )
     try:
         with cwd(worktree_dir):
-            subprocess.run(["git", "checkout", revision], shell=True, check=True)
+            subprocess.run(["git", "checkout", revision], check=True)
             yield
     finally:
         options.exclude_paths = [abspath(p, os.getcwd()) for p in rel_exclude_paths]


### PR DESCRIPTION
Fixes #2314 

Several issues I've noticed with recently introduced `subprocess.run` for git commands in progressive mode:

1. `git rev-parse HEAD^1` returns a newline, so have to be stripped, otherwise error
2. `git worktree add -f worktree_dir` uses `shell=True`. It expects a string so it fails with a list of arguments as reported in issue #2314 )
3. `git checkout revision` uses `shell=True`. Same as above
4. `git worktree add -f worktree_dir` uses `check=True`. It fails when the directory already exists. So each subsequent `ansible-lint` run will fail
