### PR TITLE
Progressive mode. Return absolute path for Lintable

### DIFF
--- a/src/ansiblelint/file_utils.py
+++ b/src/ansiblelint/file_utils.py
@@ -60,7 +60,7 @@ def normpath(path: str | BasePathLike) -> str:
     relpath = os.path.relpath(str(path))
     path_absolute = os.path.abspath(str(path))
     # we avoid returning relative paths that end-up at root level
-    if path_absolute in relpath:
+    if path_absolute in relpath or vars(options).get("progressive"):
         return path_absolute
     return relpath
 


### PR DESCRIPTION
Another issue with progressive mode.
Relative paths are different for files in the current folder and in .cache folder.
Those paths included in `matches`, so `matches` considered different as well.

Added lintable details output to demonstrate the issue:
Latest master:
```
ansible-lint --progressive /Users/konstantinplis/repositories/msp-scm/roles/msp.service.legacy_as/defaults/main.yml
Lintable name: /Users/konstantinplis/repositories/msp-scm/roles/msp.service.legacy_as/defaults/main.yml
Lintable self.name: roles/msp.service.legacy_as/defaults/main.yml
Lintable self.path: roles/msp.service.legacy_as/defaults/main.yml
Preparing worktree (checking out 'old-rev')
HEAD is now at 3d62073b0c Automatic merge from XXXXXX -> XXXXXX
Lintable name: /Users/konstantinplis/repositories/msp-scm/roles/msp.service.legacy_as/defaults/main.yml
Lintable self.name: ../../../../repositories/msp-scm/roles/msp.service.legacy_as/defaults/main.yml
Lintable self.path: ../../../../repositories/msp-scm/roles/msp.service.legacy_as/defaults/main.yml
WARNING  Listing 1 violation(s) that are fatal
```

With `normpath` hack:
```
ansible-lint --progressive /Users/konstantinplis/repositories/msp-scm/roles/msp.service.legacy_as/defaults/main.yml
Lintable name: /Users/konstantinplis/repositories/msp-scm/roles/msp.service.legacy_as/defaults/main.yml
Lintable self.name: /Users/konstantinplis/repositories/msp-scm/roles/msp.service.legacy_as/defaults/main.yml
Lintable self.path: /Users/konstantinplis/repositories/msp-scm/roles/msp.service.legacy_as/defaults/main.yml
Preparing worktree (checking out 'old-rev')
HEAD is now at 3d62073b0c Automatic merge from XXXXXX -> XXXXXX
Lintable name: /Users/konstantinplis/repositories/msp-scm/roles/msp.service.legacy_as/defaults/main.yml
Lintable self.name: /Users/konstantinplis/repositories/msp-scm/roles/msp.service.legacy_as/defaults/main.yml
Lintable self.path: /Users/konstantinplis/repositories/msp-scm/roles/msp.service.legacy_as/defaults/main.yml
WARNING  Total violations not increased since previous commit, will mark result as success. (1 -> 0)
WARNING  Marked 1 previously known violation(s) as ignored due to progressive mode.
WARNING  Listing 1 violation(s) marked as ignored, likely already known
```

Do let me know if this is a legitimate way to fix the issue, or it needs to be more sophisticated here.