### PR TITLE
command-instead-of-module: allow `systemctl --version`

### DIFF
--- a/src/ansiblelint/rules/command_instead_of_module.py
+++ b/src/ansiblelint/rules/command_instead_of_module.py
@@ -70,7 +70,7 @@ class CommandsInsteadOfModulesRule(AnsibleLintRule):
 
     _executable_options = {
         "git": ["branch", "log", "lfs"],
-        "systemctl": ["set-default", "show-environment", "status"],
+        "systemctl": ["--version", "set-default", "show-environment", "status"],
         "yum": ["clean"],
         "rpm": ["--nodeps"],
     }


### PR DESCRIPTION
If a user wants to get the version of systemd, allow this without
raising a `command-instead-of-module` error.

The `ansible.builtin.systemd` module does not have support for getting
the version.