### PR TITLE
jinja[spacing]: Include in default warn_list until it matures

### DIFF
--- a/src/ansiblelint/config.py
+++ b/src/ansiblelint/config.py
@@ -10,7 +10,13 @@ from typing import Any
 
 from ansiblelint.loaders import yaml_from_file
 
-DEFAULT_WARN_LIST = ["experimental", "name[casing]", "name[play]", "role-name"]
+DEFAULT_WARN_LIST = [
+    "experimental",
+    "jinja[spacing]",  # warning until we resolve all reported false-positives
+    "name[casing]",
+    "name[play]",
+    "role-name",
+]
 
 DEFAULT_KINDS = [
     # Do not sort this list, order matters.


### PR DESCRIPTION
As we know that there are still known false-positive formatting
recommendations we include this rule in the default warn_list.
