### PR TITLE
Avoid importing fixtures as plugins

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -20,7 +20,6 @@ if missing:
 
 
 os.environ["NO_COLOR"] = "1"
-pytest_plugins = ["ansiblelint.testing.fixtures"]
 
 
 # pylint: disable=unused-argument

--- a/src/ansiblelint/rules/__init__.py
+++ b/src/ansiblelint/rules/__init__.py
@@ -307,11 +307,18 @@ def is_valid_rule(rule: Any) -> bool:
 
 
 # pylint: disable=too-many-nested-blocks
-def load_plugins(directory: str) -> Iterator[AnsibleLintRule]:
+def load_plugins(  # noqa: max-complexity: 11
+    directory: str,
+) -> Iterator[AnsibleLintRule]:
     """Yield a rule class."""
     for pluginfile in glob.glob(os.path.join(directory, "[A-Za-z]*.py")):
 
         pluginname = os.path.basename(pluginfile.replace(".py", ""))
+
+        #  conftest.py is a special file used by pytest, not a rule
+        if pluginname == "conftest":
+            continue
+
         spec = importlib.util.spec_from_file_location(pluginname, pluginfile)
 
         # https://github.com/python/typeshed/issues/2793

--- a/src/ansiblelint/rules/conftest.py
+++ b/src/ansiblelint/rules/conftest.py
@@ -1,0 +1,3 @@
+"""Makes pytest fixtures available."""
+# pylint: disable=wildcard-import,unused-wildcard-import
+from ansiblelint.testing.fixtures import *  # noqa: F403

--- a/src/ansiblelint/rules/no_changed_when.py
+++ b/src/ansiblelint/rules/no_changed_when.py
@@ -149,7 +149,7 @@ if "pytest" in sys.modules:
         "rule_runner", (CommandHasChangesCheckRule,), indirect=["rule_runner"]
     )
     def test_no_change_command_rc(rule_runner: Any) -> None:
-        """This should pass since *_when is used."""
+        """This should pass since ``*_when`` is used."""
         results = rule_runner.run_playbook(NO_CHANGE_COMMAND_RC)
         assert len(results) == 0
 
@@ -157,7 +157,7 @@ if "pytest" in sys.modules:
         "rule_runner", (CommandHasChangesCheckRule,), indirect=["rule_runner"]
     )
     def test_no_change_shell_rc(rule_runner: Any) -> None:
-        """This should pass since *_when is used."""
+        """This should pass since ``*_when`` is used."""
         results = rule_runner.run_playbook(NO_CHANGE_SHELL_RC)
         assert len(results) == 0
 
@@ -165,7 +165,7 @@ if "pytest" in sys.modules:
         "rule_runner", (CommandHasChangesCheckRule,), indirect=["rule_runner"]
     )
     def test_no_change_shell_false(rule_runner: Any) -> None:
-        """This should pass since *_when is used."""
+        """This should pass since ``*_when`` is used."""
         results = rule_runner.run_playbook(NO_CHANGE_SHELL_FALSE)
         assert len(results) == 0
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -7,6 +7,9 @@ from typing import TYPE_CHECKING, Iterator
 
 import pytest
 
+# pylint: disable=wildcard-import,unused-wildcard-import
+from ansiblelint.testing.fixtures import *  # noqa: F403
+
 if TYPE_CHECKING:
     from typing import List  # pylint: disable=ungrouped-imports
 


### PR DESCRIPTION
This should avoid premature import of the library when testing.
