### PR TITLE
Ensure libyaml presence during testing

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -80,6 +80,7 @@ jsonschema
 junitxml
 kubernetes
 libera
+libyaml
 lineinfile
 lintable
 literalinclude

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -55,6 +55,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: "pip"
       # - name: set PY_SHA256
       #   run: echo "::set-env name=PY_SHA256::$(python -VV | sha256sum | cut -d' ' -f1)"
       # - name: Pre-commit cache

--- a/conftest.py
+++ b/conftest.py
@@ -5,6 +5,7 @@ import sys
 from typing import Any
 
 import pytest
+from ansible.module_utils.common.yaml import HAS_LIBYAML
 
 # checking if user is running pytest without installing test dependencies:
 missing = []
@@ -14,6 +15,15 @@ for module in ["ansible", "black", "flake8", "flaky", "mypy", "pylint"]:
 if missing:
     print(
         f"FATAL: Missing modules: {', '.join(missing)} -- probably you missed installing test requirements with: pip install -e '.[test]'",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+if not HAS_LIBYAML:
+    # While presence of libyaml is not required for runtime, we keep this error
+    # fatal here in order to be sure that we spot libyaml errors during testing.
+    print(
+        "FATAL: For testing, we require pyyaml to be installed with its native extension, missing it would make testing 3x slower and risk missing essential bugs.",
         file=sys.stderr,
     )
     sys.exit(1)

--- a/tools/test-setup.sh
+++ b/tools/test-setup.sh
@@ -18,7 +18,10 @@ if [ -f "/usr/bin/apt-get" ]; then
     sudo apt-get remove -y ansible pipx || true
     # cspell:disable-next-line
     sudo apt-get install -y --no-install-recommends -o=Dpkg::Use-Pty=0 \
-        git python3-venv python3-pip
+        gcc git python3-venv python3-pip python3-dev libyaml-dev
+    # Some of these might be needed for compiling packages that do not yet
+    # a binary for current platform, like pyyaml on py311
+    pip3 install -v --no-binary :all: --user pyyaml
 fi
 
 which pipx || python3 -m pip install --user pipx


### PR DESCRIPTION
As absence of libyaml can have serious repercussions, especially on speed, we now require
it for testing purposes. As pyyaml is not yet pre-compiled for all platforms, this means we need to install some system dependencies so pip can properly compile libyaml when needed.

This does does not make libyaml presence for runtime.