### PR TITLE
name[play]: now also correctly works with import_playbook blocks

### DIFF
--- a/src/ansiblelint/rules/name.py
+++ b/src/ansiblelint/rules/name.py
@@ -31,10 +31,7 @@ class NameRule(AnsibleLintRule):
         """Return matches found for a specific play (entry in playbook)."""
         if file.kind != "playbook":
             return []
-        if "name" not in data and not any(
-            key in data
-            for key in ["import_playbook", "ansible.builtin.import_playbook"]
-        ):
+        if "name" not in data:
             return [
                 self.create_matcherror(
                     message="All plays should be named.",

--- a/test/test_skip_import_playbook.py
+++ b/test/test_skip_import_playbook.py
@@ -25,7 +25,8 @@ MAIN_PLAYBOOK = """\
     - name: Should be shell  # noqa command-instead-of-shell no-changed-when
       ansible.builtin.shell: echo lol
 
-- import_playbook: imported_playbook.yml
+- name: Should not be imported
+  import_playbook: imported_playbook.yml
 """
 
 


### PR DESCRIPTION
When running ansible-lint on a playbook like:

```
---
- ansible.builtin.import_playbook: "test.yml"
```

ansible-lint is now "complaining":
```
WARNING  Ignored exception from NameRule.<bound method AnsibleLintRule.matchyaml of name: Rule for checking task and play names.>: 'name'
```

The test in src/ansiblelint/rules/name.py:matchplay() is trying to ignore
the import_playbook case but with current test leads to the line:

```
data["name"], lintable=file, linenumber=data[LINE_NUMBER_KEY]
```

and in this example, the key "name" doesn't exist, leading to the warning.

The proposed solution here is to split the test into two and return
no error if "name" is not set for import_playbook.

[ Not sure what's currently best practice with import_playbook:
should a name be set or not ? ]

Signed-off-by: Arnaud Patard <apatard@hupstream.com>