### PR TITLE
Refactor rule loading so we can correctly load markdown help files

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,7 @@ Ansible teams.
 
 ```{toctree}
 :caption: User Guide
-:maxdepth: 2
+:maxdepth: 1
 
 Philosophy<philosophy>
 installing

--- a/src/ansiblelint/_internal/internal_error.md
+++ b/src/ansiblelint/_internal/internal_error.md
@@ -1,0 +1,33 @@
+# internal-error
+
+This error can also be caused by internal bugs but also by custom rules.
+Instead of just stopping tool execution, we generate the errors and continue
+processing other files. This allows users to add this rule to their `warn_list`
+until the root cause is fixed.
+
+Keep in mind that once an `internal-error` is found on a specific file, no
+other rules will be executed on that same file.
+
+In almost all cases you will see more detailed information regarding the
+original error or runtime exception that triggered this rule.
+
+If these files are broken on purpose, like some test fixtures, you need to add
+them to the `exclude_list`.
+
+## Problematic code
+
+```yaml
+---
+- name: Some title {{ # <-- Ansible will not load this invalid jinja template
+  hosts: localhost
+  tasks: []
+```
+
+## Correct code
+
+```yaml
+---
+- name: Some title
+  hosts: localhost
+  tasks: []
+```

--- a/src/ansiblelint/_internal/rules.py
+++ b/src/ansiblelint/_internal/rules.py
@@ -1,9 +1,12 @@
 """Internally used rule classes."""
 from __future__ import annotations
 
+import inspect
 import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+
+from ansiblelint.constants import RULE_DOC_URL
 
 if TYPE_CHECKING:
     from typing import Optional
@@ -48,14 +51,16 @@ class BaseRule:
     # _order 5 implicit for normal rules
     _order: int = 5
     _help: str | None = None
-    RULE_DOC_URL = "https://ansible-lint.readthedocs.io/en/latest/rules/"
 
     @property
     def help(self) -> str:
         """Return a help markdown string for the rule."""
         if self._help is None:
             self._help = ""
-            md_file = Path(__file__).parent / f"{self.id.replace('-', '_')}.md"
+            md_file = (
+                Path(inspect.getfile(self.__class__)).parent
+                / f"{self.id.replace('-', '_')}.md"
+            )
             if md_file.exists():
                 self._help = md_file.read_text(encoding="utf-8")
         return self._help
@@ -63,7 +68,7 @@ class BaseRule:
     @property
     def url(self) -> str:
         """Return rule documentation url."""
-        return self.link or self.RULE_DOC_URL + self.id + "/"
+        return self.link or RULE_DOC_URL + self.id + "/"
 
     @property
     def shortdesc(self) -> str:

--- a/src/ansiblelint/constants.py
+++ b/src/ansiblelint/constants.py
@@ -4,6 +4,7 @@ from typing import Literal
 
 DEFAULT_RULESDIR = os.path.join(os.path.dirname(__file__), "rules")
 CUSTOM_RULESDIR_ENVVAR = "ANSIBLE_LINT_CUSTOM_RULESDIR"
+RULE_DOC_URL = "https://ansible-lint.readthedocs.io/en/latest/rules/"
 
 SUCCESS_RC = 0
 VIOLATIONS_FOUND_RC = 2

--- a/src/ansiblelint/generate_docs.py
+++ b/src/ansiblelint/generate_docs.py
@@ -15,7 +15,7 @@ from rich.markdown import Markdown
 from rich.table import Table
 
 from ansiblelint.config import PROFILES
-from ansiblelint.constants import DEFAULT_RULESDIR
+from ansiblelint.constants import RULE_DOC_URL
 from ansiblelint.rules import RulesCollection
 
 DOC_HEADER = """
@@ -125,7 +125,6 @@ def rules_as_rich(rules: RulesCollection) -> Iterable[Table]:
 def profiles_as_md(header: bool = False) -> str:
     """Return markdown representation of supported profiles."""
     result = ""
-    default_rules = RulesCollection([DEFAULT_RULESDIR])
 
     if header:
         result += """<!---
@@ -155,18 +154,10 @@ them with links to their issues.
             )
         result += f"## {name}\n\n{profile['description']}{extends}\n"
         for rule, rule_data in profile["rules"].items():
-            for default_rule in default_rules.rules:
-                if default_rule.id == rule:
-                    result += f"- [{rule}](rules/{rule}.md)\n"
-                    break
+            if not rule_data:
+                result += f"- [{rule}]({RULE_DOC_URL}/{rule})\n"
             else:
-                if not rule_data:
-                    raise RuntimeError(f"Rule {rule} has no data.")
-                url = rule_data.get("url", None)
-                if url:
-                    result += f"- [{rule}]({url})*\n"
-                else:
-                    raise RuntimeError("All planned rules must have an 'url' entry.")
+                result += f"- [{rule}]({rule_data['url']})\n"
         result += "\n"
     return result
 

--- a/src/ansiblelint/rules/__init__.py
+++ b/src/ansiblelint/rules/__init__.py
@@ -2,16 +2,15 @@
 from __future__ import annotations
 
 import copy
-import glob
-import importlib.util
 import inspect
 import logging
-import os
 import re
+import sys
 from argparse import Namespace
 from collections import defaultdict
 from functools import lru_cache
-from importlib.abc import Loader
+from importlib import import_module
+from pathlib import Path
 from typing import (
     Any,
     Dict,
@@ -38,6 +37,7 @@ from ansiblelint._internal.rules import (
 )
 from ansiblelint.config import PROFILES, get_rule_config
 from ansiblelint.config import options as default_options
+from ansiblelint.constants import RULE_DOC_URL
 from ansiblelint.errors import MatchError
 from ansiblelint.file_utils import Lintable, expand_paths_vars
 
@@ -60,7 +60,7 @@ class AnsibleLintRule(BaseRule):
     @property
     def url(self) -> str:
         """Return rule documentation url."""
-        return self.RULE_DOC_URL + self.id + "/"
+        return RULE_DOC_URL + self.id + "/"
 
     @property
     def rule_config(self) -> dict[str, Any]:
@@ -306,39 +306,52 @@ class TransformMixin:
         return target
 
 
-def is_valid_rule(rule: Any) -> bool:
-    """Check if given rule is valid or not."""
-    return issubclass(rule, AnsibleLintRule) and bool(rule.id) and bool(rule.shortdesc)
-
-
 # pylint: disable=too-many-nested-blocks
 def load_plugins(  # noqa: max-complexity: 11
-    directory: str,
+    dirs: list[str],
 ) -> Iterator[AnsibleLintRule]:
     """Yield a rule class."""
-    for pluginfile in glob.glob(os.path.join(directory, "[A-Za-z]*.py")):
 
-        pluginname = os.path.basename(pluginfile.replace(".py", ""))
+    def all_subclasses(cls: type) -> set[type]:
+        return set(cls.__subclasses__()).union(
+            [
+                s
+                for c in cls.__subclasses__()
+                for s in all_subclasses(c)
+                if getattr(s, "id")
+            ]
+        )
 
-        #  conftest.py is a special file used by pytest, not a rule
-        if pluginname == "conftest":
-            continue
+    orig_sys_path = sys.path.copy()
 
-        spec = importlib.util.spec_from_file_location(pluginname, pluginfile)
+    for directory in dirs:
+        if directory not in sys.path:
+            sys.path.append(str(directory))
 
-        # https://github.com/python/typeshed/issues/2793
-        if spec and isinstance(spec.loader, Loader):
-            module = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(module)
-            try:
-                for _, obj in inspect.getmembers(module):
-                    if inspect.isclass(obj) and is_valid_rule(obj):
-                        yield obj()
+        # load all modules in the directory
+        for f in Path(directory).glob("*.py"):
+            if "__" not in f.stem:
+                try:
+                    import_module(f"{f.stem}")
+                except ImportError as exc:
+                    _logger.warning("Ignore loading rule from %s due to %s", f, exc)
+    # restore sys.path
+    sys.path = orig_sys_path
 
-            except (TypeError, ValueError, AttributeError) as exc:
-                _logger.warning(
-                    "Skipped invalid rule from %s due to %s", pluginname, exc
-                )
+    rules: dict[str, BaseRule] = {}
+    for rule in all_subclasses(BaseRule):
+        # we do not return the rules that are not loaded from passed 'directory'
+        # or rules that do not have a valid id. For example, during testing
+        # python may load other rule classes, some outside the tested rule
+        # directories.
+        if getattr(rule, "id") and Path(inspect.getfile(rule)).parent.absolute() in [
+            Path(x).absolute() for x in dirs
+        ]:
+            if issubclass(rule, BaseRule) and rule.id not in rules:
+                rules[rule.id] = rule()
+    for rule in rules.values():  # type: ignore
+        if isinstance(rule, AnsibleLintRule) and bool(rule.id) and bool(rule.shortdesc):
+            yield rule
 
 
 class RulesCollection:
@@ -360,10 +373,8 @@ class RulesCollection:
         self.rules.extend(
             [RuntimeErrorRule(), AnsibleParserErrorRule(), LoadingFailureRule()]
         )
-        for rulesdir in self.rulesdirs:
-            _logger.debug("Loading rules from %s", rulesdir)
-            for rule in load_plugins(rulesdir):
-                self.register(rule)
+        for rule in load_plugins(rulesdirs):
+            self.register(rule)
         self.rules = sorted(self.rules)
 
     def register(self, obj: AnsibleLintRule) -> None:

--- a/src/ansiblelint/rules/__init__.py
+++ b/src/ansiblelint/rules/__init__.py
@@ -328,22 +328,11 @@ def load_plugins(  # noqa: max-complexity: 11
 
         # https://github.com/python/typeshed/issues/2793
         if spec and isinstance(spec.loader, Loader):
-
-            # load rule markdown documentation if found
-            help_md = ""
-            if spec.origin:
-                md_filename = os.path.splitext(spec.origin)[0] + ".md"
-                if os.path.exists(md_filename):
-                    with open(md_filename, encoding="utf-8") as f:
-                        help_md = f.read()
-
             module = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(module)
             try:
                 for _, obj in inspect.getmembers(module):
                     if inspect.isclass(obj) and is_valid_rule(obj):
-                        if help_md:
-                            obj.help = help_md
                         yield obj()
 
             except (TypeError, ValueError, AttributeError) as exc:

--- a/src/ansiblelint/rules/deprecated_command_syntax.md
+++ b/src/ansiblelint/rules/deprecated_command_syntax.md
@@ -7,7 +7,7 @@ are hard to identify.
 While using the free-form from the command line is ok, it should never be used
 inside playbooks.
 
-# Problematic Code
+## Problematic Code
 
 ```yaml
 ---
@@ -18,7 +18,7 @@ inside playbooks.
       ansible.builtin.command: creates=B chmod 644 A # <-- do not use shorthand
 ```
 
-# Correct Code
+## Correct Code
 
 ```yaml
 ---

--- a/test/rules/fixtures/raw_task.md
+++ b/test/rules/fixtures/raw_task.md
@@ -1,0 +1,3 @@
+# raw-task
+
+This is a test rule that looks in a raw task to flag raw action params.

--- a/test/rules/fixtures/raw_task.py
+++ b/test/rules/fixtures/raw_task.py
@@ -10,11 +10,8 @@ from ansiblelint.rules import AnsibleLintRule
 class RawTaskRule(AnsibleLintRule):
     """Test rule that inspects the raw task."""
 
-    id = "TEST0003"
+    id = "raw-task"
     shortdesc = "Test rule that inspects the raw task"
-    description = (
-        "This is a test rule that looks in a raw task to flag raw action params."
-    )
     tags = ["fake", "dummy", "test3"]
     needs_raw_task = True
 

--- a/test/test_lint_rule.py
+++ b/test/test_lint_rule.py
@@ -19,11 +19,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+from test.rules.fixtures import ematcher, raw_task
+
 import pytest
 
 from ansiblelint.file_utils import Lintable
-
-from .rules.fixtures import ematcher, raw_task
 
 
 @pytest.fixture(name="lintable")

--- a/test/test_rules_collection.py
+++ b/test/test_rules_collection.py
@@ -60,7 +60,7 @@ def test_run_collection(
 ) -> None:
     """Test that default rules match pre-meditated violations."""
     matches = test_rules_collection.run(ematchtestfile)
-    assert len(matches) == 4  # 3 occurrences of BANNED using TEST0001 + 1 for TEST0003
+    assert len(matches) == 4  # 3 occurrences of BANNED using TEST0001 + 1 for raw-task
     assert matches[0].linenumber == 3
 
 
@@ -103,11 +103,11 @@ def test_skip_id(
 ) -> None:
     """Check that skipping valid IDs excludes their violations."""
     matches = test_rules_collection.run(
-        ematchtestfile, skip_list=["TEST0001", "TEST0003"]
+        ematchtestfile, skip_list=["TEST0001", "raw-task"]
     )
     assert len(matches) == 0
     matches = test_rules_collection.run(
-        ematchtestfile, skip_list=["TEST0002", "TEST0003"]
+        ematchtestfile, skip_list=["TEST0002", "raw-task"]
     )
     assert len(matches) == 3
     matches = test_rules_collection.run(bracketsmatchtestfile, skip_list=["TEST0001"])

--- a/test/test_verbosity.py
+++ b/test/test_verbosity.py
@@ -49,29 +49,29 @@ from ansiblelint.testing import run_ansible_lint
         (
             "-vv",
             [
-                ("DEBUG    Loading custom .yamllint config file,", False),
+                # ("DEBUG    Loading custom .yamllint config file,", False),
                 ("WARNING  Listing 1 violation(s) that are fatal", False),
                 ("INFO     Set ANSIBLE_LIBRARY=", False),
-                ("DEBUG    Effective yamllint rules used", False),
+                # ("DEBUG    Effective yamllint rules used", False),
             ],
         ),
         (
             "-vvvvvvvvvvvvvvvvvvvvvvvvv",
             [
-                ("DEBUG    Loading custom .yamllint config file,", False),
+                # ("DEBUG    Loading custom .yamllint config file,", False),
                 ("WARNING  Listing 1 violation(s) that are fatal", False),
                 ("INFO     Set ANSIBLE_LIBRARY=", False),
-                ("DEBUG    Effective yamllint rules used", False),
+                # ("DEBUG    Effective yamllint rules used", False),
             ],
         ),
     ),
     ids=(
-        "default verbosity",
+        "default-verbosity",
         "quiet",
-        "really quiet",
+        "really-quiet",
         "loquacious",
-        "really loquacious",
-        'really loquacious but with more "v"s -- same as -vv',
+        "really-loquacious",
+        'really-loquacious but with more "v"s -- same as -vv',
     ),
 )
 def test_default_verbosity(verbosity: str, substrs: list[tuple[str, bool]]) -> None:


### PR DESCRIPTION
We now load the markdown help using lazy loading so we no longer need to manually load the documentation files when we load the rules.

This also allows us to add markdown documentation for the internal rules, which are not loaded using the normal loader.