### PR TITLE
Move ansible-lint config schema inside our repo

### DIFF
--- a/src/ansiblelint/config.py
+++ b/src/ansiblelint/config.py
@@ -88,7 +88,7 @@ JSON_SCHEMAS = {
     "execution-environment": "https://raw.githubusercontent.com/ansible/schemas/main/f/ansible-ee.json",
     "meta-runtime": "https://raw.githubusercontent.com/ansible/schemas/main/f/ansible-meta-runtime.json",
     "inventory": "https://raw.githubusercontent.com/ansible/schemas/main/f/ansible-inventory.json",
-    "ansible-lint-config": "https://raw.githubusercontent.com/ansible/schemas/main/f/ansible-lint.json",
+    "ansible-lint-config": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/ansible-lint-config.json",
     "ansible-navigator-config": "https://raw.githubusercontent.com/ansible/ansible-navigator/main/src/ansible_navigator/data/ansible-navigator.json",
     "arg_specs": "https://raw.githubusercontent.com/ansible/schemas/main/f/ansible-argument-specs.json",
 }

--- a/src/ansiblelint/schemas/__init__.py
+++ b/src/ansiblelint/schemas/__init__.py
@@ -1,8 +1,11 @@
 """Module containing cached JSON schemas."""
+import logging
 import os
 import urllib.request
 
 from ansiblelint.config import JSON_SCHEMAS
+
+_logger = logging.getLogger(__package__)
 
 
 def refresh_schemas() -> int:
@@ -12,6 +15,12 @@ def refresh_schemas() -> int:
     """
     changed = 0
     for kind, url in sorted(JSON_SCHEMAS.items()):
+        if url.startswith("https://raw.githubusercontent.com/ansible/ansible-lint"):
+            _logger.warning(
+                "Skipped updating schema that is part of the ansible-lint repository: %s",
+                url,
+            )
+            continue
         path = f"{os.path.relpath(os.path.dirname(__file__))}/{kind}.json"
         print(f"Refreshing {path} ...")
         with urllib.request.urlopen(url) as response:

--- a/src/ansiblelint/schemas/ansible-lint-config.json
+++ b/src/ansiblelint/schemas/ansible-lint-config.json
@@ -14,7 +14,7 @@
       "type": "object"
     }
   },
-  "$id": "https://raw.githubusercontent.com/ansible/schemas/main/f/ansible-lint.json",
+  "$id": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/ansible-lint-config.json",
   "$schema": "http://json-schema.org/draft-07/schema",
   "additionalProperties": false,
   "examples": [".ansible-lint", ".config/ansible-lint.yml"],


### PR DESCRIPTION
To make it easier to update configuration schema with newer versions of ansible-lint, we now manage it from the same repo as the tool.

To finish the switch we will need two follow-ups:
- update https://github.com/SchemaStore/schemastore to point to new location
- remove schema from https://github.com/ansible/schemas