### PR TITLE
Added extra checks regarding rule listing

### DIFF
--- a/src/ansiblelint/rules/__init__.py
+++ b/src/ansiblelint/rules/__init__.py
@@ -314,12 +314,7 @@ def load_plugins(  # noqa: max-complexity: 11
 
     def all_subclasses(cls: type) -> set[type]:
         return set(cls.__subclasses__()).union(
-            [
-                s
-                for c in cls.__subclasses__()
-                for s in all_subclasses(c)
-                if getattr(s, "id")
-            ]
+            [s for c in cls.__subclasses__() for s in all_subclasses(c)]
         )
 
     orig_sys_path = sys.path.copy()
@@ -330,9 +325,10 @@ def load_plugins(  # noqa: max-complexity: 11
 
         # load all modules in the directory
         for f in Path(directory).glob("*.py"):
-            if "__" not in f.stem:
+            if "__" not in f.stem and f.stem not in "conftest":
                 try:
                     import_module(f"{f.stem}")
+
                 except ImportError as exc:
                     _logger.warning("Ignore loading rule from %s due to %s", f, exc)
     # restore sys.path
@@ -350,7 +346,7 @@ def load_plugins(  # noqa: max-complexity: 11
             if issubclass(rule, BaseRule) and rule.id not in rules:
                 rules[rule.id] = rule()
     for rule in rules.values():  # type: ignore
-        if isinstance(rule, AnsibleLintRule) and bool(rule.id) and bool(rule.shortdesc):
+        if isinstance(rule, AnsibleLintRule) and bool(rule.id):
             yield rule
 
 

--- a/src/ansiblelint/rules/yaml_rule.py
+++ b/src/ansiblelint/rules/yaml_rule.py
@@ -31,11 +31,6 @@ class YamllintRule(AnsibleLintRule):
     # ensure this rule runs before most of other common rules
     _order = 1
 
-    def __init__(self) -> None:
-        """Construct a rule instance."""
-        # customize id by adding the one reported by yamllint
-        self.id = self.__class__.id
-
     def matchyaml(self, file: Lintable) -> list[MatchError]:
         """Return matches found for a specific YAML text."""
         matches: list[MatchError] = []

--- a/test/rules/test_line_too_long.py
+++ b/test/rules/test_line_too_long.py
@@ -1,6 +1,6 @@
 """Tests for line-too-long rule."""
 from ansiblelint.rules import RulesCollection
-from ansiblelint.rules.yaml import YamllintRule
+from ansiblelint.rules.yaml_rule import YamllintRule
 from ansiblelint.testing import RunFromText
 
 LONG_LINE = """\

--- a/test/test_rules_collection.py
+++ b/test/test_rules_collection.py
@@ -18,6 +18,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
+from __future__ import annotations
 
 import collections
 import os
@@ -155,8 +156,15 @@ def test_rules_id_format() -> None:
     rules = RulesCollection(
         [os.path.abspath("./src/ansiblelint/rules")], options=options
     )
+    keys: set[str] = set()
     for rule in rules:
         assert rule_id_re.match(
             rule.id
         ), f"Rule id {rule.id} did not match our required format."
-    assert len(rules) == 42
+        keys.add(rule.id)
+        assert (
+            rule.help != "" or rule.description or rule.__doc__
+        ), f"Rule {rule.id} must have at least one of:  .help, .description, .__doc__"
+    assert "yaml" in keys, "yaml rule is missing"
+    assert len(rules) == 42  # update this number when adding new rules!
+    assert len(keys) == 42, "Duplicate rule ids?"

--- a/test/test_with_skip_tagid.py
+++ b/test/test_with_skip_tagid.py
@@ -1,6 +1,6 @@
 """Tests related to skip tag id."""
 from ansiblelint.rules import RulesCollection
-from ansiblelint.rules.yaml import YamllintRule
+from ansiblelint.rules.yaml_rule import YamllintRule
 from ansiblelint.runner import Runner
 
 FILE = "examples/playbooks/with-skip-tag-id.yml"


### PR DESCRIPTION
As we observed that a rule name that clashes with python package may
make it fail to load, we added some extra checks that should fail
testing if we encounter it again.
