### PR TITLE
Suspend git output in progressive mode

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -166,7 +166,7 @@ jobs:
       WSLENV: FORCE_COLOR:PYTEST_REQPASS:TOXENV:TOX_PARALLEL_NO_SPINNER
       # Number of expected test passes, safety measure for accidental skip of
       # tests. Update value if you add/remove tests.
-      PYTEST_REQPASS: 702
+      PYTEST_REQPASS: 703
 
     steps:
       - name: Activate WSL1

--- a/src/ansiblelint/__main__.py
+++ b/src/ansiblelint/__main__.py
@@ -209,7 +209,6 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901
 
     if isinstance(options.tags, str):
         options.tags = options.tags.split(",")
-
     result = _get_matches(rules, options)
 
     if options.write_list:
@@ -272,17 +271,26 @@ def _previous_revision() -> Iterator[None]:
         stdout=subprocess.PIPE,
         stderr=subprocess.DEVNULL,
     ).stdout.strip()
+    _logger.info("Previous revision SHA: %s", revision)
     path = pathlib.Path(worktree_dir)
+    if path.exists():
+        shutil.rmtree(worktree_dir)
     path.mkdir(parents=True, exist_ok=True)
     # Run check will fail if worktree_dir already exists
     # pylint: disable=subprocess-run-check
     subprocess.run(
         ["git", "worktree", "add", "-f", worktree_dir],
+        stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
     try:
         with cwd(worktree_dir):
-            subprocess.run(["git", "checkout", revision], check=True)
+            subprocess.run(
+                ["git", "checkout", revision],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=True,
+            )
             yield
     finally:
         options.exclude_paths = [abspath(p, os.getcwd()) for p in rel_exclude_paths]

--- a/test/test_progressive.py
+++ b/test/test_progressive.py
@@ -1,0 +1,82 @@
+"""Test for the --progressive mode."""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from ansiblelint.file_utils import cwd
+
+FAULTY_PLAYBOOK = """---
+- name: faulty
+  hosts: localhost
+  tasks:
+    - name: hello
+      debug:
+        msg: world
+"""
+
+CORRECT_PLAYBOOK = """---
+- name: Correct
+  hosts: localhost
+  tasks:
+    - name: Hello
+      ansible.builtin.debug:
+        msg: world
+"""
+
+
+def git_init() -> None:
+    """Init temporary git repository."""
+    subprocess.run(["git", "init", "--initial-branch=main"], check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], check=True)
+    subprocess.run(["git", "config", "user.name", "test"], check=True)
+
+
+def git_commit(filename: Path, content: str) -> None:
+    """Create and commit a file."""
+    filename.write_text(content)
+    subprocess.run(["git", "add", filename], check=True)
+    subprocess.run(["git", "commit", "-a", "-m", f"Commit {filename}"], check=True)
+
+
+def run_lint(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+    """Run ansible-lint."""
+    # pylint: disable=subprocess-run-check
+    return subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_validate_progressive_mode_json_output(tmp_path: Path) -> None:
+    """Test that covers the following scenarios for progressive mode.
+
+    1. JSON output is valid in quiet and verbose modes
+    2. New files are correctly handled whether lintable paths are passed or not
+    3. Regression is not reported when the last commit doesn't add any new violations
+    """
+    cmd = [
+        sys.executable,
+        "-m",
+        "ansiblelint",
+        "--progressive",
+        "-f",
+        "json",
+    ]
+    with cwd(tmp_path):
+        git_init()
+        git_commit(tmp_path / "README.md", "pytest")
+        git_commit(tmp_path / "playbook-faulty.yml", FAULTY_PLAYBOOK)
+        cmd.append("-q")
+        res = run_lint(cmd)
+        assert res.returncode == 2
+        json.loads(res.stdout)
+
+        git_commit(tmp_path / "playbook-correct.yml", CORRECT_PLAYBOOK)
+        cmd.extend(["-vv", "playbook-correct.yml"])
+        res = run_lint(cmd)
+        assert res.returncode == 0
+        json.loads(res.stdout)


### PR DESCRIPTION
This is to have an ability to suspend `git` output in progressive mode.
As currently it doesn't allow to retrieve pure json output

It preserves the current behaviour if `quiet` is not set.

[Test repo](https://github.com/kostyaplis/ansible-lint-test)

Latest master:
```console
$ ansible-lint --progressive -f json -q -q playbook-test1.yml

Preparing worktree (checking out 'old-rev')
HEAD is now at f17ba41 Second commit. Fix 1 violation
[{"type": "issue", "check_name": "name[play]", "categories": ["idiom"], "severity": "major", "description": "All plays should be named.", "fingerprint": "8f4941934aab4dc5115f825d0e2227bb38b1b6d82f2e32d636f856c8319a7393", "location": {"path": "playbook-test1.yml", "lines": {"begin": 1}}}, {"type": "issue", "check_name": "command-instead-of-shell", "categories": ["command-shell", "idiom"], "severity": "critical", "description": "Use shell only when shell functionality is required.", "fingerprint": "b2c4318aaf4e587a5aab71607f1409cb9ed455b38d8b91efaefd5c1b39a2df4d", "location": {"path": "playbook-test1.yml", "lines": {"begin": 3}}, "content": {"body": "Task/Handler: test"}}, {"type": "issue", "check_name": "name[casing]", "categories": ["idiom"], "severity": "major", "description": "All names should start with an uppercase letter.", "fingerprint": "51e7dd5782d4115dece8ddde17bde707ec1f35ae35a0bfffae812b0f84c2e08d", "location": {"path": "playbook-test1.yml", "lines": {"begin": 3}}, "content": {"body": "Task/Handler: test"}}, {"type": "issue", "check_name": "no-changed-when", "categories": ["command-shell", "idempotency"], "severity": "critical", "description": "Commands should not change things if nothing needs doing.", "fingerprint": "4c865dced7f2cc06a89fb0cb8124bde9f89f62a762c9e7472474989079490b54", "location": {"path": "playbook-test1.yml", "lines": {"begin": 3}}, "content": {"body": "Task/Handler: test"}}]
```

Fix applied:
```console
$ ansible-lint --progressive -f json -q -q playbook-test1.yml

[{"type": "issue", "check_name": "name[play]", "categories": ["idiom"], "severity": "major", "description": "All plays should be named.", "fingerprint": "8f4941934aab4dc5115f825d0e2227bb38b1b6d82f2e32d636f856c8319a7393", "location": {"path": "playbook-test1.yml", "lines": {"begin": 1}}}, {"type": "issue", "check_name": "command-instead-of-shell", "categories": ["command-shell", "idiom"], "severity": "critical", "description": "Use shell only when shell functionality is required.", "fingerprint": "b2c4318aaf4e587a5aab71607f1409cb9ed455b38d8b91efaefd5c1b39a2df4d", "location": {"path": "playbook-test1.yml", "lines": {"begin": 3}}, "content": {"body": "Task/Handler: test"}}, {"type": "issue", "check_name": "name[casing]", "categories": ["idiom"], "severity": "major", "description": "All names should start with an uppercase letter.", "fingerprint": "51e7dd5782d4115dece8ddde17bde707ec1f35ae35a0bfffae812b0f84c2e08d", "location": {"path": "playbook-test1.yml", "lines": {"begin": 3}}, "content": {"body": "Task/Handler: test"}}, {"type": "issue", "check_name": "no-changed-when", "categories": ["command-shell", "idempotency"], "severity": "critical", "description": "Commands should not change things if nothing needs doing.", "fingerprint": "4c865dced7f2cc06a89fb0cb8124bde9f89f62a762c9e7472474989079490b54", "location": {"path": "playbook-test1.yml", "lines": {"begin": 3}}, "content": {"body": "Task/Handler: test"}}]
```
