### PR TITLE
jinja[spacing]: use black for formatting

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -178,6 +178,7 @@ toctree
 toidentifier
 tomli
 toolset
+uncook
 ungrouped
 unignored
 unimported

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -166,7 +166,7 @@ jobs:
       WSLENV: FORCE_COLOR:PYTEST_REQPASS:TOXENV:TOX_PARALLEL_NO_SPINNER
       # Number of expected test passes, safety measure for accidental skip of
       # tests. Update value if you add/remove tests.
-      PYTEST_REQPASS: 698
+      PYTEST_REQPASS: 702
 
     steps:
       - name: Activate WSL1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -141,6 +141,7 @@ repos:
         additional_dependencies:
           - ansible-compat>=2.2.0
           - ansible-core
+          - black
           - enrich
           - filelock
           - flaky
@@ -167,6 +168,7 @@ repos:
         additional_dependencies:
           - ansible-compat>=2.2.0
           - ansible-core
+          - black
           - docutils
           - enrich
           - filelock

--- a/examples/playbooks/jinja-spacing.yml
+++ b/examples/playbooks/jinja-spacing.yml
@@ -82,7 +82,7 @@
 
     - name: Invalid multiline nested JSON
       ansible.builtin.debug:
-        # <-- 8
+        # not an error currently because current implementation skips multiline expressions
         msg: >-
           {{ {'dummy_2': {'nested_dummy_1': value_1,
                           'nested_dummy_2': value_2}} |

--- a/examples/playbooks/vars/jinja-spacing.yml
+++ b/examples/playbooks/vars/jinja-spacing.yml
@@ -35,7 +35,7 @@ valid_multiline_nested_json: >-
   {{ {'dummy_2': {'nested_dummy_1': value_1,
                   'nested_dummy_2': value_2}} |
   combine(dummy_1) }}
-invalid_multiline_nested_json: >- # <-- 8
+invalid_multiline_nested_json: >- # ignored multiline expression, for now
   {{ {'dummy_2': {'nested_dummy_1': value_1,
                   'nested_dummy_2': value_2}} |
   combine(dummy_1)}}

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,6 +69,7 @@ zip_safe = False
 install_requires =
   ansible-compat>=2.2.0  # GPLv3
   ansible-core>=2.12.0  # GPLv3
+  black>=22.1.0  # MIT
   enrich>=1.2.6
   filelock  # The Unlicense
   jsonschema>=4.9.0  # MIT, version needed for improved errors


### PR DESCRIPTION
As the previous two attempts to rewrite the formatting of jinja expression did reach some dead-ends, I decided to just use black for formatting them, especially as jinja2 syntax is very close to python. For the few exceptions where it is not compatible, we decided just to not touch them until we will have a better way to address these.

The new implementation is also taking care of removing the curly braces around fields that use implicit jinja templating, such `when`.

This change also documents the current limitations, so users will know about them instead of
believing that these are bugs.

Fixes: #2358
Fixes: #2338
Fixes: #1702
Fixes: #1685