### PR TITLE
docs: replace wrong occurrences of ignore_list with skip_list in rules

### DIFF
--- a/src/ansiblelint/rules/name.md
+++ b/src/ansiblelint/rules/name.md
@@ -12,7 +12,7 @@ This rule can produce messages such:
 - `name[play]` - All plays should be named.
 
 If you want to ignore some of the messages above, you can add any of them to
-the `ignore_list`.
+the `skip_list`.
 
 ## Problematic code
 

--- a/src/ansiblelint/rules/syntax_check.md
+++ b/src/ansiblelint/rules/syntax_check.md
@@ -12,10 +12,10 @@ loaded by Ansible. This is often achieved by editing the inventory file and/or
 If undefined variables cause the failure, you can use the jinja
 `default()` filter to provide fallback values, like in the example below.
 
-This rule is among the few `unskippable` rules that cannot be added
-to `ignore_list` or `warn_list`. One possible workaround is to add the entire
-file to the `exclude_list`. This is a valid approach for special cases, like
-testing fixtures that are invalid on purpose.
+This rule is among the few `unskippable` rules that cannot be added to
+`skip_list` or `warn_list`. One possible workaround is to add the entire file
+to the `exclude_list`. This is a valid approach for special cases, like testing
+fixtures that are invalid on purpose.
 
 One of the most common sources of errors is failure to assert the presence of
 various variables at the beginning of the playbook.


### PR DESCRIPTION
Small PR that replaces the `ignore_list` references with `skip_list`. To my knowledge and after checking the code `ignore_list` does not seem to exist. Please let me know if I'm mistaken here. :)