### PR TITLE
Do not parse excluded files

### DIFF
--- a/src/ansiblelint/runner.py
+++ b/src/ansiblelint/runner.py
@@ -114,6 +114,7 @@ class Runner:
             if self.is_excluded(lintable):
                 _logger.debug("Excluded %s", lintable)
                 self.lintables.remove(lintable)
+                continue
             try:
                 lintable.data
             except RuntimeError as exc:


### PR DESCRIPTION
I have the following:

```
$ ansible-lint
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/ansible/parsing/yaml/constructor.py", line 67, in construct_mapping
    hash(key)
TypeError: unhashable type: 'AnsibleMapping'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/usr/local/bin/ansible-lint", line 8, in <module>
    sys.exit(_run_cli_entrypoint())
  File "/usr/local/lib/python3.8/site-packages/ansiblelint/__main__.py", line 297, in _run_cli_entrypoint
    sys.exit(main(sys.argv))
  File "/usr/local/lib/python3.8/site-packages/ansiblelint/__main__.py", line 213, in main
    result = _get_matches(rules, options)
  File "/usr/local/lib/python3.8/site-packages/ansiblelint/runner.py", line 223, in _get_matches
    matches.extend(runner.run())
  File "/usr/local/lib/python3.8/site-packages/ansiblelint/runner.py", line 118, in run
    lintable.data
  File "/usr/local/lib/python3.8/site-packages/ansiblelint/file_utils.py", line 300, in data
    self._data = parse_yaml_linenumbers(self)
  File "/usr/local/lib/python3.8/site-packages/ansiblelint/utils.py", line 746, in parse_yaml_linenumbers
    data = loader.get_data()
  File "/usr/local/lib64/python3.8/site-packages/yaml/constructor.py", line 45, in get_data
    return self.construct_document(self.get_node())
  File "/usr/local/lib64/python3.8/site-packages/yaml/constructor.py", line 60, in construct_document
    for dummy in generator:
  File "/usr/local/lib/python3.8/site-packages/ansible/parsing/yaml/constructor.py", line 46, in construct_yaml_map
    value = self.construct_mapping(node)
  File "/usr/local/lib/python3.8/site-packages/ansiblelint/utils.py", line 725, in construct_mapping
    mapping = AnsibleConstructor.construct_mapping(loader, node, deep=deep)
  File "/usr/local/lib/python3.8/site-packages/ansible/parsing/yaml/constructor.py", line 69, in construct_mapping
    raise ConstructorError("while constructing a mapping", node.start_mark,
yaml.constructor.ConstructorError: while constructing a mapping
  in "<unicode string>", line 5, column 13
found unacceptable key (unhashable type: 'AnsibleMapping')
  in "<unicode string>", line 5, column 14
```

From this file: https://gitlab.com/kubitus-project/kubitus-installer/-/blob/4e8f3a24b00305a9405a2c4068d3f036fb153130/roles/keycloak/files/helm_templates/keycloakrealm.yaml

While it [should be excluded](https://gitlab.com/kubitus-project/kubitus-installer/-/blob/4e8f3a24b00305a9405a2c4068d3f036fb153130/.ansible-lint#L1-5):

```yaml
exclude_paths:
- roles/*/files/helm_templates/*
- roles/*/files/helm_templates/*/*
- roles/*/files/helm_templates/*/*/*
- roles/*/files/helm_templates/*/*/*/*

```

It appeared while [upgrading](https://gitlab.com/kubitus-project/kubitus-installer/-/merge_requests/1375/diffs) `quay.io/ansible/creator-ee` from 0.6.0 to 0.7.2.


(Full context in https://gitlab.com/kubitus-project/kubitus-installer/-/jobs/2994118115#L20).
