### PR TITLE
docs: exclude_list => exclude_paths

### DIFF
--- a/src/ansiblelint/_internal/internal_error.md
+++ b/src/ansiblelint/_internal/internal_error.md
@@ -12,7 +12,7 @@ In almost all cases you will see more detailed information regarding the
 original error or runtime exception that triggered this rule.
 
 If these files are broken on purpose, like some test fixtures, you need to add
-them to the `exclude_list`.
+them to the `exclude_paths`.
 
 ## Problematic code
 

--- a/src/ansiblelint/rules/syntax_check.md
+++ b/src/ansiblelint/rules/syntax_check.md
@@ -14,7 +14,7 @@ If undefined variables cause the failure, you can use the jinja
 
 This rule is among the few `unskippable` rules that cannot be added to
 `skip_list` or `warn_list`. One possible workaround is to add the entire file
-to the `exclude_list`. This is a valid approach for special cases, like testing
+to the `exclude_paths`. This is a valid approach for special cases, like testing
 fixtures that are invalid on purpose.
 
 One of the most common sources of errors is failure to assert the presence of


### PR DESCRIPTION
Some docs were mentioning an `exclude_list` that does not (no longer?) exist.