### PR TITLE
Docs: Update the fqcn builtin rule docs for legacy shell

### DIFF
--- a/src/ansiblelint/rules/fqcn_builtins.md
+++ b/src/ansiblelint/rules/fqcn_builtins.md
@@ -2,6 +2,9 @@
 
 This rule checks that playbooks use the fully qualified collection name (FQCN) for modules in the `ansible.builtin` collection.
 
+If you do not specify the FQCN, Ansible uses the `ansible.legacy` collection for some modules by default.
+You can use local overrides with the `ansible.legacy` collection but not with the `ansible.builtin` collection.
+
 ## Problematic Code
 
 ```yaml
@@ -9,8 +12,8 @@ This rule checks that playbooks use the fully qualified collection name (FQCN) f
 - name: Example playbook
   hosts: all
   tasks:
-    - name: Shell
-      shell: echo # <- This does not use the FQCN for the shell module.
+    - name: Create an SSH connection
+      shell: ssh ssh_user@{{ ansible_ssh_host }} # <- This does not use the FQCN for the shell module.
 ```
 
 ## Correct Code
@@ -20,6 +23,15 @@ This rule checks that playbooks use the fully qualified collection name (FQCN) f
 - name: Example playbook
   hosts: all
   tasks:
-    - name: Shell
-      ansible.builtin.shell: echo # <- This uses the FQCN for the shell module.
+    - name: Create an SSH connection
+      ansible.legacy.shell: ssh ssh_user@{{ ansible_ssh_host }} -o IdentityFile=path/to/my_rsa # <- This uses the FQCN for the legacy shell module to allow local overrides.
+```
+
+```yaml
+---
+- name: Example playbook
+  hosts: all
+  tasks:
+    - name: Create an SSH connection
+      ansible.builtin.shell: ssh ssh_user@{{ ansible_ssh_host }} # <- This uses the FQCN for the builtin shell module.
 ```


### PR DESCRIPTION
Update docs for the `fqcn-builtins` rule to include more information about `ansible.legacy` and `ansible.builtin` according to https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#what-is-the-difference-between-ansible-legacy-and-ansible-builtin-collections

Follows up on this comment from a previous PR: https://github.com/ansible/ansible-lint/pull/2412#discussion_r969714128