### PR TITLE
Update meta schema to require standalone property

### DIFF
--- a/examples/roles/dependency_in_meta/meta/main.yml
+++ b/examples/roles/dependency_in_meta/meta/main.yml
@@ -1,6 +1,5 @@
 ---
 # meta file, determined by ending in meta/main.yml
-version: 1
 # https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_roles.html#role-dependencies
 allow_duplicates: true
 dependencies:
@@ -33,6 +32,7 @@ dependencies:
     name: http-role
 
 galaxy_info:
+  standalone: true
   author: foo
   description: Testing meta
   company: Not applicable

--- a/examples/roles/invalid_due_to_meta/meta/main.yml
+++ b/examples/roles/invalid_due_to_meta/meta/main.yml
@@ -1,5 +1,6 @@
 ---
 galaxy_info:
+  standalone: true
   role_name: invalid-due-to-meta # <-- invalid role name
   author: foo
   description: foo

--- a/examples/roles/invalid_meta_schema/meta/main.yml
+++ b/examples/roles/invalid_meta_schema/meta/main.yml
@@ -1,6 +1,6 @@
 ---
-version: 1 # new requirement
 galaxy_info:
+  standalone: true
   author: foo
   description: false # <-- schema fail as string is expected
   license: XXX

--- a/examples/roles/meta_noqa/meta/main.yml
+++ b/examples/roles/meta_noqa/meta/main.yml
@@ -1,6 +1,6 @@
 ---
-version: 1
 galaxy_info: # noqa meta-incorrect
+  standalone: true
   author: your-name # noqa meta-no-info
   description: missing min_ansible_version and platforms. author default not changed
   license: MIT

--- a/examples/roles/valid-due-to-meta/meta/main.yml
+++ b/examples/roles/valid-due-to-meta/meta/main.yml
@@ -1,6 +1,6 @@
 ---
-version: 1
 galaxy_info:
+  standalone: true
   role_name: valid_due_to_meta
   author: foo
   description: foo

--- a/src/ansiblelint/rules/schema.md
+++ b/src/ansiblelint/rules/schema.md
@@ -1,7 +1,7 @@
 # schema
 
 The `schema` rule validates Ansible metadata files against JSON schemas.
-These schemas ensure compatibility of syntax of Ansible content across versions.
+These schemas ensure the compatibility of Ansible syntax content across versions.
 
 This `schema` rule is **mandatory**.
 You cannot use inline `noqa` comments to ignore it.
@@ -11,7 +11,8 @@ This prevents unexpected syntax from triggering multiple rule violations.
 
 ## Validated schema
 
-Ansible-lint currently validates several schema that are maintained in the separate projects and updated independently to ansible-lint.
+Ansible-lint currently validates several schemas that are maintained in
+separate projects and updated independently to ansible-lint.
 
 > Report bugs related to schema in their respective repository and not in the ansible-lint project.
 
@@ -38,16 +39,18 @@ Maintained in the Ansible [schemas](https://github.com/ansible/schemas) project:
 
 ## schema[meta]
 
-For `meta/main.yml` files Ansible-lint requires a `version` key that specifies one of the following Ansible versions:
+For `meta/main.yml` files, Ansible-lint requires a `galaxy_info.standalone`
+property that clarifies if a role is an old standalone one or a new one,
+collection based:
 
-- `1` uses old standalone Ansible roles.
-- `2` uses new Ansible roles contained in a collection.
-
-Ansible-lint requires the `version` key to avoid confusion and provide more specific error messages.
-You must add an explicit version entry to `meta/main.yml` such as:
-
+```yaml
+galaxy_info:
+  standalone: true # <-- this is a standalone role (not part of a collection)
 ```
-version: 1
-```
+
+Ansible-lint requires the `standalone` key to avoid confusion and provide more
+specific error messages. For example, the `meta` schema will require some
+properties only for standalone roles or prevent the use of some properties that
+are not supported by collections.
 
 You cannot use an empty `meta/main.yml` file or use only comments in the `meta/main.yml` file.

--- a/src/ansiblelint/schemas/meta.json
+++ b/src/ansiblelint/schemas/meta.json
@@ -400,8 +400,19 @@
       "title": "FreeBSDPlatformModel",
       "type": "object"
     },
-    "GalaxyInfoModel-v1": {
+    "GalaxyInfoModel": {
       "additionalProperties": false,
+      "else": {
+        "$comment": "If standalone is false, then we have a collection role and only description is required",
+        "required": ["description"]
+      },
+      "if": {
+        "properties": {
+          "standalone": {
+            "const": true
+          }
+        }
+      },
       "properties": {
         "author": {
           "title": "Author",
@@ -454,14 +465,23 @@
           "pattern": "^[a-z][a-z0-9_]+$",
           "title": "Role Name",
           "type": "string"
+        },
+        "standalone": {
+          "description:": "Set to true for old standalone roles, or false for new collection roles.",
+          "title": "Standalone",
+          "type": "boolean"
         }
       },
-      "required": [
-        "description",
-        "license",
-        "min_ansible_version",
-        "platforms"
-      ],
+      "then": {
+        "$comment": "Standalone role, so we require several fields.",
+        "required": [
+          "standalone",
+          "description",
+          "license",
+          "min_ansible_version",
+          "platforms"
+        ]
+      },
       "title": "GalaxyInfoModel for old standalone role (v1)",
       "type": "object"
     },
@@ -486,7 +506,8 @@
         },
         "platforms": {
           "$ref": "#/$defs/platforms"
-        }
+        },
+        "standalone": { "const": false }
       },
       "required": ["description"],
       "title": "GalaxyInfoModel for role within a collection (v2)",
@@ -1281,79 +1302,6 @@
       "title": "Platforms",
       "type": "array"
     },
-    "v1": {
-      "additionalProperties": false,
-      "properties": {
-        "allow_duplicates": {
-          "title": "Allow Duplicates",
-          "type": "boolean"
-        },
-        "cloud_platforms": {
-          "items": {
-            "enum": [
-              "amazon",
-              "azure",
-              "centurylink",
-              "google",
-              "openstack",
-              "ovirt",
-              "rackspace",
-              "vmware"
-            ],
-            "type": "string"
-          },
-          "markdownDescription": "Which cloud platforms are supported, existing values can be gathered using the [API](https://galaxy.ansible.com/api/v1/cloud_platforms/)",
-          "title": "Cloud Platforms",
-          "type": "array"
-        },
-        "collections": {
-          "$ref": "#/$defs/collections"
-        },
-        "dependencies": {
-          "items": {
-            "$ref": "#/$defs/DependencyModel"
-          },
-          "title": "Dependencies",
-          "type": "array"
-        },
-        "galaxy_info": {
-          "$ref": "#/$defs/GalaxyInfoModel-v1"
-        },
-        "version": {
-          "const": 1
-        }
-      },
-      "required": ["version"],
-      "title": "Meta Schema v1 (standalone role)",
-      "type": "object"
-    },
-    "v2": {
-      "additionalProperties": false,
-      "properties": {
-        "allow_duplicates": {
-          "title": "Allow Duplicates",
-          "type": "boolean"
-        },
-        "collections": {
-          "$ref": "#/$defs/collections"
-        },
-        "dependencies": {
-          "items": {
-            "$ref": "#/$defs/DependencyModel"
-          },
-          "title": "Dependencies",
-          "type": "array"
-        },
-        "galaxy_info": {
-          "$ref": "#/$defs/GalaxyInfoModel-v2"
-        },
-        "version": {
-          "const": 2
-        }
-      },
-      "title": "Meta Schema v2 (role inside collection)",
-      "type": "object"
-    },
     "vCenterPlatformModel": {
       "properties": {
         "name": {
@@ -1395,26 +1343,28 @@
   },
   "$id": "https://raw.githubusercontent.com/ansible/schemas/main/f/ansible-meta.json",
   "$schema": "http://json-schema.org/draft-07/schema",
-  "else": {
-    "$ref": "#/$defs/v2"
-  },
   "examples": ["meta/main.yml"],
-  "if": {
-    "properties": {
-      "version": {
-        "const": 1
-      }
-    }
-  },
   "properties": {
-    "version": {
-      "enum": [1, 2],
-      "type": "integer"
+    "additionalProperties": false,
+    "allow_duplicates": {
+      "title": "Allow Duplicates",
+      "type": "boolean"
+    },
+    "collections": {
+      "$ref": "#/$defs/collections"
+    },
+    "dependencies": {
+      "items": {
+        "$ref": "#/$defs/DependencyModel"
+      },
+      "title": "Dependencies",
+      "type": "array"
+    },
+    "galaxy_info": {
+      "$ref": "#/$defs/GalaxyInfoModel"
     }
   },
-  "then": {
-    "$ref": "#/$defs/v1"
-  },
+  "required": ["galaxy_info"],
   "title": "Ansible Meta Schema v1/v2",
   "type": "object"
 }


### PR DESCRIPTION
Updates schemas to revert requiring version property for meta files.

Fixes: [#386](https://github.com/ansible/schemas/issues/386)