### PR TITLE
Fix bug in skip_list parsing with lists of integers

### DIFF
--- a/src/ansiblelint/_internal/rules.py
+++ b/src/ansiblelint/_internal/rules.py
@@ -84,9 +84,10 @@ class BaseRule:
                     matches.extend(method(file))
                 except Exception as exc:  # pylint: disable=broad-except
                     _logger.warning(
-                        "Ignored exception from %s.%s: %s",
+                        "Ignored exception from %s.%s while processing %s: %s",
                         self.__class__.__name__,
                         method,
+                        str(file),
                         exc,
                     )
         else:

--- a/src/ansiblelint/rules/yaml_rule.py
+++ b/src/ansiblelint/rules/yaml_rule.py
@@ -94,10 +94,11 @@ def _fetch_skips(data: Any, collector: dict[int, set[str]]) -> dict[int, set[str
         if isinstance(data, dict):
             for entry, value in data.items():
                 _fetch_skips(value, collector)
-        else:
+        else:  # must be some kind of list
             for entry in data:
                 if (
                     entry
+                    and hasattr(data, "get")
                     and LINE_NUMBER_KEY in entry
                     and "skipped_rules" in entry
                     and entry["skipped_rules"]


### PR DESCRIPTION
In addition to fix the skip_list parsing bug, it also improves the error message that helped us identify this bug.

Thanks to @felixfontein for reporting this bug.