### PR TITLE
Mark galaxy rule as required only for shared profile

### DIFF
--- a/src/ansiblelint/__main__.py
+++ b/src/ansiblelint/__main__.py
@@ -192,18 +192,13 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901
     from ansiblelint.rules import RulesCollection
     from ansiblelint.runner import _get_matches
 
-    rules = RulesCollection(options.rulesdirs)
+    rules = RulesCollection(options.rulesdirs, profile=options.profile)
 
     if options.profile == []:
         from ansiblelint.generate_docs import profiles_as_rich
 
         console.print(profiles_as_rich())
         return 0
-    if options.profile:
-        from ansiblelint.rules import filter_rules_with_profile
-
-        filter_rules_with_profile(rules, options.profile[0])
-        # When profile is mentioned, we filter-out the rules based on it
 
     if options.listrules or options.listtags:
         return _do_list(rules)

--- a/src/ansiblelint/data/profiles.yml
+++ b/src/ansiblelint/data/profiles.yml
@@ -72,12 +72,14 @@ shared:
   extends: safety
   description: >
     The shared profile is for those that want to publish their content, roles
-    or collection to either [galaxy](https://galaxy.ansible.com) or to another
-    automation-hub instance. In addition to all the rules related to packaging
-    and publishing, like metadata checks, this also includes some rules that
-    are known to be good practices for keeping the code readable and
+    or collection to either [galaxy.ansible.com](https://galaxy.ansible.com),
+    [automation-hub](https://console.redhat.com/ansible/automation-hub) or
+    another private instance of these. In addition to all the rules related to
+    packaging and publishing, like metadata checks, this also includes some
+    rules that are known to be good practices for keeping the code readable and
     maintainable.
   rules:
+    galaxy: # <-- applies to both galaxy and automation-hub
     ignore-errors:
     layout:
       url: https://github.com/ansible/ansible-lint/issues/1900

--- a/src/ansiblelint/generate_docs.py
+++ b/src/ansiblelint/generate_docs.py
@@ -144,6 +144,12 @@ If you want to consult the list of rules from each profile, type
 The rules that have a `*` suffix, are not implemented yet but we documented
 them with links to their issues.
 
+```{note}
+Special rule tags such `opt-in` and `experimental` are automatically removed
+when a rule is included in a profile, directly or indirectly. This means that
+they will always execute once included.
+```
+
 """
 
     for name, profile in PROFILES.items():

--- a/src/ansiblelint/rules/galaxy.py
+++ b/src/ansiblelint/rules/galaxy.py
@@ -22,8 +22,8 @@ class GalaxyRule(AnsibleLintRule):
     id = "galaxy"
     description = "Confirm via galaxy.yml file if collection version is greater than or equal to 1.0.0"
     severity = "MEDIUM"
-    tags = ["metadata"]
-    version_added = "v6.5.0 (last update)"
+    tags = ["metadata", "opt-in", "experimental"]
+    version_added = "v6.6.0 (last update)"
 
     def matchplay(self, file: Lintable, data: odict[str, Any]) -> list[MatchError]:
         """Return matches found for a specific play (entry in playbook)."""

--- a/test/test_profiles.py
+++ b/test/test_profiles.py
@@ -17,7 +17,7 @@ def test_profile_min() -> None:
     collection.register(ShellWithoutPipefail())
     assert len(collection.rules) == 4, "Failed to register new rule."
 
-    filter_rules_with_profile(collection, "min")
+    filter_rules_with_profile(collection.rules, "min")
     assert (
         len(collection.rules) == 3
     ), "Failed to unload rule that is not part of 'min' profile."

--- a/test/test_rules_collection.py
+++ b/test/test_rules_collection.py
@@ -152,9 +152,9 @@ def test_rich_rule_listing() -> None:
 def test_rules_id_format() -> None:
     """Assure all our rules have consistent format."""
     rule_id_re = re.compile("^[a-z-]{4,30}$")
-    options.enable_list = ["no-same-owner", "no-log-password", "no-same-owner"]
+    # options.enable_list = ["no-same-owner", "no-log-password", "no-same-owner"]
     rules = RulesCollection(
-        [os.path.abspath("./src/ansiblelint/rules")], options=options
+        [os.path.abspath("./src/ansiblelint/rules")], options=options, conditional=False
     )
     keys: set[str] = set()
     for rule in rules:
@@ -166,5 +166,5 @@ def test_rules_id_format() -> None:
             rule.help != "" or rule.description or rule.__doc__
         ), f"Rule {rule.id} must have at least one of:  .help, .description, .__doc__"
     assert "yaml" in keys, "yaml rule is missing"
-    assert len(rules) == 42  # update this number when adding new rules!
-    assert len(keys) == 42, "Duplicate rule ids?"
+    assert len(rules) == 45  # update this number when adding new rules!
+    assert len(keys) == len(rules), "Duplicate rule ids?"


### PR DESCRIPTION
- makes galaxy rule opt-in, so it would not be executed when a profile does not ask for it
- adds galaxy rule to shared profile, so we check requirements when before uploading (production profile inherits shared one)
