### PR TITLE
api: enable matchtask() to return list[MatchError]

### DIFF
--- a/src/ansiblelint/_internal/rules.py
+++ b/src/ansiblelint/_internal/rules.py
@@ -100,7 +100,7 @@ class BaseRule:
 
     def matchtask(
         self, task: dict[str, Any], file: Lintable | None = None
-    ) -> bool | str | MatchError:
+    ) -> bool | str | MatchError | list[MatchError]:
         """Confirm if current rule is matching a specific task.
 
         If ``needs_raw_task`` (a class level attribute) is ``True``, then

--- a/src/ansiblelint/rules/name.py
+++ b/src/ansiblelint/rules/name.py
@@ -29,6 +29,7 @@ class NameRule(AnsibleLintRule):
 
     def matchplay(self, file: Lintable, data: odict[str, Any]) -> list[MatchError]:
         """Return matches found for a specific play (entry in playbook)."""
+        results = []
         if file.kind != "playbook":
             return []
         if "name" not in data:
@@ -40,43 +41,50 @@ class NameRule(AnsibleLintRule):
                     filename=file,
                 )
             ]
-        match = self._check_name(
-            data["name"], lintable=file, linenumber=data[LINE_NUMBER_KEY]
+        results.extend(
+            self._check_name(
+                data["name"], lintable=file, linenumber=data[LINE_NUMBER_KEY]
+            )
         )
-        if match:
-            return [match]
-        return []
+        return results
 
     def matchtask(
         self, task: dict[str, Any], file: Lintable | None = None
-    ) -> bool | str | MatchError:
+    ) -> list[MatchError]:
+        results = []
         name = task.get("name")
         if not name:
-            return self.create_matcherror(
-                message="All tasks should be named.",
-                linenumber=task[LINE_NUMBER_KEY],
-                tag="name[missing]",
-                filename=file,
+            results.append(
+                self.create_matcherror(
+                    message="All tasks should be named.",
+                    linenumber=task[LINE_NUMBER_KEY],
+                    tag="name[missing]",
+                    filename=file,
+                )
             )
-        return (
-            self._check_name(name, lintable=file, linenumber=task[LINE_NUMBER_KEY])
-            or False
-        )
+        else:
+            results.extend(
+                self._check_name(name, lintable=file, linenumber=task[LINE_NUMBER_KEY])
+            )
+        return results
 
     def _check_name(
         self, name: str, lintable: Lintable | None, linenumber: int
-    ) -> MatchError | None:
+    ) -> list[MatchError]:
         # This rules applies only to languages that do have uppercase and
         # lowercase letter, so we ignore anything else. On Unicode isupper()
         # is not necessarily the opposite of islower()
+        results = []
         if name[0].isalpha() and name[0].islower() and not name[0].isupper():
-            return self.create_matcherror(
-                message="All names should start with an uppercase letter.",
-                linenumber=linenumber,
-                tag="name[casing]",
-                filename=lintable,
+            results.append(
+                self.create_matcherror(
+                    message="All names should start with an uppercase letter.",
+                    linenumber=linenumber,
+                    tag="name[casing]",
+                    filename=lintable,
+                )
             )
-        return None
+        return results
 
 
 if "pytest" in sys.modules:  # noqa: C901


### PR DESCRIPTION
Extends the API for matchtask() to allow implementations to also return list[MatchError), in addition to already supported results.

This change extends the API but does not break existing users. In the future we might want to discourage/deprecate returning the other type of results (bool, str or MatchError).

This change is needed in order to enable other rules to return multiple errors within a single task file, like enabling `name` rule to also report `name[templating]` errors. See https://github.com/ansible/ansible-lint/pull/2444
