### PR TITLE
fix: use ansible-compat to install collections

### DIFF
--- a/src/ansiblelint/_mockings.py
+++ b/src/ansiblelint/_mockings.py
@@ -73,37 +73,6 @@ def _perform_mockings() -> None:  # noqa: C901
         for module_name in options.mock_modules:
             _make_module_stub(module_name)
 
-    # if inside a collection repo, symlink it to simulate its installed state
-    if not os.path.exists("galaxy.yml"):
-        return
-    yaml = yaml_from_file("galaxy.yml")
-    if not yaml:
-        # ignore empty galaxy.yml file
-        return
-    if isinstance(yaml, list):
-        raise RuntimeError(
-            "Invalid galaxy.yml file contains a sequence instead of a mapping."
-        )
-    namespace = yaml.get("namespace", None)
-    collection = yaml.get("name", None)
-    if not namespace or not collection:
-        return
-    collections_path = pathlib.Path(
-        f"{options.cache_dir}/collections/ansible_collections/{ namespace }"
-    )
-    collections_path.mkdir(parents=True, exist_ok=True)
-    link_path = pathlib.Path(collections_path / collection)
-    target = pathlib.Path(options.project_dir).absolute()
-    if link_path.exists():
-        try:
-            if os.readlink(link_path) != target:
-                raise OSError()
-        # OSError could also be raised by readlink
-        except (OSError, FileNotFoundError):
-            link_path.unlink(missing_ok=True)
-    if not link_path.exists():
-        link_path.symlink_to(target, target_is_directory=True)
-
 
 def _perform_mockings_cleanup() -> None:  # noqa: C901
     """Clean up mocked modules and roles."""

--- a/src/ansiblelint/app.py
+++ b/src/ansiblelint/app.py
@@ -256,6 +256,6 @@ def get_app(offline: bool = False) -> App:
     # Make linter use the cache dir from compat
     default_options.cache_dir = app.runtime.cache_dir
 
-    app.runtime.prepare_environment(offline=offline)
+    app.runtime.prepare_environment(install_local=True, offline=offline)
     _perform_mockings()
     return app


### PR DESCRIPTION
This patch switches `ansible-lint` to start using `ansible-compat` to install a collection if needed, this removes some duplicated code and also solves issues where both `molecule` and `ansible-lint` and running on the same system and fighting against each other (one creates symlinks, the other copies content).

Fixes #2426 