### PR TITLE
Ensure that symlinked arguments are resolved

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -166,7 +166,7 @@ jobs:
       WSLENV: FORCE_COLOR:PYTEST_REQPASS:TOXENV:TOX_PARALLEL_NO_SPINNER
       # Number of expected test passes, safety measure for accidental skip of
       # tests. Update value if you add/remove tests.
-      PYTEST_REQPASS: 698
+      PYTEST_REQPASS: 702
 
     steps:
       - name: Activate WSL1

--- a/.pylintrc
+++ b/.pylintrc
@@ -24,3 +24,7 @@ disable =
 [TYPECHECK]
 # pylint is unable to detect Namespace attributes and will throw a E1101
 generated-members=options.*
+
+[SUMMARY]
+# We don't need the score spamming console, as we either pass or fail
+score=n

--- a/src/ansiblelint/cli.py
+++ b/src/ansiblelint/cli.py
@@ -529,7 +529,8 @@ def get_config(arguments: list[str]) -> Namespace:
 
     if options.project_dir == ".":
         project_dir = guess_project_dir(options.config_file)
-        options.project_dir = normpath(project_dir)
+        options.project_dir = os.path.expanduser(normpath(project_dir))
+
     if not options.project_dir or not os.path.exists(options.project_dir):
         raise RuntimeError(
             f"Failed to determine a valid project_dir: {options.project_dir}"


### PR DESCRIPTION
- Fixes bug where a giving a symlinked directory as argument would
  fail to lint the entire role, basically because the linter failed
  to resolve the link before processing all lintables within it.
- Ensure we resolve symlink in Lintable constructor
- Add normalization function that returns a Path
