### PR TITLE
Change rich markdown theme/colors

### DIFF
--- a/docs/_static/theme_overrides.css
+++ b/docs/_static/theme_overrides.css
@@ -16,3 +16,9 @@
 .icon-home {
   display: none !important;
 }
+
+/* Avoid using the red text for tt blocks */
+.rst-content code.literal,
+.rst-content tt.literal {
+  color: #888888 !important;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -165,7 +165,7 @@ default_role = "any"
 # show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = "sphinx"
+pygments_style = "ansible"
 
 highlight_language = "YAML+Jinja"
 

--- a/src/ansiblelint/color.py
+++ b/src/ansiblelint/color.py
@@ -4,9 +4,52 @@ from __future__ import annotations
 from typing import Any
 
 import rich
+import rich.markdown
 from rich.console import Console
+from rich.default_styles import DEFAULT_STYLES
+from rich.style import Style
 from rich.syntax import Syntax
 from rich.theme import Theme
+
+# WARNING: When making style changes, be sure you test the output of
+# `ansible-lint -L` on multiple terminals with dark/light themes, including:
+# - iTerm2 (macOS) - bold might not be rendered differently
+# - vscode integrated terminal - bold might not be rendered differently, links will not work
+#
+# When it comes to colors being used, try to match:
+# - Ansible official documentation theme, https://docs.ansible.com/ansible/latest/dev_guide/developing_api.html
+# - VSCode Ansible extension for syntax highlighting
+# - GitHub markdown theme
+#
+# Current values: (docs)
+# codeblock border: #404040
+# codeblock background: #edf0f2
+# codeblock comment: #6a737d (also italic)
+# teletype-text: #e74c3c (red)
+# teletype-text-border: 1px solid #e1e4e5 (background white)
+# text: #404040
+# codeblock other-text: #555555 (black-ish)
+# codeblock property: #22863a (green)
+# codeblock integer: 032f62 (blue)
+# codeblock command: #0086b3 (blue) - [shell]
+# == python ==
+# class: #445588 (dark blue and bold)
+# docstring: #dd1144 (red)
+# self: #999999 (light-gray)
+# method/function: #990000 (dark-red)
+# number: #009999 cyan
+# keywords (def,None,False,len,from,import): #007020 (green) bold
+# super|dict|print: #0086b3 light-blue
+# __name__: #bb60d5 (magenta)
+# string: #dd1144 (light-red)
+DEFAULT_STYLES.update(
+    {
+        # "code": Style(color="bright_black", bgcolor="red"),
+        "markdown.code": Style(color="bright_black"),
+        "markdown.code_block": Style(dim=True, color="cyan"),
+    }
+)
+
 
 _theme = Theme(
     {
@@ -44,3 +87,34 @@ def reconfigure(new_options: dict[str, Any]) -> None:
 def render_yaml(text: str) -> Syntax:
     """Colorize YAMl for nice display."""
     return Syntax(text, "yaml", theme="ansi_dark")
+
+
+# pylint: disable=redefined-outer-name,unused-argument
+def _rich_heading_custom_rich_console(
+    self: rich.markdown.Heading,
+    console: rich.console.Console,
+    options: rich.console.ConsoleOptions,
+) -> rich.console.RenderResult:
+    """Override for rich console heading."""
+    yield f"[bold]{self.level * '#'} {self.text}[/]"
+
+
+# pylint: disable=redefined-outer-name,unused-argument
+def _rich_codeblock_custom_rich_console(
+    self: rich.markdown.CodeBlock, console: Console, options: rich.console.ConsoleOptions
+) -> rich.console.RenderResult:
+    code = str(self.text).rstrip()
+    syntax = Syntax(
+        code,
+        self.lexer_name,
+        theme=self.theme,
+        word_wrap=True,
+        background_color="default",
+    )
+    yield syntax
+
+
+# Monkey-patch rich to alter its rendering of headings
+# https://github.com/python/mypy/issues/2427
+rich.markdown.Heading.__rich_console__ = _rich_heading_custom_rich_console  # type: ignore
+rich.markdown.CodeBlock.__rich_console__ = _rich_codeblock_custom_rich_console  # type: ignore

--- a/src/ansiblelint/color.py
+++ b/src/ansiblelint/color.py
@@ -101,7 +101,9 @@ def _rich_heading_custom_rich_console(
 
 # pylint: disable=redefined-outer-name,unused-argument
 def _rich_codeblock_custom_rich_console(
-    self: rich.markdown.CodeBlock, console: Console, options: rich.console.ConsoleOptions
+    self: rich.markdown.CodeBlock,
+    console: Console,
+    options: rich.console.ConsoleOptions,
 ) -> rich.console.RenderResult:
     code = str(self.text).rstrip()
     syntax = Syntax(

--- a/src/ansiblelint/rules/jinja.py
+++ b/src/ansiblelint/rules/jinja.py
@@ -279,6 +279,8 @@ class JinjaRule(AnsibleLintRule):
 
         except jinja2.exceptions.TemplateSyntaxError as exc:
             return "", str(exc.message), "invalid"
+        # https://github.com/PyCQA/pylint/issues/7433 - py311 only
+        # pylint: disable=c-extension-no-member
         except (NotImplementedError, black.parsing.InvalidInput) as exc:
             # black is not able to recognize all valid jinja2 templates, so we
             # just ignore InvalidInput errors.

--- a/src/ansiblelint/rules/no_jinja_when.md
+++ b/src/ansiblelint/rules/no_jinja_when.md
@@ -3,8 +3,9 @@
 This rule checks conditional statements for Jinja expressions in curly brackets `{{ }}`.
 Ansible processes conditionals statements that use the `when`, `failed_when`, and `changed_when` clauses as Jinja expressions.
 
-An Ansible rule is "always use `{{ }}` except with `when*:`".
-Using `{{ }}` in conditionals creates a nested expression, which is an Ansible anti-pattern and does not produce expected results.
+An Ansible rule is to always use `{{ }}` except with `when` keys.
+Using `{{ }}` in conditionals creates a nested expression, which is an Ansible
+anti-pattern and does not produce expected results.
 
 ## Problematic Code
 

--- a/src/ansiblelint/rules/risky_file_permissions.py
+++ b/src/ansiblelint/rules/risky_file_permissions.py
@@ -72,9 +72,9 @@ class MissingFilePermissionsRule(AnsibleLintRule):
     description = (
         "Missing or unsupported mode parameter can cause unexpected file "
         "permissions based "
-        "on version of Ansible being used. Be explicit, like ``mode: 0644`` to "
-        "avoid hitting this rule. Special ``preserve`` value is accepted "
-        f"only by {', '.join(_modules_with_preserve)} modules."
+        "on version of Ansible being used. Be explicit, like `mode: 0644` to "
+        "avoid hitting this rule. Special `preserve` value is accepted "
+        f"only by {', '.join([f'`{x}`' for x in _modules_with_preserve])} modules."
     )
     link = "https://github.com/ansible/ansible/issues/71200"
     severity = "VERY_HIGH"


### PR DESCRIPTION
- change teletype text to use dimmed text and avoid changing background color
- replace markdown headers with simple text, use bright white
- avoid custom background on code examples
- remove rectangle added to the code example boxes and use default background