### PR TITLE
Ensure we do not return relative paths outside the project

### DIFF
--- a/src/ansiblelint/file_utils.py
+++ b/src/ansiblelint/file_utils.py
@@ -66,6 +66,8 @@ def normpath(path: str | BasePathLike) -> str:
     # we avoid returning relative paths that end-up at root level
     if path_absolute in relpath:
         return path_absolute
+    if relpath.startswith("../"):
+        return path_absolute
     return relpath
 
 


### PR DESCRIPTION
Makes normpath match normpath_path one and avoid returning relative
paths outside current working directory / project.

This should fix the WSL job, which was running the testing outside
user home directory, and that produced different file paths.
