### PR TITLE
Refactor parsing of ansible syntax check

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -311,6 +311,7 @@ nitpick_ignore = [
     ("py:class", "handlers"),
     ("py:class", "meta"),
     ("py:class", "playbook"),
+    ("py:class", "re.Pattern"),
     ("py:class", "requirements"),
     ("py:class", "role"),
     ("py:class", "ruamel.yaml.comments.CommentedMap"),

--- a/src/ansiblelint/_internal/rules.py
+++ b/src/ansiblelint/_internal/rules.py
@@ -173,3 +173,14 @@ class LoadingFailureRule(BaseRule):
     version_added = "v4.3.0"
     help = LOAD_FAILURE_MD
     _order = 0
+
+
+class WarningRule(BaseRule):
+    """Other warnings detected during run."""
+
+    id = "warning"
+    severity = "LOW"
+    # should remain experimental as that would keep it warning only
+    tags = ["core", "experimental"]
+    version_added = "v6.8.0"
+    _order = 0

--- a/src/ansiblelint/_internal/warning.md
+++ b/src/ansiblelint/_internal/warning.md
@@ -1,0 +1,7 @@
+# warning
+
+`warning` is a special type of internal rule that is used to report generic
+runtime warnings found during execution. As stated by its name, they are
+not counted as errors, so they do not influence the final outcome.
+
+- `warning[empty-playbook]` is raised when a playbook file has no content.

--- a/src/ansiblelint/config.py
+++ b/src/ansiblelint/config.py
@@ -19,6 +19,7 @@ DEFAULT_WARN_LIST = [
     "name[casing]",
     "name[play]",
     "role-name",
+    "warning[empty-playbook]",  # because ansible considers it warning only
 ]
 
 DEFAULT_KINDS = [

--- a/src/ansiblelint/rules/__init__.py
+++ b/src/ansiblelint/rules/__init__.py
@@ -23,6 +23,7 @@ from ansiblelint._internal.rules import (
     BaseRule,
     LoadingFailureRule,
     RuntimeErrorRule,
+    WarningRule,
 )
 from ansiblelint.config import PROFILES, get_rule_config
 from ansiblelint.config import options as default_options
@@ -383,7 +384,12 @@ class RulesCollection:
         # internal rules included in order to expose them for docs as they are
         # not directly loaded by our rule loader.
         self.rules.extend(
-            [RuntimeErrorRule(), AnsibleParserErrorRule(), LoadingFailureRule()]
+            [
+                RuntimeErrorRule(),
+                AnsibleParserErrorRule(),
+                LoadingFailureRule(),
+                WarningRule(),
+            ]
         )
         for rule in load_plugins(rulesdirs):
             self.register(rule, conditional=conditional)

--- a/test/test_profiles.py
+++ b/test/test_profiles.py
@@ -11,15 +11,15 @@ from ansiblelint.rules.risky_shell_pipe import ShellWithoutPipefail
 def test_profile_min() -> None:
     """Asserts our ability to unload rules based on profile."""
     collection = RulesCollection()
-    assert len(collection.rules) == 3, "Unexpected number of implicit rules."
+    assert len(collection.rules) == 4, "Unexpected number of implicit rules."
     # register one extra rule that we know not to be part of "min" profile
 
     collection.register(ShellWithoutPipefail())
-    assert len(collection.rules) == 4, "Failed to register new rule."
+    assert len(collection.rules) == 5, "Failed to register new rule."
 
     filter_rules_with_profile(collection.rules, "min")
     assert (
-        len(collection.rules) == 3
+        len(collection.rules) == 4
     ), "Failed to unload rule that is not part of 'min' profile."
 
 

--- a/test/test_rules_collection.py
+++ b/test/test_rules_collection.py
@@ -53,7 +53,7 @@ def fixture_bracketsmatchtestfile() -> Lintable:
 def test_load_collection_from_directory(test_rules_collection: RulesCollection) -> None:
     """Test that custom rules extend the default ones."""
     # two detected rules plus the internal ones
-    assert len(test_rules_collection) == 6
+    assert len(test_rules_collection) == 7
 
 
 def test_run_collection(
@@ -166,5 +166,5 @@ def test_rules_id_format() -> None:
             rule.help != "" or rule.description or rule.__doc__
         ), f"Rule {rule.id} must have at least one of:  .help, .description, .__doc__"
     assert "yaml" in keys, "yaml rule is missing"
-    assert len(rules) == 46  # update this number when adding new rules!
+    assert len(rules) == 47  # update this number when adding new rules!
     assert len(keys) == len(rules), "Duplicate rule ids?"

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -319,8 +319,8 @@ def test_cli_auto_detect(capfd: CaptureFixture[str]) -> None:
     assert "Excluded removed files using: git ls-files --deleted -z" in err
     # An expected rule match from our examples
     assert (
-        "examples/playbooks/empty_playbook.yml:1: "
-        "syntax-check: Empty playbook, nothing to do" in out
+        "examples/playbooks/empty_playbook.yml:1:1: "
+        "warning: Empty playbook, nothing to do" in out
     )
     # assures that our ansible-lint config exclude was effective in excluding github files
     assert "Identified: .github/" not in out


### PR DESCRIPTION
- adds an internal 'warning' rule for displaying generic warnings
- change parsing of syntax check in order to make it easier to
  maintain and extend, with generic error message detection
