### PR TITLE
Implement strict mode

### DIFF
--- a/src/ansiblelint/app.py
+++ b/src/ansiblelint/app.py
@@ -197,7 +197,7 @@ warn_list:  # or 'skip_list' to silence them completely
             console_stderr.print(render_yaml(msg))
             self.report_summary(summary, changed_files_count, files_count)
 
-        if mark_as_success or not summary.failures:
+        if not self.options.strict and (mark_as_success or not summary.failures):
             return SUCCESS_RC
         return VIOLATIONS_FOUND_RC
 

--- a/src/ansiblelint/cli.py
+++ b/src/ansiblelint/cli.py
@@ -313,6 +313,14 @@ def get_cli_parser() -> argparse.ArgumentParser:
         help="Keep default rules when using -r",
     )
     parser.add_argument(
+        "-s",
+        "--strict",
+        action="store_true",
+        default=False,
+        dest="strict",
+        help="Return non-zero exit code on warnings as well as errors",
+    )
+    parser.add_argument(
         "--write",
         dest="write_list",
         # this is a tri-state argument that takes an optional comma separated list:

--- a/src/ansiblelint/config.py
+++ b/src/ansiblelint/config.py
@@ -129,6 +129,7 @@ options = Namespace(
     extra_vars=None,
     enable_list=[],
     skip_action_validation=True,
+    strict=False,
     rules={},  # Placeholder to set and keep configurations for each rule.
 )
 


### PR DESCRIPTION
From now, you can add --strict to make it return a non zero error
code even if only warnings are found.

Related:
- https://github.com/ansible/ansible-lint/discussions/1742
- https://github.com/ansible/ansible-lint/discussions/2530
