### PR TITLE
no-shorthand: Avoid false positive with raw

### DIFF
--- a/src/ansiblelint/_internal/warning.md
+++ b/src/ansiblelint/_internal/warning.md
@@ -5,3 +5,5 @@ runtime warnings found during execution. As stated by its name, they are
 not counted as errors, so they do not influence the final outcome.
 
 - `warning[empty-playbook]` is raised when a playbook file has no content.
+- `warning[raw-non-string]` indicates that you are using `[raw](http://docs.ansible.com/ansible/latest/collections/ansible/builtin/raw_module.html#ansible-collections-ansible-builtin-raw-module)` module with
+  non-string arguments, which is not supported by Ansible.

--- a/src/ansiblelint/rules/no_shorthand.md
+++ b/src/ansiblelint/rules/no_shorthand.md
@@ -14,6 +14,10 @@ syntax. Be sure you pass a dictionary to the module, so the short-hand parsing
 is never triggered.
 ```
 
+As `raw` module only accepts free-form, we trigger `no-shorthand[raw]` only if
+we detect the presence of `executable=` inside raw calls. We advice the
+explicit use of `args:` dictionary for configuring the executable to be run.
+
 ## Problematic code
 
 ```yaml


### PR DESCRIPTION
- Add special case for `raw`, where we would look for `executable=` string
- Add warning if we see `raw` being called with anything else than a string

Fixes: #2537