### PR TITLE
Refactor the rendering of errors and warnings

### DIFF
--- a/src/ansiblelint/color.py
+++ b/src/ansiblelint/color.py
@@ -54,11 +54,10 @@ DEFAULT_STYLES.update(
 _theme = Theme(
     {
         "info": "cyan",
-        "warning": "dim yellow",
+        "warning": "yellow",
         "danger": "bold red",
         "title": "yellow",
-        "error_code": "bright_red",
-        "error_title": "red",
+        "error": "bright_red",
         "filename": "blue",
     }
 )

--- a/src/ansiblelint/errors.py
+++ b/src/ansiblelint/errors.py
@@ -5,6 +5,7 @@ import functools
 from typing import Any
 
 from ansiblelint._internal.rules import BaseRule, RuntimeErrorRule
+from ansiblelint.config import options
 from ansiblelint.file_utils import Lintable, normpath
 
 
@@ -86,6 +87,13 @@ class MatchError(ValueError):
         self.yaml_path: list[int | str] = []
         # True when a transform has resolved this MatchError
         self.fixed = False
+
+    @functools.cached_property
+    def level(self) -> str:
+        """Return the level of the rule: error, warning or notice."""
+        if {self.tag, self.rule.id, *self.rule.tags}.isdisjoint(options.warn_list):
+            return "error"
+        return "warning"
 
     def __repr__(self) -> str:
         """Return a MatchError instance representation."""

--- a/src/ansiblelint/rules/yaml.md
+++ b/src/ansiblelint/rules/yaml.md
@@ -29,6 +29,22 @@ warn_list:
 
 See the [list of yamllint rules](https://yamllint.readthedocs.io/en/stable/rules.html) for more information.
 
+Some of the detailed error codes that you might see are:
+
+- `yaml[brackets]` - _too few spaces inside empty brackets_, or _too many spaces inside brackets_
+- `yaml[colons]` - _too many spaces before colon_, or _too many spaces after colon_
+- `yaml[commas]` - _too many spaces before comma_, or _too few spaces after comma_
+- `yaml[comments-indentation]` - _Comment not indented like content_
+- `yaml[comments]` - _Too few spaces before comment_, or _Missing starting space in comment_
+- `yaml[document-start]` - _missing document start "---"_ or _found forbidden document start "---"_
+- `yaml[empty-lines]` - _too many blank lines (...> ...)_
+- `yaml[indentation]` - _Wrong indentation: expected ... but found ..._
+- `yaml[key-duplicates]` - _Duplication of key "..." in mapping_
+- `yaml[new-line-at-end-of-file]` - _No new line character at the end of file_
+- `yaml[syntax]` - YAML syntax is broken
+- `yaml[trailing-spaces]` - Spaces are found at the end of lines
+- `yaml[truthy]` - _Truthy value should be one of ..._
+
 ## Problematic code
 
 ```yaml

--- a/src/ansiblelint/rules/yaml_rule.py
+++ b/src/ansiblelint/rules/yaml_rule.py
@@ -50,7 +50,8 @@ class YamllintRule(AnsibleLintRule):
                 self.severity = "VERY_HIGH"
             matches.append(
                 self.create_matcherror(
-                    message=problem.desc,
+                    # yamllint does return lower-case sentences
+                    message=problem.desc.capitalize(),
                     linenumber=problem.line,
                     details="",
                     filename=file,
@@ -129,9 +130,9 @@ if "pytest" in sys.modules:
                 "examples/yamllint/invalid.yml",
                 "yaml",
                 [
-                    'missing document start "---"',
-                    'duplication of key "foo" in mapping',
-                    "trailing spaces",
+                    'Missing document start "---"',
+                    'Duplication of key "foo" in mapping',
+                    "Trailing spaces",
                 ],
             ),
             (

--- a/test/test_cli_role_paths.py
+++ b/test/test_cli_role_paths.py
@@ -169,7 +169,7 @@ def test_run_playbook_github(result: bool, env: dict[str, str]) -> None:
     result_gh = run_ansible_lint(role_path, cwd=cwd, env=env)
 
     expected = (
-        "::warning file=examples/playbooks/example.yml,line=44,severity=VERY_LOW::package-latest "
+        "::error file=examples/playbooks/example.yml,line=44,severity=VERY_LOW,title=package-latest::"
         "Package installs should not use latest"
     )
     assert (expected in result_gh.stdout) is result

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -320,7 +320,7 @@ def test_cli_auto_detect(capfd: CaptureFixture[str]) -> None:
     # An expected rule match from our examples
     assert (
         "examples/playbooks/empty_playbook.yml:1:1: "
-        "warning: Empty playbook, nothing to do" in out
+        "warning[empty-playbook]: Empty playbook, nothing to do" in out
     )
     # assures that our ansible-lint config exclude was effective in excluding github files
     assert "Identified: .github/" not in out


### PR DESCRIPTION
- Display warnings different than errors on all output formats
- Document YAML specific errors
- Display warning using yellow AND adding (warning) suffix
- Corrected cases where warning was determined incorrectly
- Display only the detailed rule tag on matches (reduce clutter)
- Capitalize YAML error messages

Fixes: [#1670](https://github.com/ssbarnea/ansible-lint/issues/1670)