### PR TITLE
Add internal_names rule which flags usage of internal names in collections that must not be used

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -55,6 +55,7 @@ docstrings
 doctest
 doctrees
 docutils
+edgeos
 ematcher
 ematchtestfile
 execnet

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -166,7 +166,7 @@ jobs:
       WSLENV: FORCE_COLOR:PYTEST_REQPASS:TOXENV:TOX_PARALLEL_NO_SPINNER
       # Number of expected test passes, safety measure for accidental skip of
       # tests. Update value if you add/remove tests.
-      PYTEST_REQPASS: 705
+      PYTEST_REQPASS: 707
 
     steps:
       - name: Activate WSL1

--- a/requirements.yml
+++ b/requirements.yml
@@ -6,5 +6,6 @@ collections:
   # that collection is used during ansible-lint testing for validating our
   # ability to detect non-core modules.
   - name: ansible.posix
-  # that collection is used during ansible-lint own testing
+  # these collections are used during ansible-lint own testing
   - name: community.general
+  - name: community.network

--- a/src/ansiblelint/rules/fqcn.py
+++ b/src/ansiblelint/rules/fqcn.py
@@ -135,9 +135,7 @@ if "pytest" in sys.modules:
   - name: Shell (fqcn)
     ansible.builtin.shell: echo This rule should not get matched by the fqcn rule
   - name: Use FQCN with more than 3 parts
-    community.foo.bar.baz:
-      name: should-not-be-here
-      state: absent
+    testns.test_collection.subdir.test_module_1:
     """
 
     FAIL_PLAY = """
@@ -170,5 +168,7 @@ if "pytest" in sys.modules:
     )
     def test_fqcn_builtin_pass(rule_runner: RunFromText) -> None:
         """Test rule does not match."""
-        results = rule_runner.run_playbook(SUCCESS_PLAY)
+        results = rule_runner.run_playbook(
+            SUCCESS_PLAY, project_dir="test/local-content"
+        )
         assert len(results) == 0, results

--- a/src/ansiblelint/rules/fqcn.py
+++ b/src/ansiblelint/rules/fqcn.py
@@ -129,15 +129,13 @@ if "pytest" in sys.modules:
 
     from ansiblelint.testing import RunFromText  # pylint: disable=ungrouped-imports
 
-    # TODO: replace community.general.system.sudoers with another collection where
-    #       such FQCNs are **not** internal names!
     SUCCESS_PLAY = """
 - hosts: localhost
   tasks:
   - name: Shell (fqcn)
     ansible.builtin.shell: echo This rule should not get matched by the fqcn rule
   - name: Use FQCN with more than 3 parts
-    community.general.system.sudoers:
+    community.foo.bar.baz:
       name: should-not-be-here
       state: absent
     """

--- a/src/ansiblelint/rules/fqcn.py
+++ b/src/ansiblelint/rules/fqcn.py
@@ -129,6 +129,8 @@ if "pytest" in sys.modules:
 
     from ansiblelint.testing import RunFromText  # pylint: disable=ungrouped-imports
 
+    # TODO: replace community.general.system.sudoers with another collection where
+    #       such FQCNs are **not** internal names!
     SUCCESS_PLAY = """
 - hosts: localhost
   tasks:

--- a/src/ansiblelint/rules/internal_names.md
+++ b/src/ansiblelint/rules/internal_names.md
@@ -20,7 +20,7 @@ The `internal_names` rule has the following checks:
   tasks:
     - name: Create an SSH connection
       community.general.system.ufw: # <- Does use an internal FQCN for the ufw module
-        ...
+        state: enabled
 ```
 
 ## Correct Code
@@ -30,5 +30,6 @@ The `internal_names` rule has the following checks:
   hosts: all
   tasks:
     - name: Create an SSH connection
-      community.general.ufw: ...
+      community.general.ufw:
+        state: enabled
 ```

--- a/src/ansiblelint/rules/internal_names.md
+++ b/src/ansiblelint/rules/internal_names.md
@@ -1,0 +1,35 @@
+# internal_names
+
+This rule checks for internal names being used in Ansible content.
+
+Some collections provide content under multiple names. For example, community.general and community.network allow to
+reference actions under a long FQCN and a short FQCN. The long FQCN is an implementation detail and must not be used,
+as it can change at any time (even in bugfix releases) and using it can render your playbooks and roles nonfunctional.
+
+The `internal_names` rule has the following checks:
+
+- `internal_names[community.general]` - Checks for internal names from the `community.general` collection.
+- `internal_names[community.network]` - Checks for internal names from the `community.network` collection.
+
+## Problematic Code
+
+```yaml
+---
+- name: Example playbook
+  hosts: all
+  tasks:
+    - name: Create an SSH connection
+      community.general.system.ufw:  # <- Does use an internal FQCN for the ufw module
+        ...
+```
+
+## Correct Code
+
+```yaml
+- name: Example playbook
+  hosts: all
+  tasks:
+    - name: Create an SSH connection
+      community.general.ufw:
+        ...
+```

--- a/src/ansiblelint/rules/internal_names.md
+++ b/src/ansiblelint/rules/internal_names.md
@@ -19,7 +19,7 @@ The `internal_names` rule has the following checks:
   hosts: all
   tasks:
     - name: Create an SSH connection
-      community.general.system.ufw:  # <- Does use an internal FQCN for the ufw module
+      community.general.system.ufw: # <- Does use an internal FQCN for the ufw module
         ...
 ```
 
@@ -30,6 +30,5 @@ The `internal_names` rule has the following checks:
   hosts: all
   tasks:
     - name: Create an SSH connection
-      community.general.ufw:
-        ...
+      community.general.ufw: ...
 ```

--- a/src/ansiblelint/rules/internal_names.md
+++ b/src/ansiblelint/rules/internal_names.md
@@ -1,4 +1,4 @@
-# internal_names
+# internal-names
 
 This rule checks for internal names being used in Ansible content.
 
@@ -6,10 +6,10 @@ Some collections provide content under multiple names. For example, community.ge
 reference actions under a long FQCN and a short FQCN. The long FQCN is an implementation detail and must not be used,
 as it can change at any time (even in bugfix releases) and using it can render your playbooks and roles nonfunctional.
 
-The `internal_names` rule has the following checks:
+The `internal-names` rule has the following checks:
 
-- `internal_names[community.general]` - Checks for internal names from the `community.general` collection.
-- `internal_names[community.network]` - Checks for internal names from the `community.network` collection.
+- `internal-names[community.general]` - Checks for internal names from the `community.general` collection.
+- `internal-names[community.network]` - Checks for internal names from the `community.network` collection.
 
 ## Problematic Code
 

--- a/src/ansiblelint/rules/internal_names.py
+++ b/src/ansiblelint/rules/internal_names.py
@@ -26,7 +26,7 @@ class InternalNamesRule(AnsibleLintRule):
     def matchtask(
         self, task: dict[str, Any], file: Lintable | None = None
     ) -> list[MatchError]:
-        result = []
+        result: list[MatchError] = []
         module = task["action"]["__ansible_module_original__"]
         parts = module.split(".")
         if len(parts) <= 3:

--- a/src/ansiblelint/rules/internal_names.py
+++ b/src/ansiblelint/rules/internal_names.py
@@ -8,7 +8,6 @@ from ansiblelint.errors import MatchError
 from ansiblelint.file_utils import Lintable
 from ansiblelint.rules import AnsibleLintRule
 
-
 COLLECTIONS_WITH_FLATMAPPING = [
     "community.general",
     "community.network",

--- a/src/ansiblelint/rules/internal_names.py
+++ b/src/ansiblelint/rules/internal_names.py
@@ -17,7 +17,7 @@ COLLECTIONS_WITH_FLATMAPPING = [
 class InternalNamesRule(AnsibleLintRule):
     """Avoid internal names for actions."""
 
-    id = "internal_names"
+    id = "internal-names"
     severity = "VERY_HIGH"
     description = "Check whether actions are using internal names from collections names that should not be used."
     tags = ["formatting"]
@@ -40,7 +40,7 @@ class InternalNamesRule(AnsibleLintRule):
                         details=f"Use `{collection}.{parts[-1]}` instead.",
                         filename=file,
                         linenumber=task["__line__"],
-                        tag=f"internal_names[{collection}]",
+                        tag=f"internal-names[{collection}]",
                     )
                 )
         return result
@@ -68,11 +68,11 @@ if "pytest" in sys.modules:
     FAIL_PLAY = """
 - hosts: localhost
   tasks:
-  - name: Internal name for community.general (internal_names[community.general])
+  - name: Internal name for community.general (internal-names[community.general])
     community.general.system.sudoers:
       name: should-not-be-here
       state: absent
-  - name: Internal name for community.network (internal_names[community.network])
+  - name: Internal name for community.network (internal-names[community.network])
     community.network.network.edgeos.edgeos_facts:
       gather_subset: all
     """
@@ -84,12 +84,12 @@ if "pytest" in sys.modules:
         """Test rule matches."""
         results = rule_runner.run_playbook(FAIL_PLAY)
         assert len(results) == 2
-        assert results[0].tag == "internal_names[community.general]"
+        assert results[0].tag == "internal-names[community.general]"
         assert (
             "Do not use internal names for community.general module actions"
             in results[0].message
         )
-        assert results[1].tag == "internal_names[community.network]"
+        assert results[1].tag == "internal-names[community.network]"
         assert (
             "Do not use internal names for community.network module actions"
             in results[1].message

--- a/src/ansiblelint/rules/internal_names.py
+++ b/src/ansiblelint/rules/internal_names.py
@@ -1,0 +1,105 @@
+"""Rule definition for avoiding internal names for certain collections."""
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+from ansiblelint.errors import MatchError
+from ansiblelint.file_utils import Lintable
+from ansiblelint.rules import AnsibleLintRule
+
+
+COLLECTIONS_WITH_FLATMAPPING = [
+    "community.general",
+    "community.network",
+]
+
+
+class InternalNamesRule(AnsibleLintRule):
+    """Avoid internal names for actions."""
+
+    id = "internal_names"
+    severity = "VERY_HIGH"
+    description = "Check whether actions are using internal names from collections names that should not be used."
+    tags = ["formatting"]
+    version_added = "v6.9.0"
+
+    def matchtask(
+        self, task: dict[str, Any], file: Lintable | None = None
+    ) -> list[MatchError]:
+        result = []
+        module = task["action"]["__ansible_module_original__"]
+        parts = module.split(".")
+        if len(parts) <= 3:
+            return result
+        collection = ".".join(parts[:2])
+        if collection in COLLECTIONS_WITH_FLATMAPPING:
+            if len(parts) > 3:
+                result.append(
+                    self.create_matcherror(
+                        message=f"Do not use internal name for {collection} module actions ({module}).",
+                        details=f"Use `{collection}.{parts[-1]}` instead.",
+                        filename=file,
+                        linenumber=task["__line__"],
+                        tag=f"internal_names[{collection}]",
+                    )
+                )
+        return result
+
+
+# testing code to be loaded only with pytest or when executed the rule file
+if "pytest" in sys.modules:
+
+    import pytest
+
+    from ansiblelint.testing import RunFromText  # pylint: disable=ungrouped-imports
+
+    SUCCESS_PLAY = """
+- hosts: localhost
+  tasks:
+  - name: Correct name for community.general
+    community.general.sudoers:
+      name: should-not-be-here
+      state: absent
+  - name: Correct name for community.network
+    community.network.network.edgeos.edgeos_facts:
+      gather_subset: all
+    """
+
+    FAIL_PLAY = """
+- hosts: localhost
+  tasks:
+  - name: Internal name for community.general (internal_names[community.general])
+    community.general.system.sudoers:
+      name: should-not-be-here
+      state: absent
+  - name: Internal name for community.network (internal_names[community.network])
+    community.network.edgeos_facts:
+      gather_subset: all
+    """
+
+    @pytest.mark.parametrize(
+        "rule_runner", (InternalNamesRule,), indirect=["rule_runner"]
+    )
+    def test_internal_names_fail(rule_runner: RunFromText) -> None:
+        """Test rule matches."""
+        results = rule_runner.run_playbook(FAIL_PLAY)
+        assert len(results) == 2
+        assert results[0].tag == "internal_names[community.general]"
+        assert (
+            "Do not use internal names for community.network module actions"
+            in results[0].message
+        )
+        assert results[1].tag == "internal_names[community.network]"
+        assert (
+            "Do not use internal names for community.general module actions"
+            in results[1].message
+        )
+
+    @pytest.mark.parametrize(
+        "rule_runner", (InternalNamesRule,), indirect=["rule_runner"]
+    )
+    def test_internal_names_pass(rule_runner: RunFromText) -> None:
+        """Test rule does not match."""
+        results = rule_runner.run_playbook(SUCCESS_PLAY)
+        assert len(results) == 0, results

--- a/src/ansiblelint/rules/internal_names.py
+++ b/src/ansiblelint/rules/internal_names.py
@@ -36,7 +36,7 @@ class InternalNamesRule(AnsibleLintRule):
             if len(parts) > 3:
                 result.append(
                     self.create_matcherror(
-                        message=f"Do not use internal name for {collection} module actions ({module}).",
+                        message=f"Do not use internal names for {collection} module actions ({module}).",
                         details=f"Use `{collection}.{parts[-1]}` instead.",
                         filename=file,
                         linenumber=task["__line__"],
@@ -61,7 +61,7 @@ if "pytest" in sys.modules:
       name: should-not-be-here
       state: absent
   - name: Correct name for community.network
-    community.network.network.edgeos.edgeos_facts:
+    community.network.edgeos_facts:
       gather_subset: all
     """
 
@@ -73,7 +73,7 @@ if "pytest" in sys.modules:
       name: should-not-be-here
       state: absent
   - name: Internal name for community.network (internal_names[community.network])
-    community.network.edgeos_facts:
+    community.network.network.edgeos.edgeos_facts:
       gather_subset: all
     """
 
@@ -86,12 +86,12 @@ if "pytest" in sys.modules:
         assert len(results) == 2
         assert results[0].tag == "internal_names[community.general]"
         assert (
-            "Do not use internal names for community.network module actions"
+            "Do not use internal names for community.general module actions"
             in results[0].message
         )
         assert results[1].tag == "internal_names[community.network]"
         assert (
-            "Do not use internal names for community.general module actions"
+            "Do not use internal names for community.network module actions"
             in results[1].message
         )
 

--- a/src/ansiblelint/testing/__init__.py
+++ b/src/ansiblelint/testing/__init__.py
@@ -6,7 +6,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Optional
 
 from ansiblelint.app import get_app
 from ansiblelint.rules import RulesCollection
@@ -34,22 +34,29 @@ class RunFromText:
         """Initialize a RunFromText instance with rules collection."""
         self.collection = collection
 
-    def _call_runner(self, path: str) -> list[MatchError]:
-        runner = Runner(path, rules=self.collection)
+    def _call_runner(
+        self, path: str, project_dir: Optional[str] = None
+    ) -> list[MatchError]:
+        runner = Runner(path, rules=self.collection, project_dir=project_dir)
         return runner.run()
 
     def run(self, filename: str) -> list[MatchError]:
         """Lints received filename."""
         return self._call_runner(filename)
 
-    def run_playbook(self, playbook_text: str) -> list[MatchError]:
+    def run_playbook(
+        self, playbook_text: str, project_dir: Optional[str] = None
+    ) -> list[MatchError]:
         """Lints received text as a playbook."""
         with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".yml", prefix="playbook"
+            mode="w",
+            suffix=".yml",
+            prefix="playbook",
+            dir=project_dir,
         ) as fh:
             fh.write(playbook_text)
             fh.flush()
-            results = self._call_runner(fh.name)
+            results = self._call_runner(fh.name, project_dir=project_dir)
         return results
 
     def run_role_tasks_main(self, tasks_main_text: str) -> list[MatchError]:

--- a/src/ansiblelint/testing/__init__.py
+++ b/src/ansiblelint/testing/__init__.py
@@ -6,7 +6,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from ansiblelint.app import get_app
 from ansiblelint.rules import RulesCollection

--- a/src/ansiblelint/testing/__init__.py
+++ b/src/ansiblelint/testing/__init__.py
@@ -35,7 +35,7 @@ class RunFromText:
         self.collection = collection
 
     def _call_runner(
-        self, path: str, project_dir: Optional[str] = None
+        self, path: str, project_dir: str | None = None
     ) -> list[MatchError]:
         runner = Runner(path, rules=self.collection, project_dir=project_dir)
         return runner.run()
@@ -45,7 +45,7 @@ class RunFromText:
         return self._call_runner(filename)
 
     def run_playbook(
-        self, playbook_text: str, project_dir: Optional[str] = None
+        self, playbook_text: str, project_dir: str | None = None
     ) -> list[MatchError]:
         """Lints received text as a playbook."""
         with tempfile.NamedTemporaryFile(

--- a/test/local-content/collections/ansible_collections/testns/test_collection/plugins/modules/subdir/test_module_1.py
+++ b/test/local-content/collections/ansible_collections/testns/test_collection/plugins/modules/subdir/test_module_1.py
@@ -1,0 +1,14 @@
+#!/usr/bin/python
+"""A module."""
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main() -> None:
+    """Execute module."""
+    module = AnsibleModule({})
+    module.exit_json(msg="Hello 1!")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/test_rules_collection.py
+++ b/test/test_rules_collection.py
@@ -166,5 +166,5 @@ def test_rules_id_format() -> None:
             rule.help != "" or rule.description or rule.__doc__
         ), f"Rule {rule.id} must have at least one of:  .help, .description, .__doc__"
     assert "yaml" in keys, "yaml rule is missing"
-    assert len(rules) == 47  # update this number when adding new rules!
+    assert len(rules) == 48  # update this number when adding new rules!
     assert len(keys) == len(rules), "Duplicate rule ids?"


### PR DESCRIPTION
For example, the FQCNs `community.general.system.sudoers` and `community.network.network.edgeos.edgeos_facts` should never be used for actions, since they are internal to the collection and can even change in bugfix releases.