### PR TITLE
Fix role-name correct code example

### DIFF
--- a/src/ansiblelint/rules/role_name.md
+++ b/src/ansiblelint/rules/role_name.md
@@ -26,7 +26,7 @@ For more information see the [roles directory](https://docs.ansible.com/ansible/
 - name: Example playbook
   hosts: localhost
   roles:
-    - myRole1 # <- Starts with an alphabetic character.
+    - myrole1 # <- Starts with an alphabetic character.
     - myrole2 # <- Contains only alphanumeric characters.
     - myrole_3 # <- Contains only lowercase alphabetic characters.
 ```


### PR DESCRIPTION
One of the examples of a correctly named role included a capital letter. This PR fixes the correct example to only have lowercase letters.