### PR TITLE
Add win_command/win_shell to no-free-form modules

### DIFF
--- a/src/ansiblelint/rules/no_free_form.py
+++ b/src/ansiblelint/rules/no_free_form.py
@@ -61,6 +61,8 @@ class NoFreeFormRune(AnsibleLintRule):
         elif isinstance(action_value, str) and "=" in action_value:
             fail = False
             if task["action"].get("__ansible_module__") in (
+                "ansible.builtin.command",
+                "ansible.builtin.shell",
                 "command",
                 "shell",
             ):

--- a/src/ansiblelint/rules/no_free_form.py
+++ b/src/ansiblelint/rules/no_free_form.py
@@ -63,8 +63,12 @@ class NoFreeFormRune(AnsibleLintRule):
             if task["action"].get("__ansible_module__") in (
                 "ansible.builtin.command",
                 "ansible.builtin.shell",
+                "ansible.windows.win_command",
+                "ansible.windows.win_shell",
                 "command",
                 "shell",
+                "win_command",
+                "win_shell",
             ):
                 if self.cmd_shell_re.match(action_value):
                     fail = True


### PR DESCRIPTION
https://github.com/ansible/ansible-lint/pull/2586 softened the `no-free-form` rule, but unfortunately missed the Windows equivalents for these modules.