### PR TITLE
Allow toggling strict in the config file

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -10,6 +10,7 @@ exclude_paths:
   - test/fixtures/formatting-prettier/
 # parseable: true
 # quiet: true
+# strict: true
 # verbosity: 1
 
 # Mock modules or roles in order to pass ansible-playbook --syntax-check

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -166,7 +166,7 @@ jobs:
       WSLENV: FORCE_COLOR:PYTEST_REQPASS:TOXENV:TOX_PARALLEL_NO_SPINNER
       # Number of expected test passes, safety measure for accidental skip of
       # tests. Update value if you add/remove tests.
-      PYTEST_REQPASS: 707
+      PYTEST_REQPASS: 708
 
     steps:
       - name: Activate WSL1

--- a/src/ansiblelint/cli.py
+++ b/src/ansiblelint/cli.py
@@ -442,6 +442,7 @@ def merge_config(file_config: dict[Any, Any], cli_config: Namespace) -> Namespac
         "display_relative_path",
         "parseable",
         "quiet",
+        "strict",
         "use_default_rules",
         "progressive",
         "offline",

--- a/src/ansiblelint/schemas/ansible-lint-config.json
+++ b/src/ansiblelint/schemas/ansible-lint-config.json
@@ -157,6 +157,11 @@
       "title": "Skip List",
       "type": "array"
     },
+    "strict": {
+      "default": false,
+      "title": "Strict",
+      "type": "boolean"
+    },
     "tags": {
       "items": {
         "type": "string"

--- a/test/fixtures/strict.yml
+++ b/test/fixtures/strict.yml
@@ -1,0 +1,3 @@
+---
+strict: true
+# vim: et:sw=2:syntax=yaml:ts=2:

--- a/test/test_commandline_invocations_same_as_config.py
+++ b/test/test_commandline_invocations_same_as_config.py
@@ -23,6 +23,7 @@ def fixture_base_arguments() -> list[str]:
         (["-q"], "test/fixtures/quiet.yml"),
         (["-r", "test/fixtures/rules/"], "test/fixtures/rulesdir.yml"),
         (["-R", "-r", "test/fixtures/rules/"], "test/fixtures/rulesdir-defaults.yml"),
+        (["-s"], "test/fixtures/strict.yml"),
         (["-t", "skip_ansible_lint"], "test/fixtures/tags.yml"),
         (["-v"], "test/fixtures/verbosity.yml"),
         (["-x", "bad_tag"], "test/fixtures/skip-tags.yml"),


### PR DESCRIPTION
This commit adds `strict` to the config file schema, equivalent to passing `--strict` on the command line.

Since the config file is the only way to customize behavior in the ansible-lint action, it is useful to have parity between the command line and the config file.