### PR TITLE
Fix merging of command line options with configuration

### DIFF
--- a/src/ansiblelint/cli.py
+++ b/src/ansiblelint/cli.py
@@ -474,11 +474,13 @@ def merge_config(file_config: dict[Any, Any], cli_config: Namespace) -> Namespac
         return cli_config
 
     for entry in bools:
-        v = getattr(cli_config, entry) or file_config.pop(entry, False)
+        file_value = file_config.pop(entry, False)
+        v = getattr(cli_config, entry) or file_value
         setattr(cli_config, entry, v)
 
     for entry, default in scalar_map.items():
-        v = getattr(cli_config, entry, None) or file_config.pop(entry, default)
+        file_value = file_config.pop(entry, default)
+        v = getattr(cli_config, entry, None) or file_value
         setattr(cli_config, entry, v)
 
     # if either commandline parameter or config file option is set merge

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -326,8 +326,6 @@ def test_cli_auto_detect(capfd: CaptureFixture[str]) -> None:
     assert "Identified: .github/" not in out
     # assures that we can parse playbooks as playbooks
     assert "Identified: test/test/always-run-success.yml" not in err
-    # assure that zuul_return missing module is not reported
-    assert "examples/playbooks/mocked_dependency.yml" not in out
     assert "Executing syntax check on examples/playbooks/mocked_dependency.yml" in err
 
 


### PR DESCRIPTION
Fixed bug which prevented use of command line options that were
booleans or scalar when these were also defined in configuration file.

The root cause was that the did not pop them from the dictionary when
the command line options where present.
