### PR TITLE
Test get_version_warning

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -166,7 +166,7 @@ jobs:
       WSLENV: FORCE_COLOR:PYTEST_REQPASS:TOXENV:TOX_PARALLEL_NO_SPINNER
       # Number of expected test passes, safety measure for accidental skip of
       # tests. Update value if you add/remove tests.
-      PYTEST_REQPASS: 710
+      PYTEST_REQPASS: 713
 
     steps:
       - name: Activate WSL1

--- a/mypy.ini
+++ b/mypy.ini
@@ -23,6 +23,9 @@ ignore_missing_imports = True
 # # https://github.com/box/flaky/issues/170
 ignore_missing_imports = True
 
+[mypy-pip.*]
+ignore_missing_imports = True
+
 [mypy-pytest]
 ignore_missing_imports = True
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ coverage-enable-subprocess==1.0
 cryptography==38.0.1
 dill==0.3.6
 docutils==0.17.1
-exceptiongroup==1.0.0rc9
+exceptiongroup==1.0.0
 execnet==1.9.0
 filelock==3.8.0
 flake8==5.0.4
@@ -35,7 +35,7 @@ iniconfig==1.1.1
 isort==5.10.1
 jinja2==3.1.2
 jsonschema==4.16.0
-lazy-object-proxy==1.7.1
+lazy-object-proxy==1.8.0
 markdown-it-py==2.1.0
 markupsafe==2.1.1
 mccabe==0.7.0
@@ -60,6 +60,7 @@ pylint==2.15.5
 pyparsing==3.0.9
 pyrsistent==0.18.1
 pytest==7.2.0
+pytest-mock==3.10.0
 pytest-plus==0.2
 pytest-xdist==3.0.2
 pytz==2022.5
@@ -83,7 +84,7 @@ sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
 subprocess-tee==0.3.5
 tomli==2.0.1
-tomlkit==0.11.5
+tomlkit==0.11.6
 typing-extensions==4.4.0
 urllib3==1.26.12
 wcmatch==8.4.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -100,6 +100,7 @@ test =
   coverage[toml] >= 6.4.4
   flaky >= 3.7.0
   pytest >= 7.2.0
+  pytest-mock
   pytest-plus >= 0.2 # for PYTEST_REQPASS
   pytest-xdist >= 2.1.0
   psutil  # soft-dep of pytest-xdist

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -2,9 +2,13 @@
 import os
 import subprocess
 import sys
+import time
 from pathlib import Path
+from typing import Any
 
 import pytest
+
+from ansiblelint.config import get_version_warning
 
 
 @pytest.mark.parametrize(
@@ -30,3 +34,34 @@ def test_call_from_outside_venv(expected_warning: bool) -> None:
     )
     warning_found = "PATH altered to include" in proc.stderr
     assert warning_found is expected_warning
+
+
+@pytest.mark.parametrize(
+    ("ver_diff", "found", "check", "outlen"),
+    (
+        ("v1.2.2", True, "pre-release", 1),
+        ("v1.2.3", False, "", 1),
+        ("v1.2.4", True, "new release", 2),
+    ),
+)
+def test_get_version_warning(
+    mocker: Any, ver_diff: str, found: bool, check: str, outlen: int
+) -> None:
+    """Assert get_version_warning working as expected."""
+    data = '{"html_url": "https://127.0.0.1", "tag_name": "' + f"{ver_diff}" + '"}'
+    # simulate cache file
+    mocker.patch("os.path.exists", return_value=True)
+    mocker.patch("os.path.getmtime", return_value=time.time())
+    mocker.patch("builtins.open", mocker.mock_open(read_data=data))
+    # overwrite ansible-lint version
+    mocker.patch("ansiblelint.config.__version__", "1.2.3")
+    # overwrite install method to custom one. This one will increase msg line count
+    # to easily detect unwanted call to it.
+    mocker.patch("ansiblelint.config.guess_install_method", return_value="\n")
+    msg = get_version_warning()
+
+    if not found:
+        assert msg == check
+    else:
+        assert check in msg
+    assert len(msg.split("\n")) == outlen


### PR DESCRIPTION
This change is testing that get_version_warning():
- returns "" if current version is latest one
- returns a pre-release information if using pre-release
- returns a new release information and extra installation information. (note: this test doesn't check that guess_install_method() is working correctly)

I had to use pytest-mock to ensure that all test parameters are correctly set. The test should not rely on current version (since it's likely v1.2.3dev123) and on version on github.

Signed-off-by: Arnaud Patard <apatard@hupstream.com>