### PR TITLE
Bump minimal requirements

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -209,6 +209,7 @@ jobs:
 
       - name: Initialize tox envs ${{ matrix.tox_env }}
         run: python3 -m tox --notest --skip-missing-interpreters false -vv -e ${{ matrix.tox_env }}
+        timeout-minutes: 3 # average is under 1
 
       # sequential run improves browsing experience (almost no speed impact)
       - name: "Test with tox: ${{ matrix.tox_env }}"

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,21 +65,25 @@ packages = find:
 # include_package_data = True
 zip_safe = False
 
-# These are required in actual runtime:
+# These are required in actual runtime. Extra conditions were added in order
+# to help pip find dependencies, especially on older systems, where it might
+# end-up downloading a huge amount of wheels in its attempt to find one that
+# is compatible.
 install_requires =
   ansible-compat>=2.2.5  # GPLv3
-  ansible-core>=2.12.0  # GPLv3
+  ansible-core>=2.12.0,<2.14.0; python_version<"3.9"  # GPLv3
+  ansible-core>=2.12.0; python_version>="3.9"  # GPLv3
   black>=22.1.0  # MIT
   filelock  # The Unlicense
-  jsonschema>=4.9.0  # MIT, version needed for improved errors
+  jsonschema>=4.17.0  # MIT, version needed for improved errors
   packaging
-  pyyaml
-  rich>=9.5.1
+  pyyaml>=5.4.1  # MIT (centos 9 has 5.3.1)
+  rich>=12.6.0
   # The next version is planned to have breaking changes
-  ruamel.yaml >= 0.15.34, < 0.18
+  ruamel.yaml>=0.17.21,< 0.18
   # NOTE: per issue #509 0.15.34 included in debian backports
-  wcmatch>=7.0  # MIT
-  yamllint >= 1.25.0  # GPLv3
+  wcmatch>=8.4.1  # MIT
+  yamllint >= 1.28.0  # GPLv3
 
 [options.entry_points]
 console_scripts =
@@ -94,7 +98,6 @@ docs =
   sphinx-rtd-theme >= 1.0.0, < 2.0.0   # 1.0.0 broke rendering
   sphinxcontrib-apidoc >= 0.3.0
   sphinxcontrib-programoutput2 >= 2.0a1
-  yamllint >= 1.26.3
 test =
   coverage-enable-subprocess # see https://github.com/nedbat/coveragepy/issues/1341#issuecomment-1228942657
   coverage[toml] >= 6.4.4


### PR DESCRIPTION
In order to address huge delays when installing using pip on py38,
we bump the versions of our dependencies.
