### PR TITLE
Clarify progressive mode documentation

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -72,6 +72,11 @@ warn_list:
 # Offline mode disables installation of requirements.yml
 offline: false
 
+# Return success if number of violations compared with previous git
+# commit has not increased. This feature works only in git
+# repositories.
+progressive: false
+
 # Define required Ansible's variables to satisfy syntax check
 extra_vars:
   foo: bar

--- a/src/ansiblelint/cli.py
+++ b/src/ansiblelint/cli.py
@@ -284,9 +284,9 @@ def get_cli_parser() -> argparse.ArgumentParser:
         dest="progressive",
         default=False,
         action="store_true",
-        help="Return success if it detects a reduction in number"
-        " of violations compared with previous git commit. This "
-        "feature works only in git repositories.",
+        help="Return success if number of violations compared with"
+        "previous git commit has not increased. This feature works"
+        "only in git repositories.",
     )
     parser.add_argument(
         "--project-dir",

--- a/src/ansiblelint/schemas/ansible-lint-config.json
+++ b/src/ansiblelint/schemas/ansible-lint-config.json
@@ -70,6 +70,11 @@
       "title": "Offline",
       "type": "boolean"
     },
+    "progressive": {
+      "default": false,
+      "title": "Progressive",
+      "type": "boolean"
+    },
     "parseable": {
       "default": true,
       "title": "Parseable",


### PR DESCRIPTION
Hello.

In this PR I have fixed two issues regarding the progressive mode.

1. The default config lacks progressive mode, it is only mentioned in the cli help. I have added `progressive: false` with a comment (which is modified from the original, see 2.)

2. The logic behind progressive marking a success is a comparison of sets. The help says that the number of violations must be reduced, which is not true, because keeping the same number of violations is still a success: `len({1,2,3} - {1,2,3})` evaluates to `0` (`src/ansiblelint/__main__.py#233`). Therefore ansible-lint returns success if the number of violations has not increased. This takes no change in number into account. Once again, reducing means that every commit needs to remove at least 1 violation. Note, that the warning in `__main__.py` states correctly that `Total violations not increased since previous commit`, so does the `docs/usage.md`: `as long the total number of violations did not increase since the previous commit.`

I have read `test_progressive.py` file and came to the conclusion that these are issues of purely documentation nature, there's no need to additionally test, but I will continue to verify that once resolvelib dependency is fixed in my distro...