### PR TITLE
Prevent installation on Windows

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -71,6 +71,7 @@ zip_safe = False
 # is compatible.
 install_requires =
   # Special order section for helping pip:
+  will-not-work-on-windows-try-from-wsl-instead; platform_system=="Windows"
   ansible-core>=2.12.0,<2.14.0; python_version<"3.9"  # GPLv3
   ansible-core>=2.12.0; python_version>="3.9"  # GPLv3
   ansible-compat>=2.2.5  # GPLv3


### PR DESCRIPTION
In order to save time on platform that we know it will never work, we add an impossible dependency, named to hint the user about his mistake.

Any attempt to install the package using pip will give an error like below:
```
ERROR: Could not find a version that satisfies the requirement will-not-work-on-windows-try-from-wsl-instead; platform_system == "Windows" (from ansible-lint) (from versions: none)
ERROR: No matching distribution found for will-not-work-on-windows-try-from-wsl-instead; platform_system == "Windows"
```

This should be an improvement as it will prevent accidental installation of something that is never supposed to be run from Windows. Same issue was seen with ansible-core, which was possible to get installed under Windows.

![](https://sbarnea.com/ss/Screen-Shot-2022-11-22-14-55-19.82.png)
