### PR TITLE
Fix collections keyword link to point to the collections guide

### DIFF
--- a/src/ansiblelint/rules/fqcn.md
+++ b/src/ansiblelint/rules/fqcn.md
@@ -17,7 +17,7 @@ You should declare the `ansible.legacy` collection if you use local overrides wi
 ```
 
 ```{warning}
-This rule does not take [`collections` keyword](https://docs.ansible.com/ansible/latest/user_guide/collections_using.html#simplifying-module-names-with-the-collections-keyword) into consideration.
+This rule does not take [`collections` keyword](https://docs.ansible.com/ansible/latest/collections_guide/collections_using_playbooks.html#simplifying-module-names-with-the-collections-keyword) into consideration.
 The `collections` keyword provided a temporary mechanism transitioning to Ansible 2.9.
 You should rewrite any content that uses the `collections:` key and avoid it where possible.
 ```


### PR DESCRIPTION
This was moved around in https://github.com/ansible/ansible/commit/223e05e0125de7a699e2a9ecc910981960a6452c