### PR TITLE
local variable 'result' referenced before assignment

### DIFF
--- a/src/ansiblelint/rules/jinja.py
+++ b/src/ansiblelint/rules/jinja.py
@@ -34,6 +34,7 @@ DEANNOTATE_KEYS = ("__file__", "__line__", "__start_line__", "__end_line__")
 
 def deannotate(data: Any) -> Any:
     """Remove our annotations like __file__ and __line__ and return a JSON serializable object."""
+    result: dict[Any, Any] = {}
     if isinstance(data, dict):
         result = data.copy()
         for key, value in data.items():


### PR DESCRIPTION
This fix the following warning message:

    WARNING  Ignored exception from JinjaRule.<bound method AnsibleLintRule.matchtasks of jinja: Rule that looks inside jinja2 templates.> while processing roles/ansible/tasks/main.yml (tasks): local variable 'result' referenced before assignment

Signed-off-by: Wong Hoi Sing Edison <hswong3i@pantarei-design.com>