### PR TITLE
Allow additional modules in only-builtins

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -101,3 +101,11 @@ kinds:
   # - vars: "**/vars/*.yml"
   # - meta: "**/meta/main.yml"
   - yaml: "**/*.yaml-too"
+
+# List of additional collections to allow in only-builtins rule.
+# only_builtins_allow_collections:
+#   - example_ns.example_collection
+
+# List of additions modules to allow in only-builtins rule.
+# only_builtins_allow_modules:
+#   - example_module

--- a/examples/playbooks/.ansible-lint-only-builtins-allow
+++ b/examples/playbooks/.ansible-lint-only-builtins-allow
@@ -4,3 +4,5 @@ mock_modules:
 
 only_builtins_allow_collections:
   - fake_namespace.fake_collection
+only_builtins_allow_modules:
+  - zuul_return

--- a/examples/playbooks/rule-only-builtins.yml
+++ b/examples/playbooks/rule-only-builtins.yml
@@ -8,3 +8,5 @@
       fake_namespace.fake_collection.fake_module:
         name: vm.swappiness
         value: "5"
+    - name: Some task
+      zuul_return: {}

--- a/src/ansiblelint/cli.py
+++ b/src/ansiblelint/cli.py
@@ -462,6 +462,7 @@ def merge_config(file_config: dict[Any, Any], cli_config: Namespace) -> Namespac
         "mock_roles": [],
         "enable_list": [],
         "only_builtins_allow_collections": [],
+        "only_builtins_allow_modules": [],
         # do not include "write_list" here. See special logic below.
     }
 

--- a/src/ansiblelint/config.py
+++ b/src/ansiblelint/config.py
@@ -123,6 +123,7 @@ options = Namespace(
     mock_roles=[],
     loop_var_prefix=None,
     only_builtins_allow_collections=[],
+    only_builtins_allow_modules=[],
     var_naming_pattern=None,
     offline=False,
     project_dir=".",  # default should be valid folder (do not use None here)

--- a/src/ansiblelint/rules/only_builtins.py
+++ b/src/ansiblelint/rules/only_builtins.py
@@ -28,9 +28,12 @@ class OnlyBuiltinsRule(AnsibleLintRule):
 
         is_builtin = module.startswith("ansible.builtin.") or module in builtins
 
-        is_manually_allowed = any(
-            module.startswith(f"{prefix}.")
-            for prefix in options.only_builtins_allow_collections
+        is_manually_allowed = (
+            any(
+                module.startswith(f"{prefix}.")
+                for prefix in options.only_builtins_allow_collections
+            )
+            or module in options.only_builtins_allow_modules
         )
 
         return not is_builtin and not is_manually_allowed and not is_nested_task(task)
@@ -65,12 +68,12 @@ if "pytest" in sys.modules:
         )
         assert result.returncode == VIOLATIONS_FOUND_RC
         assert "Failed" in result.stderr
-        assert "1 warning(s)" in result.stderr
+        assert "2 warning(s)" in result.stderr
         assert "only-builtins: Use only builtin actions" in result.stdout
 
-    def test_only_builtins_allow_collections() -> None:
+    def test_only_builtins_allow() -> None:
         """Test rule doesn't match."""
-        conf_path = "examples/playbooks/.ansible-lint-only-builtins-allow-collections"
+        conf_path = "examples/playbooks/.ansible-lint-only-builtins-allow"
         result = run_ansible_lint(
             f"--config-file={conf_path}",
             "--strict",

--- a/src/ansiblelint/schemas/ansible-lint-config.json
+++ b/src/ansiblelint/schemas/ansible-lint-config.json
@@ -63,6 +63,13 @@
       "title": "Only Builtins Allow Collections",
       "type": "array"
     },
+    "only_builtins_allow_modules": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Only Builtins Allow Modules",
+      "type": "array"
+    },
     "mock_modules": {
       "items": {
         "type": "string"


### PR DESCRIPTION
This is most useful for old-style roles that ship own modules in a `library` folder.