### PR TITLE
Correct packaging metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,38 +17,30 @@ author = Will Thames
 author_email = will@thames.id.au
 maintainer = Ansible by Red Hat
 maintainer_email = info@ansible.com
-license = GPLv3
+license = GPLv3+
 license_files =
   COPYING
   docs/licenses/LICENSE*.*
+# https://pypi.org/classifiers/
 classifiers =
   Development Status :: 5 - Production/Stable
-
   Environment :: Console
-
   Intended Audience :: Developers
   Intended Audience :: Information Technology
   Intended Audience :: System Administrators
-
-  Operating System :: OS Independent
-
-  License :: OSI Approved :: GNU General Public License v3 (GPLv3)
-
+  Operating System :: MacOS
+  Operating System :: POSIX
+  License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)
+  Natural Language :: English
   Programming Language :: Python
   Programming Language :: Python :: 3
   Programming Language :: Python :: 3.8
   Programming Language :: Python :: 3.9
   Programming Language :: Python :: 3.10
   Programming Language :: Python :: 3.11
-  Programming Language :: Python :: Implementation
-  Programming Language :: Python :: Implementation :: CPython
-  Programming Language :: Python :: Implementation :: Jython
-  Programming Language :: Python :: Implementation :: PyPy
-
-  Topic :: Software Development :: Bug Tracking
+  Programming Language :: Python :: 3 :: Only
   Topic :: Software Development :: Quality Assurance
   Topic :: Software Development :: Testing
-
   Topic :: Utilities
 keywords =
   ansible


### PR DESCRIPTION
Most trove classifiers are taken from ansible-core, which is a direct dependency.

Fixes: #2731
Related: https://github.com/ansible/ansible-lint/issues/2730