### PR TITLE
Improve RPM Packaging

### DIFF
--- a/.config/ansible-lint.spec
+++ b/.config/ansible-lint.spec
@@ -45,6 +45,7 @@ potentially be improved.
 
 %install
 %pyproject_install
+%pyproject_save_files ansiblelint
 
 
 %if %{with check}
@@ -62,9 +63,7 @@ PYTHONPATH=%{buildroot}%{python3_sitelib} \
 %endif
 
 
-%files
-%{python3_sitelib}/ansiblelint/
-%{python3_sitelib}/ansible_lint-*.dist-info/
+%files -f %{pyproject_files}
 %{_bindir}/ansible-lint
 %license COPYING
 %doc docs/* README.md

--- a/.config/ansible-lint.spec
+++ b/.config/ansible-lint.spec
@@ -23,7 +23,7 @@ BuildRequires:  python%{python3_pkgversion}-devel
 BuildRequires:  python%{python3_pkgversion}-pytest
 BuildRequires:  python%{python3_pkgversion}-pytest-xdist
 BuildRequires:  python%{python3_pkgversion}-libselinux
-BuildRequires:  git
+BuildRequires:  git-core
 %endif
 
 

--- a/.config/ansible-lint.spec
+++ b/.config/ansible-lint.spec
@@ -17,33 +17,15 @@ Source0:        %{pypi_source}
 
 BuildArch:      noarch
 
-BuildRequires:  pyproject-rpm-macros
-BuildRequires:  python%{python3_pkgversion}-build
 BuildRequires:  python%{python3_pkgversion}-devel
-BuildRequires:  python%{python3_pkgversion}-pip
-BuildRequires:  python%{python3_pkgversion}-setuptools
-BuildRequires:  python%{python3_pkgversion}-setuptools_scm
-BuildRequires:  python%{python3_pkgversion}-wheel
 %if %{with check}
 # These are required for tests:
-BuildRequires:  python%{python3_pkgversion}-pyyaml
 BuildRequires:  python%{python3_pkgversion}-pytest
 BuildRequires:  python%{python3_pkgversion}-pytest-xdist
 BuildRequires:  python%{python3_pkgversion}-libselinux
 BuildRequires:  git
 %endif
-# Named based on fedora 35:
-Requires:       ansible-core >= 2.12.0
-Requires:       python3-packaging
-Requires:       python3-pyyaml
-Requires:       python3-rich
-Requires:       python3-ruamel-yaml
-Requires:       python3-ruamel-yaml-clib
-Requires:       python3-wcmatch
-Requires:       yamllint
 
-# generate_buildrequires
-# pyproject_buildrequires
 
 %description
 Ansible-lint checks ansible content for practices and behaviors that could
@@ -51,6 +33,10 @@ potentially be improved.
 
 %prep
 %autosetup
+
+
+%generate_buildrequires
+%pyproject_buildrequires
 
 
 %build

--- a/.config/ansible-lint.spec
+++ b/.config/ansible-lint.spec
@@ -11,7 +11,7 @@ Version:        VERSION_PLACEHOLDER
 Release:        1%{?dist}
 Summary:        Ansible-lint checks ansible content for common mistakes
 
-License:        MIT
+License:        GPL-3.0-or-later AND MIT
 URL:            https://github.com/ansible/ansible-lint
 Source0:        %{pypi_source}
 
@@ -66,8 +66,8 @@ potentially be improved.
 
 %files -f %{pyproject_files}
 %{_bindir}/ansible-lint
-%license COPYING
-%doc docs/* README.md
+%license COPYING docs/licenses/LICENSE.mit.txt
+%doc docs/ README.md
 
 %changelog
 Available at https://github.com/ansible/ansible-lint/releases

--- a/.config/ansible-lint.spec
+++ b/.config/ansible-lint.spec
@@ -70,4 +70,3 @@ potentially be improved.
 %doc docs/ README.md
 
 %changelog
-Available at https://github.com/ansible/ansible-lint/releases

--- a/.config/ansible-lint.spec
+++ b/.config/ansible-lint.spec
@@ -48,10 +48,11 @@ potentially be improved.
 %pyproject_save_files ansiblelint
 
 
-%if %{with check}
 %check
-PYTHONPATH=%{buildroot}%{python3_sitelib} \
-  pytest-3 \
+# Don't try to import tests that import pytest which isn't available at runtime
+%pyproject_check_import -e 'ansiblelint.testing*' -e 'ansiblelint.rules.conftest'
+%if %{with check}
+%pytest \
   -v \
   --disable-pytest-warnings \
   --numprocesses=auto \

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -19,8 +19,10 @@ jobs:
       targets:
         # See https://packit.dev/docs/configuration/#aliases
         # API to get available targets: https://api.dev.testing-farm.io/v0.1/composes/public
-        - fedora-stable
-        - fedora-development
+        - fedora-rawhide-x86_64
+        - fedora-rawhide-aarch64
+        - fedora-37-x86_64
+        - fedora-37-aarch64
         # Missing python3-build see https://bugzilla.redhat.com/show_bug.cgi?id=2129071
         # - centos-stream-9-aarch64
         # - centos-stream-9-x86_64

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,17 +66,17 @@ install_requires =
   will-not-work-on-windows-try-from-wsl-instead; platform_system=="Windows"
   ansible-core>=2.12.0,<2.14.0; python_version<"3.9"  # GPLv3
   ansible-core>=2.12.0; python_version>="3.9"  # GPLv3
-  ansible-compat>=2.2.5  # GPLv3
+  ansible-compat>=2.2.4  # GPLv3
   # alphabetically sorted:
   black>=22.8.0  # MIT
-  filelock>=3.8.0  # The Unlicense
-  jsonschema>=4.17.0  # MIT, version needed for improved errors
+  filelock>=3.3.0  # The Unlicense
+  jsonschema>=4.10.0  # MIT, version needed for improved errors
   packaging>=21.3  # Apache-2.0,BSD-2-Clause
   pyyaml>=5.4.1  # MIT (centos 9 has 5.3.1)
   rich>=12.0.0  # MIT
   ruamel.yaml >= 0.17.21, < 0.18  # MIT, next version is planned to have breaking changes
   yamllint >= 1.26.3  # GPLv3
-  wcmatch>=8.3.2  # MIT
+  wcmatch>=8.1.2  # MIT
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
(See the detailed commit bodies for more information :). I hope this repository doesn't use squash merges; I spent extra time splitting this up into logical changes... )

This improves ansible-lint.spec to follow best practices. It also addresses the glaring uninstallability problem. The pythondist runtime dependency generator preserves the version constraints you set, so if those aren't available in the Fedora repositories, the package won't install. %pyproject_buildrequires generates buildtime dependencies based on the upstream metadata after `%prep`, so the build will fail if those aren't installable, instead of silently producing broken packages.

Along with this, the version constraints were relaxed to versions that are actually available in the Fedora 37 and Rawhide repositories. Fedora 36's jsonschema and ansible-compat are a major version behind, so I left that out.

Side note: While aggressive version pins might seem beneficial from the upstream perspective, they make it difficult for distribution package maintainers to package your software. I urge you to reconsider this practice and only use pin versions when it's absolutely necessary.