### PR TITLE
Add a rule to validate module options

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -48,6 +48,7 @@ skip_list:
 # Ansible-lint does not automatically load rules that have the 'opt-in' tag.
 # You must enable opt-in rules by listing each rule 'id' below.
 enable_list:
+  - args
   - empty-string-compare # opt-in
   - no-log-password # opt-in
   - no-same-owner # opt-in

--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -160,6 +160,7 @@ jsonfile
 jsonschema
 junitxml
 keepends
+keyserver
 konstruktoid
 kubernetes
 kubevirt
@@ -254,6 +255,7 @@ pytest
 pyupgrade
 pyyaml
 redirections
+reexec
 regexes
 releasenotes
 relpath

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -83,7 +83,7 @@ jobs:
       WSLENV: FORCE_COLOR:PYTEST_REQPASS:TOXENV:GITHUB_STEP_SUMMARY
       # Number of expected test passes, safety measure for accidental skip of
       # tests. Update value if you add/remove tests.
-      PYTEST_REQPASS: 741
+      PYTEST_REQPASS: 743
 
     steps:
       - name: Activate WSL1

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -291,6 +291,8 @@ linkcheck_anchors_ignore = [
 nitpicky = True
 nitpick_ignore = [
     ("py:class", "AnsibleBaseYAMLObject"),
+    ("py:class", "ansible.module_utils.basic.AnsibleModule"),
+    ("py:class", "ansible.plugins.loader.PluginLoadContext"),
     ("py:class", "BasePathLike"),
     ("py:class", "CommentedMap"),
     ("py:class", "CommentedSeq"),

--- a/examples/playbooks/.ansible-lint-only-builtins-allow
+++ b/examples/playbooks/.ansible-lint-only-builtins-allow
@@ -6,3 +6,7 @@ only_builtins_allow_collections:
   - fake_namespace.fake_collection
 only_builtins_allow_modules:
   - zuul_return
+
+# skip rule to test builtin rule
+skip_list:
+  - args[module]

--- a/examples/playbooks/rule-args-module-fail-1.yml
+++ b/examples/playbooks/rule-args-module-fail-1.yml
@@ -1,0 +1,22 @@
+---
+- name: Fixture to validate module options failure scenarios
+  hosts: localhost
+  tasks:
+    - name: Clone content repository
+      # module should produce: 'missing required arguments: repo'
+      ansible.builtin.git:
+        dest: /home/www
+        accept_hostkey: true
+        version: master
+        update: false
+
+    - name: Enable service httpd and ensure it is not masked
+      # module should produce: 'missing parameter(s) required by 'enabled': name'
+      ansible.builtin.systemd:
+        enabled: true
+        masked: false
+
+    - name: Enable service httpd and ensure it is not masked
+      # module should produce: 'Unsupported parameters for ansible.builtin.systemd module: foo. Supported parameters include: no_block, state, daemon_reload (daemon-reload), name (service, unit), force, masked, daemon_reexec (daemon-reexec), scope, enabled.'
+      ansible.builtin.systemd:
+        foo: true

--- a/examples/playbooks/rule-args-module-pass-1.yml
+++ b/examples/playbooks/rule-args-module-pass-1.yml
@@ -1,0 +1,17 @@
+---
+- name: Fixture to validate module options pass scenario
+  hosts: localhost
+  tasks:
+    - name: Clone content repository
+      ansible.builtin.git:
+        repo: "{{ archive_services_repo_url }}"
+        dest: /home/www
+        accept_hostkey: true
+        version: master
+        update: false
+
+    - name: Enable service httpd and ensure it is not masked
+      ansible.builtin.systemd:
+        name: httpd
+        enabled: false
+        masked: false

--- a/examples/playbooks/rule-only-builtins.yml
+++ b/examples/playbooks/rule-only-builtins.yml
@@ -2,11 +2,11 @@
 - name: Fixture for examples/playbooks/rule-only-builtins.yml
   hosts: localhost
   tasks:
-    - name: Sysctl
+    - name: Sysctl # noqa: args[module]
       # while next module is mocked in our config, we still want to see that
       # only-builtins rules gets matched
       fake_namespace.fake_collection.fake_module:
         name: vm.swappiness
         value: "5"
-    - name: Some task
+    - name: Some task # noqa: args[module]
       zuul_return: {}

--- a/examples/playbooks/rule-validate-module-options-pass-2.yml
+++ b/examples/playbooks/rule-validate-module-options-pass-2.yml
@@ -1,0 +1,10 @@
+---
+- name: Fixture to validate module options action pass scenarios
+  hosts: localhost
+  tasks:
+    - name: Copy a new "ntp.conf" file into place with backup
+      ansible.builtin.copy:
+        src: /mine/ntp.conf
+        dest: /etc/ntp.conf
+        backup: true
+        mode: 0600

--- a/src/ansiblelint/rules/args.md
+++ b/src/ansiblelint/rules/args.md
@@ -1,0 +1,89 @@
+# args
+
+This rule validates if the task arguments conform with the plugin documentation.
+
+The rule validation will check if the option name is valid and
+has the correct value along with conditionals on the options like
+``mutually_exclusive``, ``required_together``, ``required_one_of`` and so on.
+
+For more information see the [argument spec validator](https://docs.ansible.com/ansible/latest/reference_appendices/module_utils.html#argumentspecvalidator) topic in the Ansible module utility documentation.
+
+Possible messages:
+
+- `args[module]` - missing required arguments: ...
+- `args[module]` - missing parameter(s) required by ...
+
+## Problematic Code
+
+```yaml
+---
+- name: Fixture to validate module options failure scenarios
+  hosts: localhost
+  tasks:
+  - name: Clone content repository
+    ansible.builtin.git: # <- Required option `repo` is missing.
+      dest: /home/www
+      accept_hostkey: true
+      version: master
+      update: false
+
+  - name: Enable service httpd and ensure it is not masked
+    ansible.builtin.systemd: # <- Missing 'name' parameter required by 'enabled'.
+      enabled: true
+      masked: false
+
+  - name: Use quiet to avoid verbose output
+    ansible.builtin.assert:
+      test:
+        - my_param <= 100
+        - my_param >= 0
+      quiet: invalid # <- Value for option `quiet` is invalid.
+```
+
+## Correct Code
+
+```yaml
+---
+- name: Fixture to validate module options pass scenario
+  hosts: localhost
+  tasks:
+  - name: Clone content repository
+    ansible.builtin.git: # <- Contains required option `repo`.
+      repo: https://github.com/ansible/ansible-examples.git
+      dest: /home/www
+      accept_hostkey: true
+      version: master
+      update: false
+
+  - name: Enable service httpd and ensure it is not masked
+    ansible.builtin.systemd: # <- Contains 'name' parameter required by 'enabled'.
+      name: httpd
+      enabled: false
+      masked: false
+
+  - name: Use quiet to avoid verbose output
+    ansible.builtin.assert:
+      that:
+        - my_param <= 100
+        - my_param >= 0
+      quiet: True # <- Has correct type value for option `quiet` which is boolean.
+```
+
+## Special cases
+
+In some complex cases where you are using jinja expressions, the linter may
+not able to fully validate all the possible values and report a false positive.
+The example below would usually report
+`parameters are mutually exclusive: data|file|keyserver|url`
+but because we added `# noqa: args[module]` it will just pass.
+
+```yaml
+- name: Add apt keys  # noqa: args[module]
+  become: true
+  ansible.builtin.apt_key:
+    url: "{{ zj_item['url'] | default(omit) }}"
+    data: "{{ zj_item['data'] | default(omit) }}"
+  loop: "{{ repositories_keys }}"
+  loop_control:
+    loop_var: zj_item
+```

--- a/src/ansiblelint/rules/args.py
+++ b/src/ansiblelint/rules/args.py
@@ -1,0 +1,251 @@
+"""Rule definition to validate task options."""
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import json
+import logging
+import re
+import sys
+from functools import lru_cache
+from typing import Any
+
+# pylint: disable=preferred-module
+from unittest import mock
+from unittest.mock import patch
+
+# pylint: disable=reimported
+import ansible.module_utils.basic as mock_ansible_module
+from ansible.module_utils import basic
+from ansible.plugins import loader
+
+from ansiblelint.constants import LINE_NUMBER_KEY
+from ansiblelint.errors import MatchError
+from ansiblelint.file_utils import Lintable
+from ansiblelint.rules import AnsibleLintRule, RulesCollection
+from ansiblelint.text import has_jinja
+
+_logger = logging.getLogger(__name__)
+
+
+@lru_cache
+def load_module(module_name: str) -> loader.PluginLoadContext:
+    """Load plugin from module name and cache it."""
+    return loader.module_loader.find_plugin_with_context(module_name)
+
+
+class ValidationPassed(Exception):
+    """Exception to be raised when validation passes."""
+
+
+class CustomAnsibleModule(basic.AnsibleModule):  # type: ignore
+    """Mock AnsibleModule class."""
+
+    def __init__(self, *args: str, **kwargs: str) -> None:
+        """Initialize AnsibleModule mock."""
+        super().__init__(*args, **kwargs)
+        raise ValidationPassed
+
+
+class ArgsRule(AnsibleLintRule):
+    """Validating module arguments."""
+
+    id = "args"
+    severity = "HIGH"
+    description = "Check whether tasks are using correct module options."
+    tags = ["syntax", "experimental"]
+    version_added = "v6.10.0"
+    module_aliases: dict[str, str] = {"block/always/rescue": "block/always/rescue"}
+
+    def matchtask(
+        self, task: dict[str, Any], file: Lintable | None = None
+    ) -> list[MatchError]:
+        # pylint: disable=too-many-branches,too-many-locals
+        results: list[MatchError] = []
+        module_name = task["action"]["__ansible_module_original__"]
+        failed_msg = None
+
+        if module_name in self.module_aliases:
+            return []
+
+        loaded_module = load_module(module_name)
+        module_args = {
+            key: value
+            for key, value in task["action"].items()
+            if not key.startswith("__")
+        }
+
+        with mock.patch.object(
+            mock_ansible_module, "AnsibleModule", CustomAnsibleModule
+        ):
+            spec = importlib.util.spec_from_file_location(
+                "plugin", loaded_module.plugin_resolved_path
+            )
+            if spec:
+                assert spec.loader is not None
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+            else:
+                assert file is not None
+                _logger.warning(
+                    "Unable to load module %s at %s:%s for options validation",
+                    module_name,
+                    file.filename,
+                    task[LINE_NUMBER_KEY],
+                )
+                return []
+
+            try:
+                if not hasattr(module, "main"):
+                    # skip validation for module options that are implemented as action plugin
+                    # as the option values can be changed in action plugin and are not passed
+                    # through `ArgumentSpecValidator` class as in case of modules.
+                    return []
+
+                with patch.object(
+                    sys,
+                    "argv",
+                    ["", json.dumps({"ANSIBLE_MODULE_ARGS": module_args})],
+                ):
+                    fio = io.StringIO()
+                    failed_msg = ""
+                    # Warning: avoid running anything while stdout is redirected
+                    # as what happens may be very hard to debug.
+                    with contextlib.redirect_stdout(fio):
+                        # pylint: disable=protected-access
+                        basic._ANSIBLE_ARGS = None
+                        try:
+                            module.main()
+                        except SystemExit:
+                            failed_msg = fio.getvalue()
+                    if failed_msg:
+                        results.extend(
+                            self._parse_failed_msg(failed_msg, task, module_name, file)
+                        )
+
+                sanitized_results = self._sanitize_results(results, module_name)
+                return sanitized_results
+            except ValidationPassed:
+                return []
+
+    def _sanitize_results(
+        self, results: list[MatchError], module_name: str
+    ) -> list[MatchError]:
+        """Remove results that are false positive."""
+        sanitized_results = []
+        for result in results:
+            result_msg = result.message
+            if result_msg.startswith("Unsupported parameters"):
+                # cmd option is a special case in command module and after option validation is done.
+                if (
+                    "Unsupported parameters for (basic.py) module" in result_msg
+                    and module_name
+                    in ["command", "ansible.builtin.command", "ansible.legacy.command"]
+                ):
+                    continue
+                result.message = result_msg.replace("(basic.py)", f"{module_name}")
+            elif result_msg.startswith("missing required arguments"):
+                if (
+                    "missing required arguments: free_form" in result_msg
+                    and module_name
+                    in [
+                        "raw",
+                        "ansible.builtin.raw",
+                        "ansible.legacy.raw",
+                        "meta",
+                        "ansible.builtin.meta",
+                        "ansible.legacy.meta",
+                    ]
+                ):
+                    # free_form option is a special case in raw module hence ignore this error.
+                    continue
+                if (
+                    "missing required arguments: key_value" in result_msg
+                    and module_name
+                    in [
+                        "set_fact",
+                        "ansible.builtin.set_fact",
+                        "ansible.legacy.set_fact",
+                    ]
+                ):
+                    # handle special case for set_fact module with key and value
+                    continue
+            if "Supported parameters include" in result_msg and module_name in [
+                "set_fact",
+                "ansible.builtin.set_fact",
+                "ansible.legacy.set_fact",
+            ]:
+                continue
+            sanitized_results.append(result)
+
+        return sanitized_results
+
+    def _parse_failed_msg(
+        self,
+        failed_msg: str,
+        task: dict[str, Any],
+        module_name: str,
+        file: Lintable | None = None,
+    ) -> list[MatchError]:
+        """Parse failed message and return list of MatchError."""
+        results: list[MatchError] = []
+        try:
+            failed_obj = json.loads(failed_msg)
+            error_message = failed_obj["msg"]
+        except json.decoder.JSONDecodeError:
+            error_message = failed_msg
+
+        option_type_check_error = re.search(
+            r"argument '(?P<name>.*)' is of type", error_message
+        )
+        if option_type_check_error:
+            # ignore options with templated variable value with type check errors
+            option_key = option_type_check_error.group("name")
+            option_value = task["action"][option_key]
+            if has_jinja(option_value):
+                _logger.debug(
+                    "Type checking ignored for '%s' option in task '%s' at line %s.",
+                    option_key,
+                    module_name,
+                    task[LINE_NUMBER_KEY],
+                )
+                return results
+
+        results.append(
+            self.create_matcherror(
+                message=error_message,
+                linenumber=task[LINE_NUMBER_KEY],
+                tag="args[module]",
+                filename=file,
+            )
+        )
+        return results
+
+
+# testing code to be loaded only with pytest or when executed the rule file
+if "pytest" in sys.modules:
+
+    from ansiblelint.runner import Runner  # pylint: disable=ungrouped-imports
+
+    def test_args_module_fail() -> None:
+        """Test rule invalid module options."""
+        collection = RulesCollection()
+        collection.register(ArgsRule())
+        success = "examples/playbooks/rule-args-module-fail-1.yml"
+        results = Runner(success, rules=collection).run()
+        assert len(results) == 3
+        assert results[0].tag == "args[module]"
+        assert "missing required arguments" in results[0].message
+        assert results[1].tag == "args[module]"
+        assert "missing parameter(s) required by " in results[1].message
+        assert results[2].tag == "args[module]"
+        assert "Unsupported parameters for" in results[2].message
+
+    def test_args_module_pass() -> None:
+        """Test rule valid module options."""
+        collection = RulesCollection()
+        collection.register(ArgsRule())
+        success = "examples/playbooks/rule-args-module-pass-1.yml"
+        results = Runner(success, rules=collection).run()
+        assert len(results) == 0, results

--- a/src/ansiblelint/rules/only_builtins.py
+++ b/src/ansiblelint/rules/only_builtins.py
@@ -69,7 +69,7 @@ if "pytest" in sys.modules:
         )
         assert result.returncode == VIOLATIONS_FOUND_RC
         assert "Failed" in result.stderr
-        assert "2 warning(s)" in result.stderr
+        assert "warning(s)" in result.stderr
         assert "only-builtins: Use only builtin actions" in result.stdout
 
     def test_only_builtins_allow() -> None:

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -12,7 +12,7 @@ def test_example(default_rules_collection: RulesCollection) -> None:
     result = Runner(
         "examples/playbooks/example.yml", rules=default_rules_collection
     ).run()
-    assert len(result) == 19
+    assert len(result) == 22
 
 
 @pytest.mark.parametrize(

--- a/test/test_rules_collection.py
+++ b/test/test_rules_collection.py
@@ -166,5 +166,5 @@ def test_rules_id_format() -> None:
             rule.help != "" or rule.description or rule.__doc__
         ), f"Rule {rule.id} must have at least one of:  .help, .description, .__doc__"
     assert "yaml" in keys, "yaml rule is missing"
-    assert len(rules) == 49  # update this number when adding new rules!
+    assert len(rules) == 50  # update this number when adding new rules!
     assert len(keys) == len(rules), "Duplicate rule ids?"

--- a/test/test_skip_inside_yaml.py
+++ b/test/test_skip_inside_yaml.py
@@ -50,12 +50,12 @@ def test_role_tasks(default_text_runner: RunFromText) -> None:
 def test_role_tasks_with_block(default_text_runner: RunFromText) -> None:
     """Check that blocks in role tasks can contain skips."""
     results = default_text_runner.run_role_tasks_main(ROLE_TASKS_WITH_BLOCK)
-    assert len(results) == 4
+    assert len(results) == 12
 
 
 @pytest.mark.parametrize(
     ("lintable", "expected"),
-    (pytest.param("examples/playbooks/test_skip_inside_yaml.yml", 7, id="yaml"),),
+    (pytest.param("examples/playbooks/test_skip_inside_yaml.yml", 11, id="yaml"),),
 )
 def test_inline_skips(
     default_rules_collection: RulesCollection, lintable: str, expected: int

--- a/test/test_skip_playbook_items.py
+++ b/test/test_skip_playbook_items.py
@@ -101,11 +101,11 @@ PLAYBOOK_WITH_BLOCK = """\
 @pytest.mark.parametrize(
     ("playbook", "length"),
     (
-        pytest.param(PLAYBOOK_PRE_TASKS, 2, id="PRE_TASKS"),
-        pytest.param(PLAYBOOK_POST_TASKS, 2, id="POST_TASKS"),
-        pytest.param(PLAYBOOK_HANDLERS, 2, id="HANDLERS"),
-        pytest.param(PLAYBOOK_TWO_PLAYS, 2, id="TWO_PLAYS"),
-        pytest.param(PLAYBOOK_WITH_BLOCK, 4, id="WITH_BLOCK"),
+        pytest.param(PLAYBOOK_PRE_TASKS, 6, id="PRE_TASKS"),
+        pytest.param(PLAYBOOK_POST_TASKS, 6, id="POST_TASKS"),
+        pytest.param(PLAYBOOK_HANDLERS, 6, id="HANDLERS"),
+        pytest.param(PLAYBOOK_TWO_PLAYS, 6, id="TWO_PLAYS"),
+        pytest.param(PLAYBOOK_WITH_BLOCK, 12, id="WITH_BLOCK"),
     ),
 )
 def test_pre_tasks(


### PR DESCRIPTION
The new rule will validate the correctness
of module options for tasks. The validation
will check if the option name is valid and
has correct value along with conditionals like
* mutually_exclusive
* required_together
* required_one_of
* required_if

Note:
*  For template values for options the data type validation will be ignored
*  For modules that are implemented as action plugins the check includes
   if the option is correct and passes the data type check or not.