### PR TITLE
Allow var_naming_pattern in linter config schema

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -34,7 +34,7 @@ loop_var_prefix: "{role}_"
 # Enforce variable names to follow pattern below, in addition to Ansible own
 # requirements, like avoiding python identifiers. To disable add `var-naming`
 # to skip_list.
-# var_naming_pattern: "^[a-z_][a-z0-9_]*$"
+var_naming_pattern: "^[a-z_][a-z0-9_]*$"
 
 use_default_rules: true
 # Load custom rules from this specific folder

--- a/requirements.txt
+++ b/requirements.txt
@@ -62,7 +62,7 @@ pyrsistent==0.19.2
 pytest==7.2.0
 pytest-mock==3.10.0
 pytest-plus==0.2
-pytest-xdist==3.0.2
+pytest-xdist==3.1.0
 pytz==2022.6
 pyyaml==6.0
 requests==2.28.1

--- a/src/ansiblelint/schemas/ansible-lint-config.json
+++ b/src/ansiblelint/schemas/ansible-lint-config.json
@@ -211,6 +211,11 @@
       "title": "Use Default Rules",
       "type": "boolean"
     },
+    "var_naming_pattern": {
+      "default": "^[a-z_][a-z0-9_]*$",
+      "title": "Regex used to verify variable names",
+      "type": "string"
+    },
     "verbosity": {
       "default": 0,
       "title": "Verbosity",


### PR DESCRIPTION
Fixes: #2751