### PR TITLE
Fix test 'eco'

### DIFF
--- a/test/test_eco.py
+++ b/test/test_eco.py
@@ -30,6 +30,8 @@ def sanitize_output(text: str) -> str:
     result = re.sub(
         r"^WARNING: PATH altered to include.+\n", "", result, flags=re.MULTILINE
     )
+    # replace venv path
+    result = result.replace(".tox/venv", ".tox/eco")
 
     return result
 

--- a/test/test_eco.py
+++ b/test/test_eco.py
@@ -84,5 +84,6 @@ def test_eco(repo: str) -> None:
         shell=True,
         check=False,
         capture_output=True,
+        text=True,
     )
-    assert result.returncode == 0, result_txt
+    assert result.returncode == 0, result_txt + f"\nDIFF:\n{result.stdout}"


### PR DESCRIPTION
Added DIFF in error output to check issue.
So got this:
```diff
DIFF:
diff --git a/test/eco/before/zuul-jobs.result b/test/eco/after/zuul-jobs.result
index 8c55d370..17de3af5 100644
--- a/test/eco/before/zuul-jobs.result
+++ b/test/eco/after/zuul-jobs.result
@@ -26,7 +26,7 @@ WARNING  Ignored exception from ArgsRule.<bound method AnsibleLintRule.matchtask
 WARNING  Ignored exception from ArgsRule.<bound method AnsibleLintRule.matchtasks of args: Validating module arguments.> while processing roles/upload-logs-ibm/tasks/main.yaml (tasks): No module named 'ibm_botocore'
 WARNING  Ignored exception from ArgsRule.<bound method AnsibleLintRule.matchtasks of args: Validating module arguments.> while processing roles/upload-logs-s3/tasks/main.yaml (tasks): No module named 'boto3'
 WARNING  Ignored exception from ArgsRule.<bound method AnsibleLintRule.matchtasks of args: Validating module arguments.> while processing roles/upload-logs-swift/tasks/main.yaml (tasks): No module named 'openstack'
-WARNING  Ignored exception from ArgsRule.<bound method AnsibleLintRule.matchtasks of args: Validating module arguments.> while processing roles/use-buildset-registry/tasks/main.yaml (tasks): cannot import name 'remarshal' from 'ansible.module_utils' (~/work/ansible-lint/ansible-lint/.tox/venv/lib/python3.9/site-packages/ansible/module_utils/__init__.py)
+WARNING  Ignored exception from ArgsRule.<bound method AnsibleLintRule.matchtasks of args: Validating module arguments.> while processing roles/use-buildset-registry/tasks/main.yaml (tasks): cannot import name 'remarshal' from 'ansible.module_utils' (~/work/ansible-lint/ansible-lint/.tox/eco/lib/python3.9/site-packages/ansible/module_utils/__init__.py)
 WARNING  Ignored exception from JinjaRule.<bound method AnsibleLintRule.matchtasks of jinja: Rule that looks inside jinja2 templates.> while processing roles/emit-job-header/tasks/main.yaml (tasks): 'KeyError' object has no attribute 'message'
 WARNING  Listing 1 violation(s) that are fatal
 WARNING  The following filters were mocked during the run: Invalid plugin FQCN (ansible.netcommon.ipwrap): unable to locate collection ansible.netcommon
```

=> Adapted sanitization accordingly.