### PR TITLE
name[template]: only trigger on word characters after the template

### DIFF
--- a/examples/playbooks/rule-name-templated-fail.yml
+++ b/examples/playbooks/rule-name-templated-fail.yml
@@ -8,3 +8,6 @@
     - name: This task is correctly templated {{ sampleService }}
       ansible.builtin.command: echo "Hello World"
       changed_when: false
+    - name: This task is correctly templated '{{ sampleService }}'
+      ansible.builtin.command: echo "Hello World"
+      changed_when: false

--- a/src/ansiblelint/rules/name.py
+++ b/src/ansiblelint/rules/name.py
@@ -25,7 +25,7 @@ class NameRule(AnsibleLintRule):
     severity = "MEDIUM"
     tags = ["idiom"]
     version_added = "v6.9.1 (last update)"
-    _re_templated_inside = re.compile(r".*\{\{.*\}\}(.+)$")
+    _re_templated_inside = re.compile(r".*\{\{.*\}\}.*\w.*$")
 
     def matchplay(self, file: Lintable, data: dict[str, Any]) -> list[MatchError]:
         """Return matches found for a specific play (entry in playbook)."""


### PR DESCRIPTION
This allows tasks being called like

    Do the thing with '{{ template }}'

Which makes the task name better readable if `template` contains spaces