### PR TITLE
Fix line number on var-naming error for 'register'

### DIFF
--- a/examples/playbooks/rule-var-naming-fail.yml
+++ b/examples/playbooks/rule-var-naming-fail.yml
@@ -26,3 +26,7 @@
             ALL_CAPS_ARE_BAD_TOO: "{{ MoreBad }}" # invalid
           ansible.builtin.set_fact:
             CamelCaseIsBad: "{{ BAD }}" # invalid
+    - name: Test on register
+      ansible.builtin.debug:
+        var: test_var
+      register: CamelCaseIsBad # invalid

--- a/src/ansiblelint/rules/var_naming.py
+++ b/src/ansiblelint/rules/var_naming.py
@@ -143,7 +143,7 @@ class VariableNamingRule(AnsibleLintRule):
             results.append(
                 self.create_matcherror(
                     filename=file,
-                    linenumber=0,
+                    linenumber=task[LINE_NUMBER_KEY],
                     message=f"Task registers a variable that violates variable naming standards: {registered_var}",
                     tag=f"var-naming[{registered_var}]",
                 )
@@ -198,7 +198,7 @@ if "pytest" in sys.modules:
     def test_invalid_var_name_playbook(rule_runner: RunFromText) -> None:
         """Test rule matches."""
         results = rule_runner.run("examples/playbooks/rule-var-naming-fail.yml")
-        assert len(results) == 6
+        assert len(results) == 7
         for result in results:
             assert result.rule.id == VariableNamingRule.id
         # We are not checking line numbers because they can vary between


### PR DESCRIPTION
To avoid this ignored exception:

```
WARNING  Ignored exception from VariableNamingRule.<bound method AnsibleLintRule.matchtasks of var-naming: All variables should be named using only lowercase and underscores.> while processing examples/playbooks/rule-var-naming-fail.yml (playbook): MatchError called incorrectly as line numbers start with 1
```