### PR TITLE
include static files with pyproject.yml as with setup.cfg

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -248,3 +248,9 @@ markers = [
 [tool.setuptools_scm]
 local_scheme = "no-local-version"
 write_to = "src/ansiblelint/_version.py"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+"*" = ["py.typed", "**/*.json", "**/*.yml", "**/*.yaml", "**/*.md"]


### PR DESCRIPTION
Commit 712a23a76ab8b41d611301bff5893c60c6e44398 moved from simple setup.cfg to PEP-621 scheme. The pyproject.toml doesn't include any references to static files that need to be installed in order to make ansible-lint work. This commit copies over the instructions from the former setup.cfg to pyproject.toml.

fixes #2826