### PR TITLE
Add the missing github_branch meta field

### DIFF
--- a/src/ansiblelint/schemas/__store__.json
+++ b/src/ansiblelint/schemas/__store__.json
@@ -28,7 +28,7 @@
     "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/inventory.json"
   },
   "meta": {
-    "etag": "c6c6d52c2e952d8708e638b45f350b327e9dd3dd09d30cf072fe5d928598a1bd",
+    "etag": "12af007a9165999f589464911ed2f0497bdf6e591c401cafa864f3b481988653",
     "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/meta.json"
   },
   "meta-runtime": {

--- a/src/ansiblelint/schemas/meta.json
+++ b/src/ansiblelint/schemas/meta.json
@@ -471,6 +471,11 @@
           "title": "Galaxy Tags",
           "type": "array"
         },
+        "github_branch": {
+          "markdownDescription": "Optionally specify the branch Galaxy will use when accessing the GitHub repo for this role",
+          "title": "GitHub Branch",
+          "type": "string"
+        },
         "issue_tracker_url": {
           "title": "Issue Tracker Url",
           "type": "string"
@@ -504,7 +509,7 @@
           "type": "string"
         },
         "standalone": {
-          "description:": "Set to true for old standalone roles, or false for new collection roles.",
+          "description": "Set to true for old standalone roles, or false for new collection roles.",
           "title": "Standalone",
           "type": "boolean"
         }


### PR DESCRIPTION
Per the Ansible-Galaxy documentation, there's an allowed optional `github_branch` field in a role's `meta/main.yml` that isn't currently allowed for in the ansible-lint schema.
See: https://galaxy.ansible.com/docs/contributing/creating_role.html#role-metadata

Also there was a weird errant `:` typo in the `standalone` field's `description` value that I removed.