### PR TITLE
Make git a runtime dependency

### DIFF
--- a/.config/ansible-lint.spec
+++ b/.config/ansible-lint.spec
@@ -25,6 +25,7 @@ BuildRequires:  python%{python3_pkgversion}-pytest-xdist
 BuildRequires:  python%{python3_pkgversion}-libselinux
 BuildRequires:  git-core
 %endif
+Requires:       git-core
 
 
 %description

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -163,21 +163,18 @@ repos:
         args: [--strict]
         additional_dependencies:
           - ansible-compat>=2.2.6
-          - ansible-core>=2.14.0
           - black>=22.10.0
+          - cryptography
           - filelock
+          - jinja2
           - pytest>=7.2.0
-          - pyyaml
           - rich>=11.0.0
           - ruamel.yaml
-          - sphinx>=4.4.0
-          - types-dataclasses
-          - types-docutils
+          - types-PyYAML
           - types-jsonschema>=4.4.2
           - types-pkg_resources
-          - types-pyyaml>=6.0.4
+          - types-setuptools
           - wcmatch
-          - yamllint
         exclude: >
           (?x)^(
             test/local-content/.*|

--- a/src/ansiblelint/__main__.py
+++ b/src/ansiblelint/__main__.py
@@ -397,8 +397,9 @@ def path_inject() -> None:
     # We do know that finding ansible in PATH does not guarantee that it is
     # functioning or that is in fact the same version that was installed as
     # our dependency, but addressing this would be done by ansible-compat.
-    if not shutil.which("ansible"):
-        raise RuntimeError("Failed to find ansible executable in PATH")
+    for cmd in ("ansible", "git"):
+        if not shutil.which(cmd):
+            raise RuntimeError(f"Failed to find runtime dependency '{cmd}' in PATH")
 
 
 # Based on Ansible implementation

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -1,5 +1,6 @@
 """Tests related to ansiblelint.__main__ module."""
 import os
+import shutil
 import subprocess
 import sys
 import time
@@ -19,19 +20,23 @@ from ansiblelint.config import get_version_warning
 def test_call_from_outside_venv(expected_warning: bool) -> None:
     """Asserts ability to be called w/ or w/o venv activation."""
     env = None
+
+    git_location = shutil.which("git")
+    assert git_location
     if expected_warning:
-        env = {"HOME": Path.home()}
+        env = {"HOME": str(Path.home()), "PATH": str(os.path.dirname(git_location))}
     py_path = os.path.dirname(sys.executable)
     # Passing custom env prevents the process from inheriting PATH or other
     # environment variables from the current process, so we emulate being
     # called from outside the venv.
     proc = subprocess.run(
         [f"{py_path}/ansible-lint", "--version"],
-        check=True,
+        check=False,
         capture_output=True,
         text=True,
         env=env,
     )
+    assert proc.returncode == 0, proc
     warning_found = "PATH altered to include" in proc.stderr
     assert warning_found is expected_warning
 


### PR DESCRIPTION
As we received numerous bug reports which proved to be caused by
the missing git, we make git a permanent runtime dependency. This will
make the tool behavior more consistent as before that behavior would
have being different if git was missing.
