### PR TITLE
Fix infinite hang on schema refresh by adding timeout parameter

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -69,7 +69,7 @@ jobs:
       WSLENV: FORCE_COLOR:PYTEST_REQPASS:TOXENV:GITHUB_STEP_SUMMARY
       # Number of expected test passes, safety measure for accidental skip of
       # tests. Update value if you add/remove tests.
-      PYTEST_REQPASS: 745
+      PYTEST_REQPASS: 747
 
     steps:
       - name: Activate WSL1

--- a/src/ansiblelint/schemas/main.py
+++ b/src/ansiblelint/schemas/main.py
@@ -104,7 +104,7 @@ def refresh_schemas(min_age_seconds: int = 3600 * 24) -> int:
         if etag:
             request.add_header("If-None-Match", f'"{data.get("etag")}"')
         try:
-            with urllib.request.urlopen(request) as response:
+            with urllib.request.urlopen(request, timeout=10) as response:
                 if response.status == 200:
                     content = response.read().decode("utf-8").rstrip()
                     etag = response.headers["etag"].strip('"')

--- a/test/test_schemas.py
+++ b/test/test_schemas.py
@@ -1,10 +1,10 @@
 """Test schemas modules."""
-from time import sleep
-import urllib
 import logging
+import urllib
+from time import sleep
+from unittest.mock import DEFAULT, patch
 
 import pytest
-from unittest.mock import patch, DEFAULT
 
 from ansiblelint.rules import RulesCollection
 from ansiblelint.runner import Runner
@@ -63,8 +63,7 @@ def test_requests_uses_timeout(MockRequest) -> None:
 @patch("urllib.request")
 def test_request_timeouterror_handling(MockRequest, caplog) -> None:
     error_msg = "Simulating handshake operation time out."
-    MockRequest.urlopen.side_effect = urllib.error.URLError(
-        TimeoutError(error_msg))
+    MockRequest.urlopen.side_effect = urllib.error.URLError(TimeoutError(error_msg))
     with caplog.at_level(logging.DEBUG):
         assert refresh_schemas(min_age_seconds=0) == 1
     MockRequest.urlopen.assert_called()

--- a/test/test_schemas.py
+++ b/test/test_schemas.py
@@ -2,7 +2,8 @@
 import logging
 import urllib
 from time import sleep
-from unittest.mock import DEFAULT, patch
+from typing import Any
+from unittest.mock import DEFAULT, MagicMock, patch
 
 import pytest
 
@@ -47,25 +48,30 @@ def test_schema(
         assert match.tag == expected_tags[i]
 
 
-def urlopen_side_effect(*args, **kwargs):
+def urlopen_side_effect(*_args: Any, **kwargs: Any) -> DEFAULT:
+    """Actual test that timeout parameter is defined."""
     assert "timeout" in kwargs
     assert kwargs["timeout"] > 0
     return DEFAULT
 
 
 @patch("urllib.request")
-def test_requests_uses_timeout(MockRequest) -> None:
-    MockRequest.urlopen.side_effect = urlopen_side_effect
+def test_requests_uses_timeout(mock_request: MagicMock) -> None:
+    """Test that schema refresh uses timeout."""
+    mock_request.urlopen.side_effect = urlopen_side_effect
     refresh_schemas(min_age_seconds=0)
-    MockRequest.urlopen.assert_called()
+    mock_request.urlopen.assert_called()
 
 
 @patch("urllib.request")
-def test_request_timeouterror_handling(MockRequest, caplog) -> None:
+def test_request_timeouterror_handling(
+    mock_request: MagicMock, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that schema refresh can handle time out errors."""
     error_msg = "Simulating handshake operation time out."
-    MockRequest.urlopen.side_effect = urllib.error.URLError(TimeoutError(error_msg))
+    mock_request.urlopen.side_effect = urllib.error.URLError(TimeoutError(error_msg))
     with caplog.at_level(logging.DEBUG):
         assert refresh_schemas(min_age_seconds=0) == 1
-    MockRequest.urlopen.assert_called()
+    mock_request.urlopen.assert_called()
     assert "Skipped schema refresh due to unexpected exception: " in caplog.text
     assert error_msg in caplog.text


### PR DESCRIPTION
Under some special network conditions, such as running inside a Docker container and over a VPN, the schema refresh can hang indefinitely. This is fixed by adding a timeout parameter.

https://github.com/ansible/ansible-lint/issues/2869