### PR TITLE
Change treatment of files that fail to load structured data

### DIFF
--- a/src/ansiblelint/_internal/rules.py
+++ b/src/ansiblelint/_internal/rules.py
@@ -17,7 +17,7 @@ _logger = logging.getLogger(__name__)
 LOAD_FAILURE_MD = """\
 # load-failure
 
-Linter failed to process a YAML file, probably because it is either:
+"Linter failed to process a file, possible invalid file. Possible reasons:
 
 * contains unsupported encoding (only UTF-8 is supported)
 * not an Ansible file
@@ -175,7 +175,7 @@ class LoadingFailureRule(BaseRule):
     """Failed to load or parse file."""
 
     id = "load-failure"
-    description = "Linter failed to process a YAML file, possible not an Ansible file."
+    description = "Linter failed to process a file, possible invalid file."
     severity = "VERY_HIGH"
     tags = ["core", "unskippable"]
     version_added = "v4.3.0"

--- a/src/ansiblelint/constants.py
+++ b/src/ansiblelint/constants.py
@@ -1,5 +1,6 @@
 """Constants used by AnsibleLint."""
 import os.path
+from enum import Enum
 from typing import Literal
 
 DEFAULT_RULESDIR = os.path.join(os.path.dirname(__file__), "rules")
@@ -152,3 +153,15 @@ ROLE_IMPORT_ACTION_NAMES = {
 #
 # https://github.com/ansible/ansible-lint-action/issues/138
 GIT_CMD = ["git", "-c", f"safe.directory={os.getcwd()}"]
+
+
+class States(Enum):
+    """States used are used as sentinel values in various places."""
+
+    NOT_LOADED = "File not loaded"
+    LOAD_FAILED = "File failed to load"
+    UNKNOWN_DATA = "Unknown data"
+
+    def __bool__(self) -> bool:
+        """Ensure all states evaluate as False as booleans."""
+        return False

--- a/src/ansiblelint/runner.py
+++ b/src/ansiblelint/runner.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, Generator
 import ansiblelint.skip_utils
 import ansiblelint.utils
 from ansiblelint._internal.rules import LoadingFailureRule
+from ansiblelint.constants import States
 from ansiblelint.errors import MatchError
 from ansiblelint.file_utils import Lintable, expand_dirs_in_lintables
 from ansiblelint.rules.syntax_check import AnsibleSyntaxCheckRule
@@ -122,14 +123,12 @@ class Runner:
                 _logger.debug("Excluded %s", lintable)
                 self.lintables.remove(lintable)
                 continue
-            try:
-                lintable.data
-            except (RuntimeError, FileNotFoundError) as exc:
+            if isinstance(lintable.data, States) and lintable.exc:
                 matches.append(
                     MatchError(
                         filename=lintable,
-                        message=str(exc),
-                        details=str(exc.__cause__),
+                        message=str(lintable.exc),
+                        details=str(lintable.exc.__cause__),
                         rule=LoadingFailureRule(),
                     )
                 )


### PR DESCRIPTION
This new approach should allow us to cache the result of the failed
attempt to load structured data on a Lintable. The exception is stored
inside the object, so we can later produce detailed errors.
