### PR TITLE
Ignore args rule finding if value for choice has jinja template

### DIFF
--- a/examples/playbooks/rule-args-module-fail-1.yml
+++ b/examples/playbooks/rule-args-module-fail-1.yml
@@ -28,3 +28,9 @@
         foo: # this is a nested object which will have the __ injections
           # that we later need to clean
           bar: true
+
+    - name: Remove deployment dir
+      # module should produce: 'value of state must be one of: absent, directory, file, hard, link, touch, got: asbent'
+      ansible.builtin.file:
+        path: /opt/software/deployment
+        state: asbent

--- a/examples/playbooks/rule-args-module-fail-1.yml
+++ b/examples/playbooks/rule-args-module-fail-1.yml
@@ -30,7 +30,7 @@
           bar: true
 
     - name: Remove deployment dir
-      # module should produce: 'value of state must be one of: absent, directory, file, hard, link, touch, got: asbent'
+      # module should produce: 'value of state must be one of: absent, directory, file, hard, link, touch, got: away'
       ansible.builtin.file:
         path: /opt/software/deployment
-        state: asbent
+        state: away

--- a/examples/playbooks/rule-args-module-pass-1.yml
+++ b/examples/playbooks/rule-args-module-pass-1.yml
@@ -15,3 +15,12 @@
         name: httpd
         enabled: false
         masked: false
+
+    - name: Clear deployment dir
+      ansible.builtin.file:
+        path: /opt/software/deployment
+        state: "{{ item }}"
+        mode: 0755
+      with_items:
+        - absent
+        - directory

--- a/src/ansiblelint/rules/args.py
+++ b/src/ansiblelint/rules/args.py
@@ -214,6 +214,22 @@ class ArgsRule(AnsibleLintRule):
                 )
                 return results
 
+        value_not_in_choices_error = re.search(
+            r"value of (?P<name>.*) must be one of:", error_message
+        )
+        if value_not_in_choices_error:
+            # ignore templated value not in allowed choices
+            choice_key = value_not_in_choices_error.group("name")
+            choice_value = task["action"][choice_key]
+            if has_jinja(choice_value):
+                _logger.debug(
+                    "Value checking ignored for '%s' option in task '%s' at line %s.",
+                    choice_key,
+                    module_name,
+                    task[LINE_NUMBER_KEY],
+                )
+                return results
+
         results.append(
             self.create_matcherror(
                 message=error_message,

--- a/src/ansiblelint/rules/args.py
+++ b/src/ansiblelint/rules/args.py
@@ -252,7 +252,7 @@ if "pytest" in sys.modules:
         collection.register(ArgsRule())
         success = "examples/playbooks/rule-args-module-fail-1.yml"
         results = Runner(success, rules=collection).run()
-        assert len(results) == 4
+        assert len(results) == 5
         assert results[0].tag == "args[module]"
         assert "missing required arguments" in results[0].message
         assert results[1].tag == "args[module]"
@@ -261,6 +261,8 @@ if "pytest" in sys.modules:
         assert "Unsupported parameters for" in results[2].message
         assert results[3].tag == "args[module]"
         assert "Unsupported parameters for" in results[2].message
+        assert results[4].tag == "args[module]"
+        assert "value of state must be one of" in results[4].message
 
     def test_args_module_pass() -> None:
         """Test rule valid module options."""


### PR DESCRIPTION
I suggest to ignore the  args[module] rule finding for `"value of %s must be one of: %s, got: %s"` completely if the value contains a jinja template. This fixes #2866 .

This is consistent to ignoring type check errors if they contain jinja templates. I copied the code from this check. Unfortunately, there is no failing test if this check is omitted. So I did not refactor the duplication any further, because I'm rather new to Python development. Feel free to improve :-)
