### PR TITLE
Remove rich markdown header override

### DIFF
--- a/.config/requirements-lock.txt
+++ b/.config/requirements-lock.txt
@@ -26,7 +26,7 @@ pygments==2.13.0
 pyrsistent==0.19.3
 pyyaml==6.0
 resolvelib==0.8.1
-rich==13.0.0
+rich==13.2.0
 ruamel-yaml==0.17.21
 setuptools==65.6.3
 subprocess-tee==0.4.1

--- a/.config/requirements.txt
+++ b/.config/requirements.txt
@@ -16,7 +16,6 @@ certifi==2022.12.7
 cffi==1.15.1
 charset-normalizer==3.0.1
 click==8.1.3
-commonmark==0.9.1
 coverage==7.0.5
 coverage-enable-subprocess==1.0
 cryptography==39.0.0
@@ -64,7 +63,7 @@ pytz==2022.7.1
 pyyaml==6.0
 requests==2.28.2
 resolvelib==0.8.1
-rich==13.1.0
+rich==13.2.0
 ruamel-yaml==0.17.21
 ruamel-yaml-clib==0.2.7
 setuptools==66.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,14 +56,14 @@ repos:
           - prettier-plugin-toml
           - prettier-plugin-sort-json
   - repo: https://github.com/streetsidesoftware/cspell-cli
-    rev: v6.17.1
+    rev: v6.19.2
     hooks:
       - id: cspell
         # entry: codespell --relative
         args: [--relative, --no-progress, --no-summary]
         name: Spell check with cspell
   - repo: https://github.com/sirosen/check-jsonschema
-    rev: 0.20.0
+    rev: 0.21.0
     hooks:
       - id: check-github-workflows
   - repo: https://github.com/pre-commit/pre-commit-hooks.git
@@ -169,7 +169,7 @@ repos:
           - filelock
           - jinja2
           - pytest>=7.2.0
-          - rich>=11.0.0
+          - rich>=13.2.0
           - ruamel.yaml
           - types-PyYAML
           - types-jsonschema>=4.4.2
@@ -182,7 +182,7 @@ repos:
             plugins/.*
           )$
   - repo: https://github.com/pycqa/pylint
-    rev: v2.16.0b0
+    rev: v2.16.0b1
     hooks:
       - id: pylint
         args:
@@ -196,7 +196,7 @@ repos:
           - jsonschema>=4.9.0
           - pytest>=7.2.0
           - pyyaml
-          - rich>=11.0.0
+          - rich>=13.2.0
           - ruamel.yaml
           - sphinx
           - typing_extensions

--- a/src/ansiblelint/color.py
+++ b/src/ansiblelint/color.py
@@ -89,16 +89,6 @@ def render_yaml(text: str) -> Syntax:
 
 
 # pylint: disable=redefined-outer-name,unused-argument
-def _rich_heading_custom_rich_console(
-    self: rich.markdown.Heading,
-    console: rich.console.Console,
-    options: rich.console.ConsoleOptions,
-) -> rich.console.RenderResult:
-    """Override for rich console heading."""
-    yield f"[bold]{self.level * '#'} {self.text}[/]"
-
-
-# pylint: disable=redefined-outer-name,unused-argument
 def _rich_codeblock_custom_rich_console(
     self: rich.markdown.CodeBlock,
     console: Console,
@@ -115,7 +105,4 @@ def _rich_codeblock_custom_rich_console(
     yield syntax
 
 
-# Monkey-patch rich to alter its rendering of headings
-# https://github.com/python/mypy/issues/2427
-rich.markdown.Heading.__rich_console__ = _rich_heading_custom_rich_console  # type: ignore
 rich.markdown.CodeBlock.__rich_console__ = _rich_codeblock_custom_rich_console  # type: ignore


### PR DESCRIPTION
As rich [13.2.0](https://github.com/Textualize/rich/releases/tag/v13.2.0) is changing internals related to markdown rendering, it is better to remove our custom header rendering override, so users can use the library with any version of rich.

The bug was observed by mypy which noted the internal changes in newer rich, as they do not pin these dependencies.

Related: https://github.com/Textualize/rich/issues/2137
Related: https://github.com/Textualize/rich/discussions/2413