### PR TITLE
Remove zuul-jobs and tripleo-ansible from eco pipelines

### DIFF
--- a/test/test_eco.py
+++ b/test/test_eco.py
@@ -17,8 +17,6 @@ eco_repos = {
     "docker-rootless": "https://github.com/konstruktoid/ansible-docker-rootless",
     "hardening": "https://github.com/konstruktoid/ansible-role-hardening",
     "mysql": "https://github.com/geerlingguy/ansible-role-mysql.git",
-    "tripleo-ansible": "https://opendev.org/openstack/tripleo-ansible",
-    "zuul-jobs": "https://opendev.org/zuul/zuul-jobs",
 }
 
 


### PR DESCRIPTION
Removing zuul-jobs and tripleo-ansible as the maintainers of these
repositories did not show active interest in updating their codebase
based on ansible-lint updates.
