### PR TITLE
Fix typo in doc site name

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 ---
-site_name: Ansible List Documentation
+site_name: Ansible Lint Documentation
 site_url: https://ansible-lint.readthedocs.io/
 repo_url: https://github.com/ansible/ansible-lint
 edit_uri: blob/main/docs/


### PR DESCRIPTION
The doc site_name should be "Ansible Lint Documentation", not "Ansible List Documentation". This pull request fixes that.