### PR TITLE
src/ansiblelint/file_utils.py: Fix playbook/rulebook detection

### DIFF
--- a/src/ansiblelint/file_utils.py
+++ b/src/ansiblelint/file_utils.py
@@ -242,7 +242,7 @@ class Lintable:
         self.abspath = self.path.expanduser().absolute()
 
         if self.kind == "yaml":
-            self._guess_kind()
+            self.data
 
     def _guess_kind(self) -> None:
         if self.kind == "yaml":
@@ -371,6 +371,11 @@ class Lintable:
                     )
 
                     self._data = parse_yaml_linenumbers(self)
+                    # now that _data is not empty, we can try guessing if playbook or rulebook
+                    # it has to be done before append_skipped_rules() call as it's relying
+                    # on self.kind.
+                    if self.kind == "yaml":
+                        self._guess_kind()
                     # Lazy import to avoid delays and cyclic-imports
                     if "append_skipped_rules" not in globals():
                         # pylint: disable=import-outside-toplevel


### PR DESCRIPTION
Don't try detecting the file type unless file already loaded in Lintable._data, otherwise the line numbers for inline rule skipping will be set to the line where's it's used since self.kind is 'yaml'.
In case of a playbook, after _guess_kind() call, the kind will be set to playbook and the error line will be the one of the task, which is possibly different that the one with the 'noqa:' comment.

Fixes: #2977
Signed-off-by: Arnaud Patard <apatard@hupstream.com>