### PR TITLE
Keep jinja2 leading spaces

### DIFF
--- a/src/ansiblelint/rules/jinja.py
+++ b/src/ansiblelint/rules/jinja.py
@@ -270,7 +270,8 @@ class JinjaRule(AnsibleLintRule):
                     # pylint: disable=unsupported-membership-test
                     if isinstance(expr_str, str) and "\n" in expr_str:
                         raise NotImplementedError()
-                    expr_str = blacken(expr_str)
+                    leading_spaces = " " * (len(expr_str) - len(expr_str.lstrip()))
+                    expr_str = leading_spaces + blacken(expr_str.lstrip())
                     if tokens[
                         -1
                     ].token_type != "whitespace" and not expr_str.startswith(" "):
@@ -374,7 +375,8 @@ if "pytest" in sys.modules:  # noqa: C901
             pytest.param("", "", "spacing", id="1"),
             pytest.param("foo", "foo", "spacing", id="2"),
             pytest.param("{##}", "{# #}", "spacing", id="3"),
-            pytest.param("{#  #}", "{# #}", "spacing", id="4"),
+            # we want to keep leading spaces as they might be needed for complex multiline jinja files
+            pytest.param("{#  #}", "{#  #}", "spacing", id="4"),
             pytest.param(
                 "{{-aaa|xx   }}foo\nbar{#some#}\n{%%}",
                 "{{- aaa | xx }}foo\nbar{# some #}\n{% %}",

--- a/src/ansiblelint/schemas/__store__.json
+++ b/src/ansiblelint/schemas/__store__.json
@@ -40,7 +40,7 @@
     "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/molecule.json"
   },
   "playbook": {
-    "etag": "20b5fa542890607ce3d07f4313ae3446c2dd356208e3d4341a982be93d650190",
+    "etag": "9627d4eda0e6fe48d42a2b351782ce8dae2ffcc9e17d75831ec2138c922f963a",
     "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/playbook.json"
   },
   "requirements": {
@@ -48,7 +48,7 @@
     "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/requirements.json"
   },
   "tasks": {
-    "etag": "99258e1cec68edf91850e0c8663cc10ea5386a759b7ff46b9b6d366b548564b5",
+    "etag": "21f2c463bbae2cdaa4cda3a22453e9e108e1748685e2308a670295a116252e3c",
     "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/tasks.json"
   },
   "vars": {


### PR DESCRIPTION
In order to avoid breaking jinja2 indentation used in complex multiline blocks, we keep leading spaces wrote by the user.

This should address at least two undesired reformatting suggestions that we seen with
debops repository.
