### PR TITLE
Bump cryptography to 39.0.1

### DIFF
--- a/.config/requirements-lock.txt
+++ b/.config/requirements-lock.txt
@@ -11,7 +11,7 @@ black==22.12.0
 bracex==2.3.post1
 cffi==1.15.1
 click==8.1.3
-cryptography==38.0.4
+cryptography==39.0.1
 filelock==3.9.0
 jinja2==3.1.2
 jsonschema==4.17.3

--- a/.config/requirements.txt
+++ b/.config/requirements.txt
@@ -18,7 +18,7 @@ click==8.1.3
 colorama==0.4.6
 coverage==7.1.0
 coverage-enable-subprocess==1.0
-cryptography==39.0.0
+cryptography==39.0.1
 cssselect2==0.7.0
 defusedxml==0.7.1
 dill==0.3.6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -161,7 +161,7 @@ repos:
         additional_dependencies:
           - ansible-compat>=3.0.1
           - black>=22.10.0
-          - cryptography
+          - cryptography>=39.0.1
           - filelock
           - jinja2
           - pytest>=7.2.0


### PR DESCRIPTION
Related: https://github.com/ansible/ansible-lint/security/dependabot/7