### PR TITLE
Fix playbook/rulebook detection

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -70,7 +70,7 @@ jobs:
       WSLENV: FORCE_COLOR:PYTEST_REQPASS:TOXENV:GITHUB_STEP_SUMMARY
       # Number of expected test passes, safety measure for accidental skip of
       # tests. Update value if you add/remove tests.
-      PYTEST_REQPASS: 781
+      PYTEST_REQPASS: 782
 
     steps:
       - name: Activate WSL1

--- a/src/ansiblelint/file_utils.py
+++ b/src/ansiblelint/file_utils.py
@@ -242,7 +242,7 @@ class Lintable:
         self.abspath = self.path.expanduser().absolute()
 
         if self.kind == "yaml":
-            self._guess_kind()
+            self.data  # pylint: disable=pointless-statement
 
     def _guess_kind(self) -> None:
         if self.kind == "yaml":
@@ -371,6 +371,11 @@ class Lintable:
                     )
 
                     self._data = parse_yaml_linenumbers(self)
+                    # now that _data is not empty, we can try guessing if playbook or rulebook
+                    # it has to be done before append_skipped_rules() call as it's relying
+                    # on self.kind.
+                    if self.kind == "yaml":
+                        self._guess_kind()
                     # Lazy import to avoid delays and cyclic-imports
                     if "append_skipped_rules" not in globals():
                         # pylint: disable=import-outside-toplevel

--- a/src/ansiblelint/testing/__init__.py
+++ b/src/ansiblelint/testing/__init__.py
@@ -45,11 +45,11 @@ class RunFromText:
         """Lints received filename."""
         return self._call_runner(filename)
 
-    def run_playbook(self, playbook_text: str) -> list[MatchError]:
+    def run_playbook(
+        self, playbook_text: str, prefix: str = "playbook"
+    ) -> list[MatchError]:
         """Lints received text as a playbook."""
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".yml", prefix="playbook"
-        ) as fh:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", prefix=prefix) as fh:
             fh.write(playbook_text)
             fh.flush()
             results = self._call_runner(fh.name)

--- a/test/test_skiputils.py
+++ b/test/test_skiputils.py
@@ -53,6 +53,13 @@ def test_playbook_noqa(default_text_runner: RunFromText) -> None:
     assert len(results) == 1
 
 
+def test_playbook_noqa2(default_text_runner: RunFromText) -> None:
+    """Check that noqa is properly taken into account on vars and tasks."""
+    results = default_text_runner.run_playbook(PLAYBOOK_WITH_NOQA, "test")
+    # Should raise error at "SOME_VAR".
+    assert len(results) == 1
+
+
 @pytest.mark.parametrize(
     ("lintable", "yaml", "expected_form"),
     (


### PR DESCRIPTION
Don't try detecting the file type unless file already loaded in Lintable._data, otherwise the line numbers for inline rule skipping will be set to the line where's it's used since self.kind is 'yaml'. After _guess_kind() call, the kind will be set to playbook and the error line will be the one of the task, which is possibly different that the one with the 'noqa:' comment.

Fixes: #2977
Signed-off-by: Arnaud Patard <apatard@hupstream.com>