### PR TITLE
Use XDG_CACHE_HOME instead of XDG_CONFIG_CACHE

### DIFF
--- a/src/ansiblelint/config.py
+++ b/src/ansiblelint/config.py
@@ -23,7 +23,7 @@ _logger = logging.getLogger(__name__)
 
 
 CACHE_DIR = (
-    os.path.expanduser(os.environ.get("XDG_CONFIG_HOME", "~/.cache")) + "/ansible-lint"
+    os.path.expanduser(os.environ.get("XDG_CACHE_HOME", "~/.cache")) + "/ansible-lint"
 )
 
 DEFAULT_WARN_LIST = [

--- a/src/ansiblelint/config.py
+++ b/src/ansiblelint/config.py
@@ -23,7 +23,7 @@ _logger = logging.getLogger(__name__)
 
 
 CACHE_DIR = (
-    os.path.expanduser(os.environ.get("XDG_CONFIG_CACHE", "~/.cache")) + "/ansible-lint"
+    os.path.expanduser(os.environ.get("XDG_CONFIG_HOME", "~/.cache")) + "/ansible-lint"
 )
 
 DEFAULT_WARN_LIST = [


### PR DESCRIPTION
XDG_CONFIG_CACHE does not exist in the XDG Base directory listing.
XDG_CACHE_HOME is the correct env.var. to use for cache directories.

Reference: https://wiki.archlinux.org/title/XDG_Base_Directory
Fixes: #3008 