### PR TITLE
Mark syntax-check as unskippable

### DIFF
--- a/src/ansiblelint/rules/syntax_check.py
+++ b/src/ansiblelint/rules/syntax_check.py
@@ -63,7 +63,7 @@ class AnsibleSyntaxCheckRule(AnsibleLintRule):
 
     id = "syntax-check"
     severity = "VERY_HIGH"
-    tags = ["core"]
+    tags = ["core", "unskippable"]
     version_added = "v5.0.0"
     _order = 0
 

--- a/src/ansiblelint/runner.py
+++ b/src/ansiblelint/runner.py
@@ -214,6 +214,13 @@ class Runner:
 def _get_matches(rules: RulesCollection, options: Namespace) -> LintResult:
     lintables = ansiblelint.utils.get_lintables(opts=options, args=options.lintables)
 
+    for rule in rules:
+        if "unskippable" in rule.tags:
+            for entry in (*options.skip_list, *options.warn_list):
+                if rule.id == entry or entry.startswith(f"{rule.id}["):
+                    raise RuntimeError(
+                        f"Rule '{rule.id}' is unskippable, you cannot use it in 'skip_list' or 'warn_list'. Still, you could exclude the file."
+                    )
     matches = []
     checked_files: set[Lintable] = set()
     runner = Runner(

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -7,15 +7,15 @@ from ansiblelint.testing import run_ansible_lint
 
 def test_generate_ignore(tmp_path: Path) -> None:
     """Validate that --generate-ignore dumps expected ignore to the file."""
-    lintable = Lintable(tmp_path / "playbook.yaml")
-    lintable.content = "foo: bar"
+    lintable = Lintable(tmp_path / "vars.yaml")
+    lintable.content = "foo: bar\nfoo: baz\n"
     lintable.write(force=True)
     assert not (tmp_path / ".ansible-lint-ignore").exists()
     result = run_ansible_lint(lintable.filename, "--generate-ignore", cwd=str(tmp_path))
     assert result.returncode == 2
     assert (tmp_path / ".ansible-lint-ignore").exists()
     with open(tmp_path / ".ansible-lint-ignore", encoding="utf-8") as f:
-        assert "playbook.yaml syntax-check[specific]\n" in f.readlines()
+        assert "vars.yaml yaml[key-duplicates]\n" in f.readlines()
     # Run again and now we expect to succeed as we have an ignore file.
     result = run_ansible_lint(lintable.filename, cwd=str(tmp_path))
     assert result.returncode == 0

--- a/test/test_with_skip_tagid.py
+++ b/test/test_with_skip_tagid.py
@@ -46,12 +46,12 @@ def test_positive_skip_tag() -> None:
     assert [] == good_runner.run()
 
 
-def test_run_skip_warning_rule() -> None:
-    """Test that we can skip syntax-check[empty-playbook]."""
+def test_run_skip_rule() -> None:
+    """Test that we can skip a rule with -x."""
     result = run_ansible_lint(
         "-x",
-        "syntax-check[empty-playbook]",
-        "examples/playbooks/empty_playbook.yml",
+        "name[casing]",
+        "examples/playbooks/rule-name-casing.yml",
         executable="ansible-lint",
     )
     assert result.returncode == 0


### PR DESCRIPTION
While documentation mentioned that syntax-check was unskippable, that
was not implemented in code. This address this aspect and prevents
users from adding these rules to their skip or warn lists.
