### PR TITLE
Allow only use of quoted octals

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -223,6 +223,8 @@ norole
 nostderr
 notest
 nxos
+octal
+octals
 opensearch
 openshift
 outdir
@@ -287,6 +289,7 @@ rulebooks
 ruledirs
 rulesdir
 rulesdirs
+ruleset
 runas
 sarif
 scalarint

--- a/.yamllint
+++ b/.yamllint
@@ -8,6 +8,9 @@ rules:
   indentation:
     level: error
     indent-sequences: consistent
+  octal-values:
+    forbid-implicit-octal: true
+    forbid-explicit-octal: true
 ignore: |
   .tox
   examples/playbooks/example.yml

--- a/examples/playbooks/rule-args-module-pass-1.yml
+++ b/examples/playbooks/rule-args-module-pass-1.yml
@@ -20,7 +20,7 @@
       ansible.builtin.file:
         path: /opt/software/deployment
         state: "{{ item }}"
-        mode: 0755
+        mode: "0755"
       with_items:
         - absent
         - directory

--- a/examples/playbooks/rule-avoid-implicit-fail.yml
+++ b/examples/playbooks/rule-avoid-implicit-fail.yml
@@ -6,4 +6,4 @@
       ansible.builtin.copy:
         content: { "foo": "bar" } # <-- avoid-implicit[copy-content]
         dest: /tmp/foo.txt
-        mode: 0600
+        mode: "0600"

--- a/examples/playbooks/rule-avoid-implicit-pass.yml
+++ b/examples/playbooks/rule-avoid-implicit-pass.yml
@@ -6,4 +6,4 @@
       ansible.builtin.copy:
         content: "Some {{ foo }}"
         dest: /tmp/foo.txt
-        mode: 0600
+        mode: "0600"

--- a/examples/playbooks/rule-fqcn-fail.yml
+++ b/examples/playbooks/rule-fqcn-fail.yml
@@ -11,4 +11,4 @@
       ini_file:
         section: foo
         path: /tmp/test.ini
-        mode: 0644
+        mode: "0644"

--- a/examples/playbooks/rule-no-handler-fail.yml
+++ b/examples/playbooks/rule-no-handler-fail.yml
@@ -6,7 +6,7 @@
       ansible.builtin.copy:
         dest: "/tmp/placeholder"
         content: "Ansible made this!"
-        mode: 0600
+        mode: "0600"
       register: result # <-- we register the result of the task
 
     - name: Second command to run

--- a/examples/playbooks/rule-no-handler-pass.yml
+++ b/examples/playbooks/rule-no-handler-pass.yml
@@ -6,7 +6,7 @@
       ansible.builtin.copy:
         dest: "/tmp/placeholder"
         content: "Ansible made this!"
-        mode: 0600
+        mode: "0600"
       notify:
         - Second command to run # <-- handler will run only when file is changed
   handlers:

--- a/examples/playbooks/rule-risky-file-permissions-pass.yml
+++ b/examples/playbooks/rule-risky-file-permissions-pass.yml
@@ -6,7 +6,7 @@
     - name: Permissions not missing and numeric
       ansible.builtin.file:
         path: foo
-        mode: 0600
+        mode: "0600"
 
 - name: SUCCESS_PERMISSIONS_PRESENT_GET_URL
   hosts: all
@@ -15,7 +15,7 @@
       ansible.builtin.get_url:
         url: http://foo
         dest: foo
-        mode: 0600
+        mode: "0600"
 
 - name: SUCCESS_ABSENT_STATE
   hosts: all
@@ -67,7 +67,7 @@
     - name: Permissions not missing and numeric (fqcn)
       ansible.builtin.file:
         path: bar
-        mode: 755 # noqa: risky-octal
+        mode: "755" # noqa: risky-octal
     - name: File edit when create is false (fqcn)
       ansible.builtin.lineinfile:
         path: foo

--- a/examples/playbooks/rule-risky-octal-pass.yml
+++ b/examples/playbooks/rule-risky-octal-pass.yml
@@ -9,22 +9,22 @@
     - name: Octal permissions test success (0600)
       ansible.builtin.file:
         path: foo
-        mode: 0600
+        mode: "0600"
 
     - name: Octal permissions test success (0000)
       ansible.builtin.file:
         path: foo
-        mode: 0000
+        mode: "0000"
 
     - name: Octal permissions test success (02000)
       ansible.builtin.file:
         path: bar
-        mode: 02000
+        mode: "02000"
 
     - name: Octal permissions test success (02751)
       ansible.builtin.file:
         path: bar
-        mode: 02751
+        mode: "02751"
 
     - name: Octal permissions test success (0777)
       ansible.builtin.file: path=baz mode=0777 # noqa: no-free-form

--- a/examples/playbooks/rule-validate-module-options-pass-2.yml
+++ b/examples/playbooks/rule-validate-module-options-pass-2.yml
@@ -7,4 +7,4 @@
         src: /mine/ntp.conf
         dest: /etc/ntp.conf
         backup: true
-        mode: 0600
+        mode: "0600"

--- a/src/ansiblelint/rules/risky_octal.md
+++ b/src/ansiblelint/rules/risky_octal.md
@@ -1,11 +1,12 @@
 # risky-octal
 
 This rule checks that octal file permissions are strings that contain a leading
-zero or are written in [symbolic modes](https://www.gnu.org/software/findutils/manual/html_node/find_html/Symbolic-Modes.html),
+zero or are written in
+[symbolic modes](https://www.gnu.org/software/findutils/manual/html_node/find_html/Symbolic-Modes.html),
 such as `u+rwx` or `u=rw,g=r,o=r`.
 
-Using integers or octal values in YAML can result in unexpected behavior.
-For example, the YAML loader interprets `0644` as the decimal number `420` but
+Using integers or octal values in YAML can result in unexpected behavior. For
+example, the YAML loader interprets `0644` as the decimal number `420` but
 putting `644` there will produce very different results.
 
 Modules that are checked:
@@ -43,11 +44,6 @@ Modules that are checked:
         path: /etc/foo.conf
         owner: foo
         group: foo
-        mode: 0644 # <- Leading zero will prevent Numeric file permissions to behave in unexpected ways.
-    - name: Safe example of declaring Numeric file permissions (2nd solution)
-      ansible.builtin.file:
-        path: /etc/foo.conf
-        owner: foo
-        group: foo
-        mode: "0644" # <- Being in a string will prevent Numeric file permissions to behave in unexpected ways.
+        mode: "0644" # <- quoting and the leading zero will prevent surprises
+        # "0o644" is also a valid alternative.
 ```

--- a/src/ansiblelint/rules/yaml.md
+++ b/src/ansiblelint/rules/yaml.md
@@ -2,8 +2,8 @@
 
 This rule checks YAML syntax and is an implementation of `yamllint`.
 
-You can disable YAML syntax violations by adding `yaml` to the `skip_list`
-in your Ansible-lint configuration as follows:
+You can disable YAML syntax violations by adding `yaml` to the `skip_list` in
+your Ansible-lint configuration as follows:
 
 ```yaml
 skip_list:
@@ -20,44 +20,73 @@ skip_list:
 ```
 
 If you want Ansible-lint to report YAML syntax violations as warnings, and not
-fatal errors, add tag identifiers to the `warn_list` in your configuration, for example:
+fatal errors, add tag identifiers to the `warn_list` in your configuration, for
+example:
 
 ```yaml
 warn_list:
   - yaml[document-start]
 ```
 
-See the [list of yamllint rules](https://yamllint.readthedocs.io/en/stable/rules.html) for more information.
+See the
+[list of yamllint rules](https://yamllint.readthedocs.io/en/stable/rules.html)
+for more information.
 
 Some of the detailed error codes that you might see are:
 
-- `yaml[brackets]` - _too few spaces inside empty brackets_, or _too many spaces inside brackets_
-- `yaml[colons]` - _too many spaces before colon_, or _too many spaces after colon_
-- `yaml[commas]` - _too many spaces before comma_, or _too few spaces after comma_
+- `yaml[brackets]` - _too few spaces inside empty brackets_, or _too many spaces
+  inside brackets_
+- `yaml[colons]` - _too many spaces before colon_, or _too many spaces after
+  colon_
+- `yaml[commas]` - _too many spaces before comma_, or _too few spaces after
+  comma_
 - `yaml[comments-indentation]` - _Comment not indented like content_
-- `yaml[comments]` - _Too few spaces before comment_, or _Missing starting space in comment_
-- `yaml[document-start]` - _missing document start "---"_ or _found forbidden document start "---"_
+- `yaml[comments]` - _Too few spaces before comment_, or _Missing starting space
+  in comment_
+- `yaml[document-start]` - _missing document start "---"_ or _found forbidden
+  document start "---"_
 - `yaml[empty-lines]` - _too many blank lines (...> ...)_
 - `yaml[indentation]` - _Wrong indentation: expected ... but found ..._
 - `yaml[key-duplicates]` - _Duplication of key "..." in mapping_
 - `yaml[new-line-at-end-of-file]` - _No new line character at the end of file_
+- `yaml[octal-values]`: forbidden implicit or explicit [octal](#octals) value
 - `yaml[syntax]` - YAML syntax is broken
 - `yaml[trailing-spaces]` - Spaces are found at the end of lines
 - `yaml[truthy]` - _Truthy value should be one of ..._
+
+## Octals
+
+As [YAML specification] regarding octal values changed at least 3 times in
+[1.1], [1.2.0] and [1.2.2] we now require users to always add quotes around
+octal values, so the YAML loaders will all load them as strings, providing a
+consistent behavior. This is also safer as JSON does not support octal values
+either.
+
+By default, yamllint does not check for octals but our custom default ruleset
+for it does check these. If for some reason, you do not want to follow our
+defaults, you can create a `.yamllint` file in your project and this will take
+precedence over our defaults.
 
 ## Problematic code
 
 ```yaml
 # Missing YAML document start.
-foo: ...
-foo: ...  # <-- Duplicate key.
-bar: ...       # <-- Incorrect comment indentation
+foo: 0777 # <-- yaml[octal-values]
+foo2: 0o777 # <-- yaml[octal-values]
+foo2: ... # <-- yaml[key-duplicates]
+bar: ...       # <-- yaml[comments-indentation]
 ```
 
 ## Correct code
 
 ```yaml
 ---
-foo: ...
+foo: "0777" # <-- Explicitly quoting octal is less risky.
+foo2: "0o777" # <-- Explicitly quoting octal is less risky.
 bar: ... # Correct comment indentation.
 ```
+
+[1.1]: https://yaml.org/spec/1.1/
+[1.2.0]: https://yaml.org/spec/1.2.0/
+[1.2.2]: https://yaml.org/spec/1.2.2/
+[yaml specification]: https://yaml.org/

--- a/test/fixtures/formatting-after/fmt-2.yml
+++ b/test/fixtures/formatting-after/fmt-2.yml
@@ -14,8 +14,8 @@
 - nothing: # null
 
 - octal:
-    - 0o123 # YAML 1.2 octal
-    - 0123 # YAML 1.1 octal
+    - "0o123" # YAML 1.2 octal
+    - "0123" # YAML 1.1 octal
 
 - integer:
     - 0 # Not an octal. See #2071

--- a/test/fixtures/formatting-prettier/fmt-2.yml
+++ b/test/fixtures/formatting-prettier/fmt-2.yml
@@ -14,8 +14,8 @@
 - nothing: null # null
 
 - octal:
-    - 0o123 # YAML 1.2 octal
-    - 0123 # YAML 1.1 octal
+    - "0o123" # YAML 1.2 octal
+    - "0123" # YAML 1.1 octal
 
 - integer:
     - 0 # Not an octal. See #2071


### PR DESCRIPTION
In order to prevent errors caused by different versions of YAML loaders we now forbid use of implicit and explicit octals and ask user to add quotes, so the behavior will be consistent.


```yaml
foo: 0777 # <-- yaml[octal-values]
bar: 0o777 # <-- yaml[octal-values]
---
# Fixed:
foo: "0777"
bar: "0o777"
```
Fixes: #2965
