### PR TITLE
Removed experimental flag from multiple rules

### DIFF
--- a/examples/playbooks/strict-mode.yml
+++ b/examples/playbooks/strict-mode.yml
@@ -2,6 +2,7 @@
 - name: Fixture for test_strict
   hosts: localhost
   tasks:
-    - ansible.builtin.debug: # <-- name should be first key (warning)
-        msg: "Hello World"
-      name: Display debug information
+    - name: Display debug information
+      ansible.builtin.stat:
+        path2: echo "Hello World" # <-- args[module] due to invalid use of path2 instead of path
+      changed_when: false

--- a/src/ansiblelint/config.py
+++ b/src/ansiblelint/config.py
@@ -27,16 +27,8 @@ CACHE_DIR = (
 )
 
 DEFAULT_WARN_LIST = [
-    "avoid-implicit",
     "experimental",
-    "fqcn[action]",
-    "fqcn[redirect]",
     "jinja[spacing]",  # warning until we resolve all reported false-positives
-    "name[casing]",
-    "name[play]",
-    "name[prefix]",
-    "role-name",
-    "role-name[path]",  # too new
 ]
 
 DEFAULT_KINDS = [

--- a/src/ansiblelint/rules/avoid_implicit.py
+++ b/src/ansiblelint/rules/avoid_implicit.py
@@ -21,7 +21,7 @@ class AvoidImplicitRule(AnsibleLintRule):
         "``copy`` with ``content`` to ensure correctness."
     )
     severity = "MEDIUM"
-    tags = ["unpredictability", "experimental"]
+    tags = ["unpredictability"]
     version_added = "v6.8.0"
 
     def matchtask(

--- a/src/ansiblelint/rules/ignore_errors.py
+++ b/src/ansiblelint/rules/ignore_errors.py
@@ -21,7 +21,7 @@ class IgnoreErrorsRule(AnsibleLintRule):
         "to reduce the risk of ignoring important failures."
     )
     severity = "LOW"
-    tags = ["unpredictability", "experimental"]
+    tags = ["unpredictability"]
     version_added = "v5.0.7"
 
     def matchtask(

--- a/src/ansiblelint/rules/key_order.py
+++ b/src/ansiblelint/rules/key_order.py
@@ -53,7 +53,7 @@ class KeyOrderRule(AnsibleLintRule):
     id = "key-order"
     shortdesc = __doc__
     severity = "LOW"
-    tags = ["formatting", "experimental"]
+    tags = ["formatting"]
     version_added = "v6.6.2"
     needs_raw_task = True
 

--- a/src/ansiblelint/rules/no_free_form.py
+++ b/src/ansiblelint/rules/no_free_form.py
@@ -19,7 +19,7 @@ class NoFreeFormRule(AnsibleLintRule):
     id = "no-free-form"
     description = "Avoid free-form inside files as it can produce subtile bugs."
     severity = "MEDIUM"
-    tags = ["syntax", "risk", "experimental"]
+    tags = ["syntax", "risk"]
     version_added = "v6.8.0"
     needs_raw_task = True
     cmd_shell_re = re.compile(

--- a/src/ansiblelint/rules/no_prompting.py
+++ b/src/ansiblelint/rules/no_prompting.py
@@ -20,7 +20,7 @@ class NoPromptingRule(AnsibleLintRule):
         "Disallow the use of vars_prompt or ansible.builtin.pause to better"
         "accommodate unattended playbook runs and use in CI pipelines."
     )
-    tags = ["opt-in", "experimental"]
+    tags = ["opt-in"]
     severity = "VERY_LOW"
     version_added = "v6.0.3"
 

--- a/src/ansiblelint/rules/risky_file_permissions.py
+++ b/src/ansiblelint/rules/risky_file_permissions.py
@@ -78,7 +78,7 @@ class MissingFilePermissionsRule(AnsibleLintRule):
     )
     link = "https://github.com/ansible/ansible/issues/71200"
     severity = "VERY_HIGH"
-    tags = ["unpredictability", "experimental"]
+    tags = ["unpredictability"]
     version_added = "v4.3.0"
 
     _modules = _MODULES

--- a/src/ansiblelint/rules/run_once.py
+++ b/src/ansiblelint/rules/run_once.py
@@ -19,7 +19,7 @@ class RunOnce(AnsibleLintRule):
     link = "https://docs.ansible.com/ansible/latest/reference_appendices/playbooks_keywords.html"
     description = "When using run_once, we should avoid using strategy as free."
 
-    tags = ["idiom", "experimental"]
+    tags = ["idiom"]
     severity = "MEDIUM"
 
     def matchplay(self, file: Lintable, data: dict[str, Any]) -> list[MatchError]:

--- a/src/ansiblelint/rules/schema.py
+++ b/src/ansiblelint/rules/schema.py
@@ -50,7 +50,7 @@ class ValidateSchemaRule(AnsibleLintRule):
 
     id = "schema"
     severity = "VERY_HIGH"
-    tags = ["core", "experimental"]
+    tags = ["core"]
     version_added = "v6.1.0"
 
     def matchtask(

--- a/src/ansiblelint/rules/var_naming.py
+++ b/src/ansiblelint/rules/var_naming.py
@@ -42,7 +42,7 @@ class VariableNamingRule(AnsibleLintRule):
 
     id = "var-naming"
     severity = "MEDIUM"
-    tags = ["idiom", "experimental"]
+    tags = ["idiom"]
     version_added = "v5.0.10"
     needs_raw_task = True
     re_pattern = re.compile(options.var_naming_pattern or "^[a-z_][a-z0-9_]*$")

--- a/test/test_strict.py
+++ b/test/test_strict.py
@@ -18,7 +18,7 @@ def test_strict(strict: bool, returncode: int, message: str) -> None:
         args.insert(0, "--strict")
     result = run_ansible_lint(*args)
     assert result.returncode == returncode
-    assert "key-order[task]" in result.stdout
+    assert "args[module]" in result.stdout
     for summary_line in result.stderr.splitlines():
         if summary_line.startswith(message):
             break


### PR DESCRIPTION
Remove experimental tag from avoid-implicit, ignore-errors, key-order, no-free-form, no-prompting, risky-file-permissions, run-once, schema and var-naming.

This means that occurrences of these violations will be marked as errors instead of warnings. Users still have the option to add them to their own warn_list or skip_list.

All mentioned rules were in place for some time and that is a confirmation that we find their implementation mature.

If you were using the `--strict` mode, this change will have no impact.