### PR TITLE
fix exclude-path test

### DIFF
--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -137,9 +137,11 @@ def test_expand_path_user_and_vars_config_file(base_arguments: list[str]) -> Non
     )
 
     assert str(config1.exclude_paths[0]) == os.path.expanduser("~/.ansible/roles")
-    assert str(config2.exclude_paths[0]) == os.path.expanduser("~/.ansible/roles")
     assert str(config1.exclude_paths[1]) == os.path.expandvars("$HOME/.ansible/roles")
-    assert str(config2.exclude_paths[1]) == os.path.expandvars("$HOME/.ansible/roles")
+
+    # exclude-paths coming in via cli are PosixPath objects; which hold the (canonical) real path (without symlinks)
+    assert str(config2.exclude_paths[0]) == os.path.realpath(os.path.expanduser("~/.ansible/roles"))
+    assert str(config2.exclude_paths[1]) == os.path.realpath(os.path.expandvars("$HOME/.ansible/roles"))
 
 
 def test_path_from_config_do_not_depend_on_cwd(

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -140,8 +140,12 @@ def test_expand_path_user_and_vars_config_file(base_arguments: list[str]) -> Non
     assert str(config1.exclude_paths[1]) == os.path.expandvars("$HOME/.ansible/roles")
 
     # exclude-paths coming in via cli are PosixPath objects; which hold the (canonical) real path (without symlinks)
-    assert str(config2.exclude_paths[0]) == os.path.realpath(os.path.expanduser("~/.ansible/roles"))
-    assert str(config2.exclude_paths[1]) == os.path.realpath(os.path.expandvars("$HOME/.ansible/roles"))
+    assert str(config2.exclude_paths[0]) == os.path.realpath(
+        os.path.expanduser("~/.ansible/roles")
+    )
+    assert str(config2.exclude_paths[1]) == os.path.realpath(
+        os.path.expandvars("$HOME/.ansible/roles")
+    )
 
 
 def test_path_from_config_do_not_depend_on_cwd(


### PR DESCRIPTION
Hey there,

I've made a small fix for the path handling (see comment in code).
Without it this test will fail in environments where the `.ansible` folder is actually a symlink to somewhere else (which will be resolved by the `PosixPath` coming in via CLI; but not the `expandvars`-statement in the testcase).
