### PR TITLE
Remove "mode: preserve" from risky file perms doc, add copy example

### DIFF
--- a/src/ansiblelint/rules/risky_file_permissions.md
+++ b/src/ansiblelint/rules/risky_file_permissions.md
@@ -52,7 +52,7 @@ Modules that are checked:
     path: foo
     mode: 0600  # explicitly sets the desired permissions, to make the results predictable
 
-- name: Safe example of using copy (3nd solution)
+- name: Safe example of using copy (3rd solution)
   ansible.builtin.copy:
     src: foo
     dest: bar

--- a/src/ansiblelint/rules/risky_file_permissions.md
+++ b/src/ansiblelint/rules/risky_file_permissions.md
@@ -36,7 +36,6 @@ Modules that are checked:
   community.general.ini_file:
     path: foo
     create: true
-    mode: preserve
 ```
 
 ## Correct code
@@ -47,11 +46,15 @@ Modules that are checked:
   community.general.ini_file:
     path: foo
     create: false  # prevents creating a file with potentially insecure permissions
-    mode: preserve
 
 - name: Safe example of using ini_file (2nd solution)
   community.general.ini_file:
     path: foo
     mode: 0600  # explicitly sets the desired permissions, to make the results predictable
-    mode: preserve
+
+- name: Safe example of using copy (3nd solution)
+  ansible.builtin.copy:
+    src: foo
+    dest: bar
+    mode: preserve   # copy has a special mode that sets the same permissions as the source file
 ```


### PR DESCRIPTION
As per the discussion https://github.com/ansible/ansible-lint/discussions/2997, this applies the patch suggested by @AKorezin in [this comment](https://github.com/ansible/ansible-lint/discussions/2997#discussioncomment-4925849).

Original issue #2988.

* Removes `mode: preserve` lines from risky file permissions correct code examples.
* Adds new example using `ansible.builtin.copy`.