### PR TITLE
Improved coverage for missing line for rule no-log-password

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -70,7 +70,7 @@ jobs:
       WSLENV: FORCE_COLOR:PYTEST_REQPASS:TOXENV:GITHUB_STEP_SUMMARY
       # Number of expected test passes, safety measure for accidental skip of
       # tests. Update value if you add/remove tests.
-      PYTEST_REQPASS: 799
+      PYTEST_REQPASS: 800
 
     steps:
       - name: Activate WSL1


### PR DESCRIPTION
Added coverage for no-log-password rule
Related: #3026
