### PR TITLE
Suppress deprecation warning caused by ruamel.yaml with newer setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,7 +162,11 @@ addopts = "-p no:pytest_cov"
 # `--no-cov` which prevents activation from tox.ini and which also fails
 # when plugin is effectively missing.
 doctest_optionflags = ["ALLOW_UNICODE", "ELLIPSIS"]
-filterwarnings = ["error"]
+filterwarnings = [
+  "error",
+  # https://sourceforge.net/p/ruamel-yaml/tickets/452/
+  "ignore:Deprecated call to `pkg_resources.declare_namespace:DeprecationWarning",
+]
 junit_duration_report = "call"
 # Our github annotation parser from .github/workflows/tox.yml requires xunit1 format. Ref:
 # https://github.com/shyim/junit-report-annotations-action/issues/3#issuecomment-663241378

--- a/src/ansiblelint/schemas/__store__.json
+++ b/src/ansiblelint/schemas/__store__.json
@@ -20,7 +20,7 @@
     "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/execution-environment.json"
   },
   "galaxy": {
-    "etag": "90d0beb8a8ec0fc9ebdc146f3d19f1566c648ed5574b381ed63e06cb15de4d37",
+    "etag": "8a7b0505c5b42a6a0fb065b1e1b6ba864f53d69b54d1cfbeaab1fa4b03b705a7",
     "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/galaxy.json"
   },
   "inventory": {
@@ -40,7 +40,7 @@
     "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/molecule.json"
   },
   "playbook": {
-    "etag": "f49882815c54f8595c4e2b9cbcf8f48b1bf5dee892b4cf8938d13343c8448d7b",
+    "etag": "1813d65227c1b299b53d012ea451409acce3bdac33037fe4224bfe5df0fab76e",
     "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/playbook.json"
   },
   "requirements": {
@@ -48,7 +48,7 @@
     "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/requirements.json"
   },
   "tasks": {
-    "etag": "7725d87e98752a96967cce8a62bc8593c15a85582f1cdefef6afce61a6a9bbe5",
+    "etag": "9226a9fea0a3cfa1bbc6c4db57fb4b28e5cf8abd7f390fa4a93cf1cf38ac64cd",
     "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/tasks.json"
   },
   "vars": {


### PR DESCRIPTION
Related: https://setuptools.pypa.io/en/latest/history.html#v67-3-0
Related: https://sourceforge.net/p/ruamel-yaml/tickets/452/
Similar: https://github.com/matplotlib/matplotlib/issues/25244