### PR TITLE
Adding 2.9 ignore allow-list for sanity rule

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -207,29 +207,32 @@ repos:
     hooks:
       - id: pip-compile
         name: lock
+        alias: lock
         always_run: true
         entry: pip-compile --upgrade --resolver=backtracking -q --no-annotate --output-file=.config/requirements-lock.txt pyproject.toml --strip-extras --unsafe-package ruamel-yaml-clib
-        language: python
         files: ^.config\/requirements.*$
-        alias: lock
-        stages: [manual]
+        language: python
         language_version: "3.9" # minimal we support officially
+        pass_filenames: false
+        stages: [manual]
         additional_dependencies:
           - pip>=22.3.1
       - id: pip-compile
         name: deps
-        entry: pip-compile --resolver=backtracking -q --no-annotate --output-file=.config/requirements.txt pyproject.toml --extra docs --extra test --strip-extras --unsafe-package ruamel-yaml-clib
-        language: python
-        files: ^.config\/requirements.*$
         alias: deps
-        language_version: "3.9" # minimal we support officially
         always_run: true
+        entry: pip-compile --resolver=backtracking -q --no-annotate --output-file=.config/requirements.txt pyproject.toml --extra docs --extra test --strip-extras --unsafe-package ruamel-yaml-clib
+        files: ^.config\/requirements.*$
+        language: python
+        language_version: "3.9" # minimal we support officially
+        pass_filenames: false
         additional_dependencies:
           - pip>=22.3.1
       - id: pip-compile
         entry: pip-compile --resolver=backtracking -q --no-annotate --output-file=.config/requirements.txt pyproject.toml --extra docs --extra test --strip-extras --unsafe-package ruamel-yaml-clib --upgrade
         language: python
         always_run: true
+        pass_filenames: false
         files: ^.config\/requirements.*$
         alias: up
         stages: [manual]
@@ -243,3 +246,5 @@ repos:
         name: update json schemas
         entry: python3 src/ansiblelint/schemas/__main__.py
         language: python
+        pass_filenames: false
+        always_run: true

--- a/examples/sanity_ignores/tests/sanity/ignore-2.13.txt
+++ b/examples/sanity_ignores/tests/sanity/ignore-2.13.txt
@@ -1,1 +1,1 @@
-plugins/module_utils/ansible_example_module.py import-3.6!skip          # comment
+plugins/module_utils/ansible_example_module.py validate-modules:deprecation-mismatch         # comment

--- a/examples/sanity_ignores/tests/sanity/ignore-2.14.txt
+++ b/examples/sanity_ignores/tests/sanity/ignore-2.14.txt
@@ -1,2 +1,0 @@
-plugins/module_utils/ansible_example_module.py compile-2.6!skip
-plugins/module_utils/ansible_example_module.py import-2.6!skip

--- a/examples/sanity_ignores/tests/sanity/ignore-2.9.txt
+++ b/examples/sanity_ignores/tests/sanity/ignore-2.9.txt
@@ -1,0 +1,2 @@
+plugins/module_utils/ansible_example_module.py validate-modules:deprecation-mismatch
+plugins/module_utils/ansible_example_module.py import-2.6!skip

--- a/src/ansiblelint/rules/sanity.md
+++ b/src/ansiblelint/rules/sanity.md
@@ -13,9 +13,10 @@ This rule can produce messages like:
 - `sanity[bad-ignore]` - Ignore file entry at {line_num} is formatted
   incorrectly. Please review.
 
-Currently allowed ignores are:
+Currently allowed ignores for all Ansible versions are:
 
 - `validate-modules:missing-gplv3-license`
+- `action-plugin-docs`
 - `import-2.6`
 - `import-2.6!skip`
 - `import-2.7`
@@ -28,6 +29,10 @@ Currently allowed ignores are:
 - `compile-2.7!skip`
 - `compile-3.5`
 - `compile-3.5!skip`
+
+Additionally allowed ignores for Ansible 2.9 are:
+- `validate-modules:deprecation-mismatch`
+- `validate-modules:invalid-documentation`
 
 ## Problematic code
 

--- a/src/ansiblelint/schemas/__store__.json
+++ b/src/ansiblelint/schemas/__store__.json
@@ -1,6 +1,6 @@
 {
   "ansible-lint-config": {
-    "etag": "03cc2882dff22434360b76d333bc58cf88ed1629dc2c4432ae92caa35d6cb61a",
+    "etag": "4753f3c433fc6c05c62c7c36adf8cc9379a51f0554b2c7eee67685a2a7061a4d",
     "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/ansible-lint-config.json"
   },
   "ansible-navigator-config": {


### PR DESCRIPTION
_Note: This is an extremely opinionated rule that Partner Engineering enforces for certified content._

Modifying new rule **sanity** to add an allow-list for Ansible 2.9 (ignore-2.9.txt files). 
Allowed ignores added:
`validate-modules:deprecation-mismatch`
`validate-modules:invalid-documentation`

Also added the `action-plugin-docs` ignore to the `all` allow list. 

These were added at the request of the Networking collections' maintainers. 

_Note: the `eco` test will fail, until the `arguments-renamed` ignore is removed from the collection ignore files._ 