### PR TITLE
Document skip_ansible_lint does not work with yamllint rule

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -70,7 +70,7 @@ jobs:
       WSLENV: FORCE_COLOR:PYTEST_REQPASS:TOXENV:GITHUB_STEP_SUMMARY
       # Number of expected test passes, safety measure for accidental skip of
       # tests. Update value if you add/remove tests.
-      PYTEST_REQPASS: 799
+      PYTEST_REQPASS: 801
     steps:
       - name: Activate WSL1
         if: "contains(matrix.shell, 'wsl')"

--- a/examples/playbooks/rule-yaml-fail.yml
+++ b/examples/playbooks/rule-yaml-fail.yml
@@ -1,0 +1,18 @@
+---
+- name: Fixture for yaml rule that should generate 3 errors
+  # https://github.com/ansible/ansible-lint/issues/3139
+  hosts: localhost
+  tasks:
+    - name: "1"
+      ansible.builtin.debug:
+        msg: yes
+
+    - name: "2"
+      ansible.builtin.debug:
+        msg: yes
+      tags:
+        - skip_ansible_lint # this has no effect for yamllint rule
+
+    - name: "3"
+      ansible.builtin.debug:
+        msg: yes

--- a/examples/playbooks/rule-yaml-pass.yml
+++ b/examples/playbooks/rule-yaml-pass.yml
@@ -1,0 +1,7 @@
+---
+# yamllint disable rule:truthy
+- name: Fixture for yaml rule testing ability to use disable comments
+  hosts: localhost
+  tasks: []
+  become: yes # <-- allowed only due to comment above
+# yamllint enable rule:truthy

--- a/src/ansiblelint/rules/yaml.md
+++ b/src/ansiblelint/rules/yaml.md
@@ -28,6 +28,11 @@ warn_list:
   - yaml[document-start]
 ```
 
+!!! warning
+
+    You cannot use `tags: [skip_ansible_lint]` to disable this rule but you can
+    use [yamllint magic comments](https://yamllint.readthedocs.io/en/stable/disable_with_comments.html#disabling-checks-for-all-or-part-of-the-file) for tuning it.
+
 See the
 [list of yamllint rules](https://yamllint.readthedocs.io/en/stable/rules.html)
 for more information.


### PR DESCRIPTION
Main reason for this decision is in order to make the behavior consistent between yamllint itself and ansible-lint, reducing the divergences and user confusions.

Fixes: #3139