### PR TITLE
docs: fix link for rule galaxy[no-runtime]

### DIFF
--- a/src/ansiblelint/rules/galaxy.md
+++ b/src/ansiblelint/rules/galaxy.md
@@ -21,7 +21,7 @@ This rule can produce messages such:
 - `galaxy[no-changelog]` - collection is missing a changelog file in expected
   locations.
 - `galaxy[no-runtime]` - Please add a
-  [meta/runtime.yml](https://docs.ansible.com/ansible/latest/dev_guide/developing_collections_structurehtml#meta-directory-and-runtime-yml)
+  [meta/runtime.yml](https://docs.ansible.com/ansible/latest/dev_guide/developing_collections_structure.html#meta-directory-and-runtime-yml)
   file.
 - `galaxy[tags]` - `galaxy.yaml` must have one of the required tags:
   `application`, `cloud`, `database`, `infrastructure`, `linux`, `monitoring`,


### PR DESCRIPTION
The link for meta/runtime.yml was broken.