### PR TITLE
Fix "helpUri" assignment for SARIF output

### DIFF
--- a/src/ansiblelint/formatters/__init__.py
+++ b/src/ansiblelint/formatters/__init__.py
@@ -270,8 +270,6 @@ class SarifFormatter(BaseFormatter[Any]):
             "helpUri": match.rule.url,
             "properties": {"tags": match.rule.tags},
         }
-        if match.rule.link:
-            rule["helpUri"] = match.rule.link
         return rule
 
     def _to_sarif_result(self, match: MatchError) -> dict[str, Any]:

--- a/test/test_formatter_sarif.py
+++ b/test/test_formatter_sarif.py
@@ -94,7 +94,7 @@ class TestSarifFormatter:
         assert rules[0]["defaultConfiguration"]["level"] == "error"
         assert rules[0]["help"]["text"] == self.matches[0].rule.description
         assert rules[0]["properties"]["tags"] == self.matches[0].rule.tags
-        assert rules[0]["helpUri"] == self.rule.link
+        assert rules[0]["helpUri"] == self.matches[0].rule.url
         results = sarif["runs"][0]["results"]
         assert len(results) == 2
         for i, result in enumerate(results):


### PR DESCRIPTION
Hi,

the current implementation of the SARIF output overrides content of `helpUri` if a `match.rule.link` is present (instead of keeping `match.rule.url`):

https://github.com/ansible/ansible-lint/blob/36ef08b965cb63a8a7d1efafc45cd569e1a4f87f/src/ansiblelint/formatters/__init__.py#L257-L275

This deviates from the output of the other formatters (e.g. "CodeClimate) and produces "non sensical" results for the consumer.

## Examples

### SARIF Output for "risky file permissions"

```
...
            {
              "id": "risky-file-permissions",
              "name": "risky-file-permissions",
              "shortDescription": {
                "text": "File permissions unset or incorrect."
              },
              "defaultConfiguration": {
                "level": "error"
              },
              "help": {
                "text": "Missing or unsupported mode parameter can cause unexpected file permissions based on version of Ansible being used. Be explicit, like `mode: 0644` to avoid hitting this rule. Special `preserve` value is accepted only by `copy`, `template` modules."
              },
              "helpUri": "https://github.com/ansible/ansible/issues/71200",
              "properties": {
...
```

A "helpUri"-link to a GitHub issue will be rendered.

(Probably originating from this change: https://github.com/ansible/ansible-lint/commit/d063c1b69d35cc9f3afd0fd9517479a99b92eda1#diff-30908a16d992805132a8dd60f6d4ad7d7c90bf6ea6e0f90d549735271452aeb5)

### CodeClimate output for the same "risky file permissions" issue

```
...
  {
    "type": "issue",
    "check_name": "risky-file-permissions",
    "categories": [
      "unpredictability"
    ],
    "url": "https://ansible-lint.readthedocs.io/rules/risky-file-permissions/",
    "severity": "major",
...
```

A correct link to the ansible-lint docs is presented.

I personally see no valid reason behind the current implementation; but I may be wrong. :smile:

Just like #3163 ; this makes the SARIF output inferior to the CodeClimate output, or at least less useful for external tools.

Hope this can be fixed/merged soon.

Thanks a lot. :bow: 