### PR TITLE
Allow templated boolean for any_errors_fatal

### DIFF
--- a/src/ansiblelint/schemas/ansible.json
+++ b/src/ansiblelint/schemas/ansible.json
@@ -81,7 +81,7 @@
         },
         "any_errors_fatal": {
           "title": "Any Errors Fatal",
-          "type": "boolean"
+          "$ref": "#/$defs/templated-boolean"
         },
         "become": {
           "$ref": "#/$defs/templated-boolean",
@@ -285,7 +285,7 @@
       "properties": {
         "any_errors_fatal": {
           "title": "Any Errors Fatal",
-          "type": "boolean"
+          "$ref": "#/$defs/templated-boolean"
         },
         "become": {
           "$ref": "#/$defs/templated-boolean",
@@ -647,7 +647,7 @@
       "properties": {
         "any_errors_fatal": {
           "title": "Any Errors Fatal",
-          "type": "boolean"
+          "$ref": "#/$defs/templated-boolean"
         },
         "become": {
           "$ref": "#/$defs/templated-boolean",
@@ -816,7 +816,7 @@
         },
         "any_errors_fatal": {
           "title": "Any Errors Fatal",
-          "type": "boolean"
+          "$ref": "#/$defs/templated-boolean"
         },
         "args": {
           "$ref": "#/$defs/templated-object",

--- a/src/ansiblelint/schemas/ansible.json
+++ b/src/ansiblelint/schemas/ansible.json
@@ -80,8 +80,8 @@
           "type": "array"
         },
         "any_errors_fatal": {
-          "title": "Any Errors Fatal",
-          "$ref": "#/$defs/templated-boolean"
+          "$ref": "#/$defs/templated-boolean",
+          "title": "Any Errors Fatal"
         },
         "become": {
           "$ref": "#/$defs/templated-boolean",
@@ -284,8 +284,8 @@
       ],
       "properties": {
         "any_errors_fatal": {
-          "title": "Any Errors Fatal",
-          "$ref": "#/$defs/templated-boolean"
+          "$ref": "#/$defs/templated-boolean",
+          "title": "Any Errors Fatal"
         },
         "become": {
           "$ref": "#/$defs/templated-boolean",
@@ -646,8 +646,8 @@
       "markdownDescription": "See [roles](https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_roles.html#roles)",
       "properties": {
         "any_errors_fatal": {
-          "title": "Any Errors Fatal",
-          "$ref": "#/$defs/templated-boolean"
+          "$ref": "#/$defs/templated-boolean",
+          "title": "Any Errors Fatal"
         },
         "become": {
           "$ref": "#/$defs/templated-boolean",
@@ -815,8 +815,8 @@
           "type": "string"
         },
         "any_errors_fatal": {
-          "title": "Any Errors Fatal",
-          "$ref": "#/$defs/templated-boolean"
+          "$ref": "#/$defs/templated-boolean",
+          "title": "Any Errors Fatal"
         },
         "args": {
           "$ref": "#/$defs/templated-object",

--- a/src/ansiblelint/schemas/playbook.json
+++ b/src/ansiblelint/schemas/playbook.json
@@ -89,8 +89,8 @@
           "type": "array"
         },
         "any_errors_fatal": {
-          "title": "Any Errors Fatal",
-          "type": "boolean"
+          "$ref": "#/$defs/templated-boolean",
+          "title": "Any Errors Fatal"
         },
         "become": {
           "$ref": "#/$defs/templated-boolean",
@@ -299,8 +299,8 @@
       ],
       "properties": {
         "any_errors_fatal": {
-          "title": "Any Errors Fatal",
-          "type": "boolean"
+          "$ref": "#/$defs/templated-boolean",
+          "title": "Any Errors Fatal"
         },
         "become": {
           "$ref": "#/$defs/templated-boolean",
@@ -667,8 +667,8 @@
       "markdownDescription": "See [roles](https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_roles.html#roles)",
       "properties": {
         "any_errors_fatal": {
-          "title": "Any Errors Fatal",
-          "type": "boolean"
+          "$ref": "#/$defs/templated-boolean",
+          "title": "Any Errors Fatal"
         },
         "become": {
           "$ref": "#/$defs/templated-boolean",
@@ -831,8 +831,8 @@
           "type": "string"
         },
         "any_errors_fatal": {
-          "title": "Any Errors Fatal",
-          "type": "boolean"
+          "$ref": "#/$defs/templated-boolean",
+          "title": "Any Errors Fatal"
         },
         "args": {
           "$ref": "#/$defs/templated-object",

--- a/src/ansiblelint/schemas/tasks.json
+++ b/src/ansiblelint/schemas/tasks.json
@@ -41,8 +41,8 @@
           "type": "array"
         },
         "any_errors_fatal": {
-          "title": "Any Errors Fatal",
-          "type": "boolean"
+          "$ref": "#/$defs/templated-boolean",
+          "title": "Any Errors Fatal"
         },
         "become": {
           "$ref": "#/$defs/templated-boolean",
@@ -283,8 +283,8 @@
           "type": "string"
         },
         "any_errors_fatal": {
-          "title": "Any Errors Fatal",
-          "type": "boolean"
+          "$ref": "#/$defs/templated-boolean",
+          "title": "Any Errors Fatal"
         },
         "args": {
           "$ref": "#/$defs/templated-object",


### PR DESCRIPTION
I have this:

``` yaml
- name: Asserts
  hosts: 'all,localhost'
  gather_facts: false
  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"  # <===========
  roles:
  - role: kubitus_defaults
  - role: asserts
```