### PR TITLE
name[casing]: Add transform to automatically fix this during --write

### DIFF
--- a/src/ansiblelint/rules/name.py
+++ b/src/ansiblelint/rules/name.py
@@ -8,13 +8,13 @@ from typing import TYPE_CHECKING, Any
 
 from ansiblelint.constants import LINE_NUMBER_KEY
 from ansiblelint.errors import MatchError
-from ansiblelint.rules import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule, TransformMixin
 
 if TYPE_CHECKING:
     from ansiblelint.file_utils import Lintable  # noqa: F811
 
 
-class NameRule(AnsibleLintRule):
+class NameRule(AnsibleLintRule, TransformMixin):
     """Rule for checking task and play names."""
 
     id = "name"
@@ -140,6 +140,18 @@ class NameRule(AnsibleLintRule):
                 )
             )
         return results
+
+    def transform(
+        self,
+        match: MatchError,
+        lintable: Lintable,
+        data: CommentedMap | CommentedSeq | str
+    ) -> None:
+        if match.tag == "name[casing]":
+            target_task = self.seek(match.yaml_path, data)
+            # Not using capitalize(), since that rewrites the rest of the name to lower case
+            target_task["name"] = f"{target_task['name'][:1].upper()}{target_task['name'][1:]}"
+            match.fixed = True
 
 
 if "pytest" in sys.modules:  # noqa: C901


### PR DESCRIPTION
One of the easier rules for adding transforms I guess, but it is probably time to actually start doing it.

I didn't find any transformations being used (or tested) in the repo so far, but it seems to work and makes this rather annoying rewrite _much_ easier.