### PR TITLE
Rename arg-spec schema file to clarify it applies to roles only

### DIFF
--- a/src/ansiblelint/config.py
+++ b/src/ansiblelint/config.py
@@ -56,7 +56,7 @@ DEFAULT_KINDS = [
     {"test-meta": "**/tests/integration/targets/*/meta/main.{yaml,yml}"},
     {"meta": "**/meta/main.{yaml,yml}"},
     {"meta-runtime": "**/meta/runtime.{yaml,yml}"},
-    {"arg_specs": "**/meta/argument_specs.{yaml,yml}"},  # role argument specs
+    {"role-arg-spec": "**/meta/argument_specs.{yaml,yml}"},  # role argument specs
     {"yaml": ".config/molecule/config.{yaml,yml}"},  # molecule global config
     {
         "requirements": "**/molecule/*/{collections,requirements}.{yaml,yml}"

--- a/src/ansiblelint/rules/schema.md
+++ b/src/ansiblelint/rules/schema.md
@@ -29,8 +29,9 @@ Maintained in the
 - `schema[ansible-navigator]` validates
   [ansible-navigator configuration](https://github.com/ansible/ansible-navigator/blob/main/src/ansible_navigator/data/ansible-navigator.json)
 
-- `schema[arg_specs]` validates
-  [module argument specs](https://docs.ansible.com/ansible/latest/dev_guide/developing_program_flow_modules.html#argument-spec)
+- `schema[role-arg-spec]` validates
+  [role argument specs](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_reuse_roles.html#specification-format)
+  which is a little bit different than the module argument spec.
 - `schema[execution-environment]` validates
   [execution environments](https://docs.ansible.com/automation-controller/latest/html/userguide/execution_environments.html)
 - `schema[galaxy]` validates

--- a/src/ansiblelint/rules/schema.py
+++ b/src/ansiblelint/rules/schema.py
@@ -198,15 +198,15 @@ if "pytest" in sys.modules:
             ),
             pytest.param(
                 "examples/roles/hello/meta/argument_specs.yml",
-                "arg_specs",
+                "role-arg-spec",
                 [],
-                id="arg_specs",
+                id="role-arg-spec",
             ),
             pytest.param(
                 "examples/roles/broken_argument_specs/meta/argument_specs.yml",
-                "arg_specs",
+                "role-arg-spec",
                 ["Additional properties are not allowed ('foo' was unexpected)"],
-                id="arg_specs-broken",
+                id="role-arg-spec-broken",
             ),
             pytest.param(
                 "examples/changelogs/changelog.yaml",

--- a/src/ansiblelint/schemas/__store__.json
+++ b/src/ansiblelint/schemas/__store__.json
@@ -7,10 +7,6 @@
     "etag": "40c81a8e173bc86393cf4dbbccef4151d069f05d24e43a95a3b6b17fa3a2150a",
     "url": "https://raw.githubusercontent.com/ansible/ansible-navigator/main/src/ansible_navigator/data/ansible-navigator.json"
   },
-  "arg_specs": {
-    "etag": "f74d4de954104f4908a9aa3b7834cca6c9fd98f8dce59ebe245c14bae9942fa5",
-    "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/arg_specs.json"
-  },
   "changelog": {
     "etag": "2b862fe2be05a6d3ed4fbed9a31752deb3b1cc63d4f98bded6a4f90e9166a6bd",
     "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/changelog.json"
@@ -46,6 +42,10 @@
   "requirements": {
     "etag": "93c6ccd1f79f58134795b85f9b1193d6e18417dd01a9d1f37d9f247562a1e6fe",
     "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/requirements.json"
+  },
+  "role-arg-spec": {
+    "etag": "f74d4de954104f4908a9aa3b7834cca6c9fd98f8dce59ebe245c14bae9942fa5",
+    "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/role-arg-spec.json"
   },
   "rulebook": {
     "etag": "61ccd5e187ba837b5cea6ad1f696a29fb1e2a8f14278dddda6269c43c5594c7f",

--- a/src/ansiblelint/schemas/role-arg-spec.json
+++ b/src/ansiblelint/schemas/role-arg-spec.json
@@ -233,7 +233,7 @@
       "title": "Option"
     }
   },
-  "$id": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/arg_specs.json",
+  "$id": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/role-arg-spec.json",
   "$schema": "http://json-schema.org/draft-07/schema",
   "additionalProperties": false,
   "examples": ["meta/argument_specs.yml"],
@@ -246,5 +246,5 @@
       "markdownDescription": "Add entry point, usually `main`.\nSee [role-argument-validation](https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_roles.html#role-argument-validation)"
     }
   },
-  "title": "Ansible Argument Specs Schema"
+  "title": "Ansible Role Argument Specs Schema"
 }

--- a/test/test_file_utils.py
+++ b/test/test_file_utils.py
@@ -171,7 +171,7 @@ def test_discover_lintables_umlaut(monkeypatch: MonkeyPatch) -> None:
             "roles/foo/molecule/scenario3/collections.yml", "requirements", id="10"
         ),  # requirements
         pytest.param(
-            "roles/foo/meta/argument_specs.yml", "arg_specs", id="11"
+            "roles/foo/meta/argument_specs.yml", "role-arg-spec", id="11"
         ),  # role argument specs
         # tasks files:
         pytest.param("tasks/directory with spaces/main.yml", "tasks", id="12"),  # tasks


### PR DESCRIPTION
As we have multiple types of arg specs, we clarify that this applies to roles.

Fixes: #3241