### PR TITLE
Add name[import_playbook]

### DIFF
--- a/examples/playbooks/rule-name-import_playbook-fail.yml
+++ b/examples/playbooks/rule-name-import_playbook-fail.yml
@@ -1,0 +1,2 @@
+---
+- ansible.builtin.import_playbook: "./rule-name-play-fail.yml" # <-- name[import_playbook]

--- a/src/ansiblelint/rules/name.md
+++ b/src/ansiblelint/rules/name.md
@@ -9,6 +9,7 @@ This rule can produce messages as:
 - `name[casing]` - All names should start with an uppercase letter for languages
   that support it.
 - `name[missing]` - All tasks should be named.
+- `name[import_playbook]` - All import_playbooks should be named.
 - `name[play]` - All plays should be named.
 - `name[prefix]` - Prefix task names in sub-tasks files. (opt-in)
 - `name[template]` - Jinja templates should only be at the end of 'name'. This

--- a/src/ansiblelint/rules/name.py
+++ b/src/ansiblelint/rules/name.py
@@ -32,6 +32,15 @@ class NameRule(AnsibleLintRule):
         results = []
         if file.kind != "playbook":
             return []
+        if "import_playbook" in data or "ansible.builtin.import_playbook" in data:
+            return [
+                self.create_matcherror(
+                    message="All import_playbooks should be named.",
+                    linenumber=data[LINE_NUMBER_KEY],
+                    tag="name[import_playbook]",
+                    filename=file,
+                )
+            ]
         if "name" not in data:
             return [
                 self.create_matcherror(
@@ -201,6 +210,16 @@ if "pytest" in sys.modules:  # noqa: C901
         errs = Runner(success, rules=collection).run()
         assert len(errs) == 1
         assert errs[0].tag == "name[play]"
+        assert errs[0].rule.id == "name"
+
+    def test_name_import_playbook() -> None:
+        """Positive test for name[import_playbook]."""
+        collection = RulesCollection()
+        collection.register(NameRule())
+        success = "examples/playbooks/rule-name-import_playbook-fail.yml"
+        errs = Runner(success, rules=collection).run()
+        assert len(errs) == 1
+        assert errs[0].tag == "name[import_playbook]"
         assert errs[0].rule.id == "name"
 
     def test_name_template() -> None:


### PR DESCRIPTION
Split a new rule message 'name[import_playbook]' from 'name[play]' to allow users to skip the 'name' rule for 'import_playbook' module calls while still allowing 'name[play]' checks for normal plays.