### PR TITLE
Refactor project root directory detection code

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -324,6 +324,7 @@ slackpkg
 slaveinput
 sortfunc
 sourcegraph
+srcs
 srpm
 ssbarnea
 stylesheet

--- a/src/ansiblelint/__main__.py
+++ b/src/ansiblelint/__main__.py
@@ -48,7 +48,7 @@ from ansiblelint.color import (
     reconfigure,
     render_yaml,
 )
-from ansiblelint.config import get_version_warning, options
+from ansiblelint.config import get_version_warning, log_entries, options
 from ansiblelint.constants import EXIT_CONTROL_C_RC, GIT_CMD, LOCK_TIMEOUT_RC
 from ansiblelint.file_utils import abspath, cwd, normpath
 from ansiblelint.loaders import load_ignore_txt
@@ -184,7 +184,7 @@ def support_banner() -> None:
         )
 
 
-# pylint: disable=too-many-branches,too-many-statements
+# pylint: disable=too-many-branches,too-many-statements,too-many-locals
 def main(argv: list[str] | None = None) -> int:  # noqa: C901
     """Linter CLI entry point."""
     # alter PATH if needed (venv support)
@@ -210,6 +210,8 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901
         support_banner()
 
     initialize_logger(options.verbosity)
+    for level, message in log_entries:
+        _logger.log(level, message)
     _logger.debug("Options: %s", options)
     _logger.debug(os.getcwd())
 

--- a/src/ansiblelint/config.py
+++ b/src/ansiblelint/config.py
@@ -139,6 +139,9 @@ used_old_tags: dict[str, str] = {}
 # Used to store collection list paths (with mock paths if needed)
 collection_list: list[str] = []
 
+# Used to store log messages before logging is initialized (level, message)
+log_entries: list[tuple[int, str]] = []
+
 
 def get_rule_config(rule_id: str) -> dict[str, Any]:
     """Get configurations for the rule ``rule_id``."""

--- a/src/ansiblelint/constants.py
+++ b/src/ansiblelint/constants.py
@@ -156,6 +156,8 @@ ROLE_IMPORT_ACTION_NAMES = {
 # https://github.com/ansible/ansible-lint-action/issues/138
 GIT_CMD = ["git", "-c", f"safe.directory={os.getcwd()}"]
 
+CONFIG_FILENAMES = [".ansible-lint", ".config/ansible-lint.yml"]
+
 
 class States(Enum):
     """States used are used as sentinel values in various places."""


### PR DESCRIPTION
This changes the way linter determines project root folder to mimic the way black works. This will allow us to use linter to lint code that if outside current working directory and in path location like /tmp.
