### PR TITLE
Ensure profile rules do not have experimental or opt-in tag

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -59,7 +59,7 @@ jobs:
       WSLENV: FORCE_COLOR:PYTEST_REQPASS:TOXENV:GITHUB_STEP_SUMMARY
       # Number of expected test passes, safety measure for accidental skip of
       # tests. Update value if you add/remove tests.
-      PYTEST_REQPASS: 791
+      PYTEST_REQPASS: 792
     steps:
       - name: Activate WSL1
         if: "contains(matrix.shell, 'wsl')"

--- a/src/ansiblelint/rules/__init__.py
+++ b/src/ansiblelint/rules/__init__.py
@@ -542,16 +542,4 @@ def filter_rules_with_profile(rule_col: list[BaseRule], profile: str) -> None:
                 profile,
             )
             rule_col.remove(rule)
-        else:
-            for tag in ("opt-in", "experimental"):
-                if tag in rule.tags:
-                    _logger.debug(
-                        "Removing tag `%s` from `%s` rule because `%s` profile makes it mandatory.",
-                        tag,
-                        rule.id,
-                        profile,
-                    )
-                    rule.tags.remove(tag)
-            if "opt-in" in rule.tags:
-                rule.tags.remove("opt-in")
     _logger.debug("%s/%s rules included in the profile", len(rule_col), total_rules)

--- a/src/ansiblelint/rules/sanity.py
+++ b/src/ansiblelint/rules/sanity.py
@@ -22,7 +22,7 @@ class CheckSanityIgnoreFiles(AnsibleLintRule):
         "Identifies non-allowed entries in the `tests/sanity/ignore*.txt files."
     )
     severity = "MEDIUM"
-    tags = ["experimental"]
+    tags = []
     version_added = "v6.14.0"
 
     # Partner Engineering defines this list. Please contact PE for changes.

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,0 +1,16 @@
+"""Tests for config module."""
+from ansiblelint.config import PROFILES
+from ansiblelint.rules import RulesCollection
+
+
+def test_profiles(default_rules_collection: RulesCollection) -> None:
+    """Test the rules included in profiles are valid."""
+    profile_banned_tags = set(["opt-in", "experimental"])
+    for name, data in PROFILES.items():
+        for profile_rule_id in data["rules"]:
+            for rule in default_rules_collection.rules:
+                if profile_rule_id == rule.id:
+                    forbidden_tags = profile_banned_tags & set(rule.tags)
+                    assert (
+                        not forbidden_tags
+                    ), f"Rule {profile_rule_id} from {name} profile cannot use {profile_banned_tags & set(rule.tags)} tag."


### PR DESCRIPTION
- Checks that we do not accidentally add rules to profiles while they still have the opt-in or experimental tag.
- Remove experimental tag from `sanity` rule

Fixes: #3255
