### PR TITLE
Ensure non zero exit code when no files are linted

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -59,7 +59,7 @@ jobs:
       WSLENV: FORCE_COLOR:PYTEST_REQPASS:TOXENV:GITHUB_STEP_SUMMARY
       # Number of expected test passes, safety measure for accidental skip of
       # tests. Update value if you add/remove tests.
-      PYTEST_REQPASS: 792
+      PYTEST_REQPASS: 793
     steps:
       - name: Activate WSL1
         if: "contains(matrix.shell, 'wsl')"

--- a/src/ansiblelint/app.py
+++ b/src/ansiblelint/app.py
@@ -223,8 +223,17 @@ class App:
                 files_count,
                 is_success=mark_as_success,
             )
-
-        return RC.SUCCESS if mark_as_success else RC.VIOLATIONS_FOUND
+        if mark_as_success:
+            if not files_count:
+                # success without any file being analyzed is reported as failure
+                # to match match, preventing accidents where linter was running
+                # not doing anything due to misconfiguration.
+                _logger.critical(
+                    "Linter finished without analyzing any file, check configuration and arguments given.",
+                )
+                return RC.NO_FILES_MATCHED
+            return RC.SUCCESS
+        return RC.VIOLATIONS_FOUND
 
     def report_summary(  # pylint: disable=too-many-branches,too-many-locals
         self,

--- a/src/ansiblelint/constants.py
+++ b/src/ansiblelint/constants.py
@@ -11,12 +11,13 @@ RULE_DOC_URL = "https://ansible-lint.readthedocs.io/rules/"
 # Not using an IntEnum because only starting with py3.11 it will evaluate it
 # as int.
 class RC:  # pylint: disable=too-few-public-methods
-    """All exist codes used by ansible-lint."""
+    """All exit codes used by ansible-lint."""
 
     SUCCESS = 0
     VIOLATIONS_FOUND = 2
     INVALID_CONFIG = 3
     LOCK_TIMEOUT = 4
+    NO_FILES_MATCHED = 5
     EXIT_CONTROL_C = 130
 
 

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -1,6 +1,7 @@
 """Test for app module."""
 from pathlib import Path
 
+from ansiblelint.constants import RC
 from ansiblelint.file_utils import Lintable
 from ansiblelint.testing import run_ansible_lint
 
@@ -19,3 +20,9 @@ def test_generate_ignore(tmp_path: Path) -> None:
     # Run again and now we expect to succeed as we have an ignore file.
     result = run_ansible_lint(lintable.filename, cwd=str(tmp_path))
     assert result.returncode == 0
+
+
+def test_app_no_matches(tmp_path: Path) -> None:
+    """Validate that linter returns special exit code if no files are analyzed."""
+    result = run_ansible_lint(cwd=str(tmp_path))
+    assert result.returncode == RC.NO_FILES_MATCHED

--- a/tools/test-hook.sh
+++ b/tools/test-hook.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# This scripts checks if ansible-lint works as a hook as expected.
+SOURCE=${BASH_SOURCE[0]}
+while [ -L "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR=$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )
+  SOURCE=$(readlink "$SOURCE")
+  [[ $SOURCE != /* ]] && SOURCE=$DIR/$SOURCE # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR=$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )
+
+set -euo pipefail
+rm -rf .tox/x
+mkdir -p .tox/x
+cd .tox/x
+git init
+# we add a file to the repo to avoid error due to no file to to lint
+touch foo.yml
+git add foo.yml
+python3 -m pre_commit try-repo -v "${DIR}/.." ansible-lint

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps =
   --editable .[test]
   devel: ansible-core @ git+https://github.com/ansible/ansible.git  # GPLv3+
 commands_pre =
-  -sh -c "rm .tox/.coverage.*"
+  sh -c "rm -f .tox/.coverage.* 2>/dev/null || true"
 commands =
   # safety measure to assure we do not accidentally run tests with broken dependencies
   {envpython} -m pip check
@@ -69,6 +69,7 @@ allowlist_externals =
   rm
   sh
   tox
+  ./tools/test-hook.sh
 # both options needed to workaround https://github.com/tox-dev/tox/issues/2197
 usedevelop = false
 skip_install = true
@@ -97,7 +98,7 @@ setenv =
 description = Validate pre-commit hook definition
 deps = pre-commit
 commands =
-  sh -c "mkdir -p .tox/x && cd .tox/x && git init && python3 -m pre_commit try-repo -v {toxinidir} ansible-lint"
+  ./tools/test-hook.sh
 setenv =
   PIP_CONSTRAINT=/dev/null
 


### PR DESCRIPTION
This change will make the linter return a special exit code when no files are analyzed. This should prevent accidents related to misconfiguration via config file excludes or wrong arguments being passed to it. The returned exit code is unique and returned only for this special case.

Related: #3284