### PR TITLE
Require at least one known subfolder for roles

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -330,6 +330,7 @@ ssbarnea
 stylesheet
 subdir
 subelements
+subfolders
 subresults
 subschema
 subschemas

--- a/src/ansiblelint/file_utils.py
+++ b/src/ansiblelint/file_utils.py
@@ -160,7 +160,15 @@ def kind_from_path(path: Path, base: bool = False) -> FileType:
         return ""
 
     if path.is_dir():
-        return "role"
+        known_role_subfolders = ("tasks", "meta", "vars", "defaults", "handlers")
+        for filename in known_role_subfolders:
+            if (path / filename).is_dir():
+                return "role"
+        _logger.debug(
+            "Folder `%s` does not look like a role due to missing any of the common subfolders such: %s.",
+            path,
+            ", ".join(known_role_subfolders),
+        )
 
     if str(path) == "/dev/stdin":
         return "playbook"

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -1017,8 +1017,8 @@ def _extend_with_roles(lintables: list[Lintable]) -> None:
             while role.parent.name != "roles" and role.name:
                 role = role.parent
             if role.exists() and not role.is_file():
-                lintable = Lintable(role, kind="role")
-                if lintable not in lintables:
+                lintable = Lintable(role)
+                if lintable.kind == "role" and lintable not in lintables:
                     _logger.debug("Added role: %s", lintable)
                     lintables.append(lintable)
 

--- a/test/test_runner.py
+++ b/test/test_runner.py
@@ -124,7 +124,13 @@ def test_runner_unicode_format(
     formatter.format(matches[0])
 
 
-@pytest.mark.parametrize("directory_name", ("test/", os.path.abspath("test")))
+@pytest.mark.parametrize(
+    "directory_name",
+    (
+        pytest.param("test/fixtures/verbosity-tests", id="rel"),
+        pytest.param(os.path.abspath("test/fixtures/verbosity-tests"), id="abs"),
+    ),
+)
 def test_runner_with_directory(
     default_rules_collection: RulesCollection,
     directory_name: str,

--- a/test/test_verbosity.py
+++ b/test/test_verbosity.py
@@ -14,63 +14,61 @@ from ansiblelint.testing import run_ansible_lint
 @pytest.mark.parametrize(
     ("verbosity", "substrs"),
     (
-        (
+        pytest.param(
             "",
             [
                 ("WARNING  Listing 1 violation(s) that are fatal", False),
                 ("DEBUG ", True),
                 ("INFO ", True),
             ],
+            id="default",
         ),
-        (
+        pytest.param(
             "-q",
             [
                 ("WARNING ", True),
                 ("DEBUG ", True),
                 ("INFO ", True),
             ],
+            id="q",
         ),
-        (
+        pytest.param(
             "-qq",
             [
                 ("WARNING ", True),
                 ("DEBUG ", True),
                 ("INFO ", True),
             ],
+            id="qq",
         ),
-        (
+        pytest.param(
             "-v",
             [
                 ("WARNING  Listing 1 violation(s) that are fatal", False),
                 ("INFO     Set ANSIBLE_LIBRARY=", False),
                 ("DEBUG ", True),
             ],
+            id="v",
         ),
-        (
+        pytest.param(
             "-vv",
             [
                 ("WARNING  Listing 1 violation(s) that are fatal", False),
                 ("INFO     Set ANSIBLE_LIBRARY=", False),
             ],
+            id="really-loquacious",
         ),
-        (
-            "-vvvvvvvvvvvvvvvvvvvvvvvvv",
+        pytest.param(
+            "-vv",
             [
                 ("WARNING  Listing 1 violation(s) that are fatal", False),
                 ("INFO     Set ANSIBLE_LIBRARY=", False),
             ],
+            id="vv",
         ),
     ),
-    ids=(
-        "default-verbosity",
-        "quiet",
-        "really-quiet",
-        "loquacious",
-        "really-loquacious",
-        'really-loquacious but with more "v"s -- same as -vv',
-    ),
 )
-def test_default_verbosity(verbosity: str, substrs: list[tuple[str, bool]]) -> None:
+def test_verbosity(verbosity: str, substrs: list[tuple[str, bool]]) -> None:
     """Checks that our default verbosity displays (only) warnings."""
     # Piggyback off the .yamllint in the root of the repo, just for testing.
     # We'll "override" it with the one in the fixture, to produce a warning.


### PR DESCRIPTION
Identified folders as roles only if they contain one of the known subfolders used by roles, such "tasks", "meta", "vars", "defaults", "handlers".

This behaviour change should prevent undesired identification of other folders as roles, like we seen on debops repository, where documentation folders were wrongly identified as roles.
