### PR TITLE
Allow linting plugin EXAMPLES as playbooks

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -259,6 +259,7 @@ pipx
 pkgcache  # linux
 pkgs
 placefolder
+plainexamples
 pluggy
 pluginmanager
 pmrun

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -70,7 +70,7 @@ jobs:
     env:
       # Number of expected test passes, safety measure for accidental skip of
       # tests. Update value if you add/remove tests.
-      PYTEST_REQPASS: 829
+      PYTEST_REQPASS: 831
     steps:
       - uses: actions/checkout@v4
         with:

--- a/plugins/modules/fake_module.py
+++ b/plugins/modules/fake_module.py
@@ -4,6 +4,14 @@ This is used to test ability to detect and use custom modules.
 """
 from ansible.module_utils.basic import AnsibleModule
 
+EXAMPLES = r"""
+- name: "playbook"
+  tasks:
+    - name: Hello
+      debug:
+        msg: 'world'
+"""
+
 
 def main() -> None:
     """Return the module instance."""

--- a/src/ansiblelint/errors.py
+++ b/src/ansiblelint/errors.py
@@ -110,6 +110,9 @@ class MatchError(ValueError):
             msg = "MatchError called incorrectly as column numbers start with 1"
             raise RuntimeError(msg)
 
+        offset = getattr(self.lintable, "_line_offset", 1)
+        self.lineno += offset - 1
+
     @functools.cached_property
     def level(self) -> str:
         """Return the level of the rule: error, warning or notice."""

--- a/src/ansiblelint/errors.py
+++ b/src/ansiblelint/errors.py
@@ -110,8 +110,8 @@ class MatchError(ValueError):
             msg = "MatchError called incorrectly as column numbers start with 1"
             raise RuntimeError(msg)
 
-        offset = getattr(self.lintable, "_line_offset", 1)
-        self.lineno += offset - 1
+        offset = getattr(self.lintable, "_line_offset", 0)
+        self.lineno += offset
 
     @functools.cached_property
     def level(self) -> str:

--- a/src/ansiblelint/file_utils.py
+++ b/src/ansiblelint/file_utils.py
@@ -256,8 +256,11 @@ class Lintable:
             _ = self.data  # pylint: disable=pointless-statement
 
         if self.kind == "plugin":
+            # pylint: disable=consider-using-with
             self.file = NamedTemporaryFile(
-                mode="w+", suffix=f"_{name.name}.yaml", dir=self.dir
+                mode="w+",
+                suffix=f"_{name.name}.yaml",
+                dir=self.dir,
             )
             self.filename = self.file.name
             self._content = self.parse_examples_from_plugin()
@@ -267,7 +270,7 @@ class Lintable:
             self.base_kind = "text/yaml"
 
 
-    def __del__(self):
+    def __del__(self) -> None:
         if hasattr(self, "file"):
             self.file.close()
 

--- a/src/ansiblelint/file_utils.py
+++ b/src/ansiblelint/file_utils.py
@@ -256,7 +256,9 @@ class Lintable:
             _ = self.data  # pylint: disable=pointless-statement
 
         if self.kind == "plugin":
-            self.file = NamedTemporaryFile(mode="w+", suffix=f"_{name.name}.yaml", dir=self.dir)
+            self.file = NamedTemporaryFile(
+                mode="w+", suffix=f"_{name.name}.yaml", dir=self.dir
+            )
             self.filename = self.file.name
             self._content = self.parse_examples_from_plugin()
             self.file.write(self._content)

--- a/src/ansiblelint/file_utils.py
+++ b/src/ansiblelint/file_utils.py
@@ -408,7 +408,9 @@ class Lintable:
 
         docs = read_docstring(str(self.path))
         examples = docs["plainexamples"]
-        return examples or ""
+        # Ignore the leading newline and lack of document start
+        # as including those in EXAMPLES would be weird.
+        return f"---{examples}" if examples else ""
 
     @property
     def data(self) -> Any:

--- a/src/ansiblelint/file_utils.py
+++ b/src/ansiblelint/file_utils.py
@@ -397,6 +397,20 @@ class Lintable:
                         from ansiblelint.skip_utils import append_skipped_rules
 
                     self.state = append_skipped_rules(self.state, self)
+                elif self.kind == "plugin":
+                    from ansiblelint.utils import (  # pylint: disable=import-outside-toplevel
+                        parse_plugin,
+                    )
+
+                    self._data = parse_plugin(self)
+                    if self._data:
+                        # Lazy import to avoid delays and cyclic-imports
+                        if "append_skipped_rules" not in globals():
+                            # pylint: disable=import-outside-toplevel
+                            from ansiblelint.skip_utils import append_skipped_rules
+
+                        self._data = append_skipped_rules(self._data, self)
+
                 else:
                     logging.debug(
                         "data set to None for %s due to being '%s' (%s) kind.",

--- a/src/ansiblelint/file_utils.py
+++ b/src/ansiblelint/file_utils.py
@@ -1,7 +1,6 @@
 """Utility functions related to file operations."""
 from __future__ import annotations
 
-import ast
 import copy
 import logging
 import os
@@ -13,6 +12,7 @@ from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING, Any, cast
 
 import pathspec
+from ansible.parsing.plugin_docs import read_docstring
 import wcmatch.pathlib
 import wcmatch.wcmatch
 from yaml.error import YAMLError
@@ -392,15 +392,8 @@ class Lintable:
 
         The line numbers are stored in each node's LINE_NUMBER_KEY key.
         """
-        parsed = ast.parse(self.content, self.path)
-
-        examples = None
-        for node in parsed.body:
-            if isinstance(node, ast.Assign):
-                for target in node.targets:
-                    if isinstance(target, ast.Name) and target.id == "EXAMPLES" and isinstance(node.value, ast.Constant):
-                        examples = node.value.value
-
+        docs = read_docstring(str(self.path))
+        examples = docs["plainexamples"]
         return examples or ""
 
     @property

--- a/src/ansiblelint/file_utils.py
+++ b/src/ansiblelint/file_utils.py
@@ -265,6 +265,10 @@ class Lintable:
             self.base_kind = "text/yaml"
 
 
+    def __del__(self):
+        if hasattr(self, "file"):
+            self.file.close()
+
     def _guess_kind(self) -> None:
         if self.kind == "yaml":
             if (

--- a/src/ansiblelint/file_utils.py
+++ b/src/ansiblelint/file_utils.py
@@ -425,8 +425,7 @@ class Lintable:
                         parse_yaml_linenumbers,
                     )
 
-                    offset = getattr(self, "_line_offset", 0)
-                    self.state = parse_yaml_linenumbers(self, line_number_offset=offset)
+                    self.state = parse_yaml_linenumbers(self)
                     # now that _data is not empty, we can try guessing if playbook or rulebook
                     # it has to be done before append_skipped_rules() call as it's relying
                     # on self.kind.
@@ -438,7 +437,6 @@ class Lintable:
                         from ansiblelint.skip_utils import append_skipped_rules
 
                     self.state = append_skipped_rules(self.state, self)
-
                 else:
                     logging.debug(
                         "data set to None for %s due to being '%s' (%s) kind.",

--- a/src/ansiblelint/file_utils.py
+++ b/src/ansiblelint/file_utils.py
@@ -403,7 +403,7 @@ class Lintable:
             if isinstance(child, ast.Assign):
                 label = child.targets[0]
                 if isinstance(label, ast.Name) and label.id == "EXAMPLES":
-                    self._line_offset = child.lineno
+                    self._line_offset = child.lineno - 1
                     break
 
         docs = read_docstring(str(self.path))

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -852,7 +852,6 @@ def get_action_tasks(data: AnsibleBaseYAMLObject, file: Lintable) -> list[Any]:
 @cache
 def parse_yaml_linenumbers(
     lintable: Lintable,
-    line_number_offset: int = 0,
 ) -> AnsibleBaseYAMLObject:
     """Parse yaml as ansible.utils.parse_yaml but with linenumbers.
 
@@ -867,7 +866,7 @@ def parse_yaml_linenumbers(
         if not isinstance(node, yaml.nodes.Node):
             msg = "Unexpected yaml data."
             raise RuntimeError(msg)
-        node.__line__ = line + (line_number_offset or 1)  # type: ignore[attr-defined]
+        node.__line__ = line + 1  # type: ignore[attr-defined]
         return node
 
     def construct_mapping(

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -22,6 +22,7 @@
 """Generic utility helpers."""
 from __future__ import annotations
 
+import ast
 import contextlib
 import inspect
 import logging
@@ -906,6 +907,78 @@ def parse_yaml_linenumbers(
     ) as exc:
         msg = "Failed to load YAML file"
         raise RuntimeError(msg) from exc
+
+    if len(result) == 0:
+        return None  # empty documents
+    if len(result) == 1:
+        return result[0]
+    return result
+
+
+@lru_cache(maxsize=None)
+def parse_plugin(  # noqa: max-complexity: 12
+    lintable: Lintable,
+) -> AnsibleBaseYAMLObject:
+    """Parse yaml inside plugin EXAMPLES string as ansible.utils.parse_yaml but with linenumbers.
+
+    The line numbers are stored in each node's LINE_NUMBER_KEY key.
+    """
+    result = []
+
+    def compose_node(parent: yaml.nodes.Node, index: int) -> yaml.nodes.Node:
+        # the line number where the previous token has ended (plus empty lines)
+        line = loader.line
+        node = Composer.compose_node(loader, parent, index)
+        if not isinstance(node, yaml.nodes.Node):
+            raise RuntimeError("Unexpected yaml data.")
+        setattr(node, "__line__", line + 1)
+        return node
+
+    def construct_mapping(
+        node: AnsibleBaseYAMLObject, deep: bool = False
+    ) -> AnsibleMapping:
+        mapping = AnsibleConstructor.construct_mapping(loader, node, deep=deep)
+        if hasattr(node, "__line__"):
+            mapping[LINE_NUMBER_KEY] = node.__line__
+        else:
+            mapping[
+                LINE_NUMBER_KEY
+            ] = mapping._line_number  # pylint: disable=protected-access
+        mapping[FILENAME_KEY] = lintable.path
+        return mapping
+
+    parsed = ast.parse(lintable.content, lintable.path)
+
+    examples = None
+    for node in parsed.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "EXAMPLES" and isinstance(node.value, ast.Constant):
+                    examples = node.value.value
+
+    if not examples:
+        # EXAMPLES string not found
+        return None
+    lintable.content = examples
+
+    try:
+        loader = AnsibleLoader(lintable.content)
+        loader.compose_node = compose_node
+        loader.construct_mapping = construct_mapping
+        # while Ansible only accepts single documents, we also need to load
+        # multi-documents, as we attempt to load any YAML file, not only
+        # Ansible managed ones.
+        while True:
+            data = loader.get_data()
+            if data is None:
+                break
+            result.append(data)
+    except (
+        yaml.parser.ParserError,
+        yaml.scanner.ScannerError,
+        yaml.constructor.ConstructorError,
+    ) as exc:
+        raise RuntimeError("Failed to load YAML file") from exc
 
     if len(result) == 0:
         return None  # empty documents

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -852,6 +852,7 @@ def get_action_tasks(data: AnsibleBaseYAMLObject, file: Lintable) -> list[Any]:
 @cache
 def parse_yaml_linenumbers(
     lintable: Lintable,
+    line_number_offset: int = 0,
 ) -> AnsibleBaseYAMLObject:
     """Parse yaml as ansible.utils.parse_yaml but with linenumbers.
 
@@ -866,7 +867,7 @@ def parse_yaml_linenumbers(
         if not isinstance(node, yaml.nodes.Node):
             msg = "Unexpected yaml data."
             raise RuntimeError(msg)
-        node.__line__ = line + 1  # type: ignore[attr-defined]
+        node.__line__ = line + (line_number_offset or 1)  # type: ignore[attr-defined]
         return node
 
     def construct_mapping(

--- a/test/test_file_utils.py
+++ b/test/test_file_utils.py
@@ -258,6 +258,11 @@ def test_discover_lintables_umlaut(monkeypatch: MonkeyPatch) -> None:
             "playbook",
             id="43",
         ),  # content should determine it as a play
+        pytest.param(
+            "plugins/modules/fake_module.py",
+            "plugin",
+            id="44",
+        ),
     ),
 )
 def test_kinds(path: str, kind: FileType) -> None:
@@ -536,3 +541,13 @@ def test_bug_2513(
         results = Runner(filename, rules=default_rules_collection).run()
         assert len(results) == 1
         assert results[0].rule.id == "name"
+
+
+def test_examples_content() -> None:
+    """Test that a module loads the correct content."""
+    filename = Path("plugins/modules/fake_module.py")
+    lintable = Lintable(filename)
+    # Lintable is now correctly purporting to be a YAML file
+    assert lintable.base_kind == "text/yaml"
+    # Lintable content should be contents of EXAMPLES
+    assert lintable.content == "---" + BASIC_PLAYBOOK


### PR DESCRIPTION
Add a means of reading ansible plugins and linting their EXAMPLES string.

Fixes: https://github.com/ansible/ansible-lint/issues/2881