### PR TITLE
Fix config path detection logic

### DIFF
--- a/examples/roles/test-role/molecule/default/include-import-role.yml
+++ b/examples/roles/test-role/molecule/default/include-import-role.yml
@@ -1,5 +1,5 @@
 ---
-- name: test
+- name: Fixture for test_run_playbook test
   gather_facts: false
   hosts: all
   roles:

--- a/src/ansiblelint/cli.py
+++ b/src/ansiblelint/cli.py
@@ -581,7 +581,7 @@ def get_config(arguments: list[str]) -> Namespace:
         log_entries.append(
             (
                 logging.INFO,
-                f"Identified `{project_dir}` as project root as project root containing {method}.",
+                f"Identified [filename]{project_dir}[/] as project root due [bold]{method}[/].",
             ),
         )
 

--- a/src/ansiblelint/file_utils.py
+++ b/src/ansiblelint/file_utils.py
@@ -519,9 +519,14 @@ def find_project_root(
             return directory, ".hg directory"
 
         for cfg_file in cfg_files:
-            if not os.path.isabs(cfg_file):
-                if (directory / cfg_file).is_file():
-                    return directory, str(cfg_file)
+            # note that if cfg_file is already absolute, 'directory' is ignored
+            resolved_cfg_path = directory / cfg_file
+            if resolved_cfg_path.is_file():
+                if os.path.isabs(cfg_file):
+                    directory = Path(cfg_file).parent
+                    if directory.name == ".config":
+                        directory = directory.parent
+                return directory, f"config file {resolved_cfg_path}"
 
     if not directory:
         return Path.cwd(), "current working directory"

--- a/test/test_cli_role_paths.py
+++ b/test/test_cli_role_paths.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from ansiblelint.constants import RC
 from ansiblelint.testing import run_ansible_lint
 from ansiblelint.text import strip_ansi_escape
 
@@ -90,8 +91,12 @@ def test_run_playbook(local_test_dir: str) -> None:
     env = os.environ.copy()
     env["ANSIBLE_ROLES_PATH"] = role_path
 
-    result = run_ansible_lint(lintable, cwd=cwd, env=env)
-    assert "Use shell only when shell functionality is required" in result.stdout
+    result = run_ansible_lint("-f", "pep8", lintable, cwd=cwd, env=env)
+    # All 4 failures are expected to be found inside the included role and not
+    # from the playbook given as argument.
+    assert result.returncode == RC.VIOLATIONS_FOUND
+    assert "tasks/main.yml:2: command-instead-of-shell" in result.stdout
+    assert "tasks/world.yml:2: name[missing]" in result.stdout
 
 
 @pytest.mark.parametrize(

--- a/test/test_file_utils.py
+++ b/test/test_file_utils.py
@@ -324,7 +324,7 @@ def test_find_project_root_dotconfig() -> None:
         ), "Test requires config file inside .config folder."
         path, method = find_project_root([])
         assert str(path) == str(os.getcwd())
-        assert method == ".config/ansible-lint.yml"
+        assert ".config/ansible-lint.yml" in method
 
 
 BASIC_PLAYBOOK = """


### PR DESCRIPTION
Fixed bug introduced in #3295 which prevented the linter from
discovering the config file in a parent directory.
