### PR TITLE
Make lintables act like singletons

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -59,7 +59,7 @@ jobs:
       WSLENV: FORCE_COLOR:PYTEST_REQPASS:TOXENV:GITHUB_STEP_SUMMARY
       # Number of expected test passes, safety measure for accidental skip of
       # tests. Update value if you add/remove tests.
-      PYTEST_REQPASS: 795
+      PYTEST_REQPASS: 796
     steps:
       - name: Activate WSL1
         if: "contains(matrix.shell, 'wsl')"

--- a/test/test_file_utils.py
+++ b/test/test_file_utils.py
@@ -568,3 +568,11 @@ def test_bug_2513(
         results = Runner(filename, rules=default_rules_collection).run()
         assert len(results) == 1
         assert results[0].rule.id == "name"
+
+
+def test_lintable_singleton() -> None:
+    """Validate that Lintables are singletons."""
+
+    lintable1 = Lintable("/dev/null")
+    lintable2 = Lintable("/dev/null")
+    assert id(lintable1) == id(lintable2)


### PR DESCRIPTION
This change will ensure that for a given file (lintable), we only have one instance inside the linter.
