### PR TITLE
Capture python warnings and report some of them as matches

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -59,7 +59,7 @@ jobs:
       WSLENV: FORCE_COLOR:PYTEST_REQPASS:TOXENV:GITHUB_STEP_SUMMARY
       # Number of expected test passes, safety measure for accidental skip of
       # tests. Update value if you add/remove tests.
-      PYTEST_REQPASS: 794
+      PYTEST_REQPASS: 795
     steps:
       - name: Activate WSL1
         if: "contains(matrix.shell, 'wsl')"

--- a/examples/playbooks/capture-warning.yml
+++ b/examples/playbooks/capture-warning.yml
@@ -1,0 +1,8 @@
+---
+- name: Fixture to generate a warning
+  hosts: localhost
+  tasks:
+    - name: Generate a warning
+      ansible.builtin.debug:
+        msg: "This is a warning"
+      when: "{{ false }}" # noqa: 102 jinja[spacing]

--- a/src/ansiblelint/errors.py
+++ b/src/ansiblelint/errors.py
@@ -13,6 +13,20 @@ if TYPE_CHECKING:
     from ansiblelint.utils import Task
 
 
+class LintWarning(Warning):
+    """Used by linter."""
+
+
+@dataclass
+class WarnSource:
+    """Container for warning information, so we can later create a MatchError from it."""
+
+    filename: Lintable
+    lineno: int
+    tag: str
+    message: str | None = None
+
+
 class StrictModeError(RuntimeError):
     """Raise when we encounter a warning in strict mode."""
 

--- a/src/ansiblelint/rules/__init__.py
+++ b/src/ansiblelint/rules/__init__.py
@@ -119,7 +119,10 @@ class AnsibleLintRule(BaseRule):
             if line.lstrip().startswith("#"):
                 continue
 
-            rule_id_list = ansiblelint.skip_utils.get_rule_skips_from_line(line)
+            rule_id_list = ansiblelint.skip_utils.get_rule_skips_from_line(
+                line,
+                lintable=file,
+            )
             if self.id in rule_id_list:
                 continue
 

--- a/src/ansiblelint/rules/jinja.py
+++ b/src/ansiblelint/rules/jinja.py
@@ -203,7 +203,10 @@ class JinjaRule(AnsibleLintRule):
                 lines = file.content.splitlines()
                 for match in raw_results:
                     # lineno starts with 1, not zero
-                    skip_list = get_rule_skips_from_line(lines[match.lineno - 1])
+                    skip_list = get_rule_skips_from_line(
+                        line=lines[match.lineno - 1],
+                        lintable=file,
+                    )
                     if match.rule.id not in skip_list and match.tag not in skip_list:
                         results.append(match)
         else:

--- a/src/ansiblelint/rules/var_naming.py
+++ b/src/ansiblelint/rules/var_naming.py
@@ -95,7 +95,10 @@ class VariableNamingRule(AnsibleLintRule):
             lines = file.content.splitlines()
             for match in raw_results:
                 # lineno starts with 1, not zero
-                skip_list = get_rule_skips_from_line(lines[match.lineno - 1])
+                skip_list = get_rule_skips_from_line(
+                    line=lines[match.lineno - 1],
+                    lintable=file,
+                )
                 if match.rule.id not in skip_list and match.tag not in skip_list:
                     results.append(match)
 
@@ -175,7 +178,10 @@ class VariableNamingRule(AnsibleLintRule):
                 lines = file.content.splitlines()
                 for match in raw_results:
                     # lineno starts with 1, not zero
-                    skip_list = get_rule_skips_from_line(lines[match.lineno - 1])
+                    skip_list = get_rule_skips_from_line(
+                        line=lines[match.lineno - 1],
+                        lintable=file,
+                    )
                     if match.rule.id not in skip_list and match.tag not in skip_list:
                         results.append(match)
         else:


### PR DESCRIPTION
This change introduces a new way to generate warnings in linter, one that uses the warnings support in Python. The benefit is that this allows use to generate warnings from anywhere inside the code without having to pass them from function to function.

For start we will be using this for internal rules, like ability to report outdated tag names in noqa comments.