### PR TITLE
Enforce use of lineno variable name inside the library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,13 +109,7 @@ disallow_any_generics = true
 exclude = "(build|dist|test/local-content|site-packages|~/.pyenv|examples/playbooks/collections|plugins/modules)"
 
 [[tool.mypy.overrides]]
-module = [
-  "ansible.*",
-  "yamllint.*",
-  "ansiblelint._version",
-  "ruamel.yaml",
-  "spdx.*"
-]
+module = ["ansible.*", "yamllint.*", "ansiblelint._version", "ruamel.yaml", "spdx.*"]
 ignore_missing_imports = true
 ignore_errors = true
 
@@ -126,6 +120,12 @@ extension-pkg-allow-list = ["black.parsing"]
 preferred-modules = ["py:pathlib", "unittest:pytest"]
 
 [tool.pylint.MASTER]
+bad-names = [
+  # spell-checker:ignore linenumber
+  "linenumber", # use lineno instead
+  "line_number", # use lineno instead
+
+]
 # pylint defaults + f,fh,v,id
 good-names = ["i", "j", "k", "ex", "Run", "_", "f", "fh", "v", "id", "T"]
 # Ignore as being generated:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,13 @@ disallow_any_generics = true
 exclude = "(build|dist|test/local-content|site-packages|~/.pyenv|examples/playbooks/collections|plugins/modules)"
 
 [[tool.mypy.overrides]]
-module = ["ansible.*", "yamllint.*", "ansiblelint._version", "ruamel.yaml", "spdx.*"]
+module = [
+  "ansible.*",
+  "yamllint.*",
+  "ansiblelint._version",
+  "ruamel.yaml",
+  "spdx.*"
+]
 ignore_missing_imports = true
 ignore_errors = true
 

--- a/src/ansiblelint/errors.py
+++ b/src/ansiblelint/errors.py
@@ -45,7 +45,7 @@ class MatchError(ValueError):
         message: str | None = None,
         # most linters report use (1,1) base, including yamllint and flake8
         # we should never report line 0 or column 0 in output.
-        linenumber: int = 1,
+        lineno: int = 1,
         column: int | None = None,
         details: str = "",
         filename: Lintable | None = None,
@@ -65,7 +65,7 @@ class MatchError(ValueError):
         self.message = str(message or getattr(rule, "shortdesc", ""))
 
         # Safety measure to ensure we do not end-up with incorrect indexes
-        if linenumber == 0:  # pragma: no cover
+        if lineno == 0:  # pragma: no cover
             raise RuntimeError(
                 "MatchError called incorrectly as line numbers start with 1",
             )
@@ -74,7 +74,7 @@ class MatchError(ValueError):
                 "MatchError called incorrectly as column numbers start with 1",
             )
 
-        self.linenumber = linenumber
+        self.lineno = lineno
         self.column = column
         self.details = details
         self.filename = ""
@@ -120,7 +120,7 @@ class MatchError(ValueError):
             _id,
             self.message,
             self.filename,
-            self.linenumber,
+            self.lineno,
             self.details,
         )
 
@@ -128,15 +128,15 @@ class MatchError(ValueError):
     def position(self) -> str:
         """Return error positioning, with column number if available."""
         if self.column:
-            return f"{self.linenumber}:{self.column}"
-        return str(self.linenumber)
+            return f"{self.lineno}:{self.column}"
+        return str(self.lineno)
 
     @property
     def _hash_key(self) -> Any:
         # line attr is knowingly excluded, as dict is not hashable
         return (
             self.filename,
-            self.linenumber,
+            self.lineno,
             str(getattr(self.rule, "id", 0)),
             self.message,
             self.details,

--- a/src/ansiblelint/formatters/__init__.py
+++ b/src/ansiblelint/formatters/__init__.py
@@ -116,7 +116,7 @@ class AnnotationsFormatter(BaseFormatter):  # type: ignore
     def format(self, match: MatchError) -> str:
         """Prepare a match instance for reporting as a GitHub Actions annotation."""
         file_path = self._format_path(match.filename or "")
-        line_num = match.linenumber
+        line_num = match.lineno
         severity = match.rule.severity
         violation_details = self.escape(match.message)
         col = f",col={match.column}" if match.column else ""
@@ -160,11 +160,11 @@ class CodeclimateJSONFormatter(BaseFormatter[Any]):
             if match.column:
                 issue["location"]["positions"] = {}
                 issue["location"]["positions"]["begin"] = {}
-                issue["location"]["positions"]["begin"]["line"] = match.linenumber
+                issue["location"]["positions"]["begin"]["line"] = match.lineno
                 issue["location"]["positions"]["begin"]["column"] = match.column
             else:
                 issue["location"]["lines"] = {}
-                issue["location"]["lines"]["begin"] = match.linenumber
+                issue["location"]["lines"]["begin"] = match.lineno
             if match.details:
                 issue["content"] = {}
                 issue["content"]["body"] = match.details
@@ -287,7 +287,7 @@ class SarifFormatter(BaseFormatter[Any]):
                             "uriBaseId": self.BASE_URI_ID,
                         },
                         "region": {
-                            "startLine": match.linenumber,
+                            "startLine": match.lineno,
                         },
                     },
                 },

--- a/src/ansiblelint/rules/__init__.py
+++ b/src/ansiblelint/rules/__init__.py
@@ -75,7 +75,7 @@ class AnsibleLintRule(BaseRule):
     def create_matcherror(
         self,
         message: str | None = None,
-        linenumber: int = 1,
+        lineno: int = 1,
         details: str = "",
         filename: Lintable | None = None,
         tag: str = "",
@@ -83,7 +83,7 @@ class AnsibleLintRule(BaseRule):
         """Instantiate a new MatchError."""
         match = MatchError(
             message=message,
-            linenumber=linenumber,
+            lineno=lineno,
             details=details,
             filename=filename,
             rule=copy.copy(self),
@@ -111,8 +111,8 @@ class AnsibleLintRule(BaseRule):
         match.task = task
         if not match.details:
             match.details = "Task/Handler: " + ansiblelint.utils.task_to_str(task)
-        if match.linenumber < task[LINE_NUMBER_KEY]:
-            match.linenumber = task[LINE_NUMBER_KEY]
+        if match.lineno < task[LINE_NUMBER_KEY]:
+            match.lineno = task[LINE_NUMBER_KEY]
 
     def matchlines(self, file: Lintable) -> list[MatchError]:
         matches: list[MatchError] = []
@@ -134,7 +134,7 @@ class AnsibleLintRule(BaseRule):
                 message = result
             matcherror = self.create_matcherror(
                 message=message,
-                linenumber=prev_line_no + 1,
+                lineno=prev_line_no + 1,
                 details=line,
                 filename=file,
             )
@@ -204,7 +204,7 @@ class AnsibleLintRule(BaseRule):
                     message = result
                 match = self.create_matcherror(
                     message=message,
-                    linenumber=task.normalized_task[LINE_NUMBER_KEY],
+                    lineno=task.normalized_task[LINE_NUMBER_KEY],
                     filename=file,
                 )
 

--- a/src/ansiblelint/rules/args.py
+++ b/src/ansiblelint/rules/args.py
@@ -251,7 +251,7 @@ class ArgsRule(AnsibleLintRule):
         results.append(
             self.create_matcherror(
                 message=error_message,
-                linenumber=task[LINE_NUMBER_KEY],
+                lineno=task[LINE_NUMBER_KEY],
                 tag="args[module]",
                 filename=file,
             ),

--- a/src/ansiblelint/rules/fqcn.py
+++ b/src/ansiblelint/rules/fqcn.py
@@ -135,7 +135,7 @@ class FQCNBuiltinsRule(AnsibleLintRule, TransformMixin):
                             message=f"Use FQCN for builtin module actions ({module}).",
                             details=f"Use `{module_alias}` or `{legacy_module}` instead.",
                             filename=file,
-                            linenumber=task["__line__"],
+                            lineno=task["__line__"],
                             tag="fqcn[action-core]",
                         ),
                     )
@@ -146,7 +146,7 @@ class FQCNBuiltinsRule(AnsibleLintRule, TransformMixin):
                             message=f"Use FQCN for module actions, such `{self.module_aliases[module]}`.",
                             details=f"Action `{module}` is not FQCN.",
                             filename=file,
-                            linenumber=task["__line__"],
+                            lineno=task["__line__"],
                             tag="fqcn[action]",
                         ),
                     )
@@ -160,7 +160,7 @@ class FQCNBuiltinsRule(AnsibleLintRule, TransformMixin):
                         self.create_matcherror(
                             message=f"You should use canonical module name `{self.module_aliases[module]}` instead of `{module}`.",
                             filename=file,
-                            linenumber=task["__line__"],
+                            lineno=task["__line__"],
                             tag="fqcn[canonical]",
                         ),
                     )
@@ -173,7 +173,7 @@ class FQCNBuiltinsRule(AnsibleLintRule, TransformMixin):
             return [
                 self.create_matcherror(
                     message="Avoid `collections` keyword by using FQCN for all plugins, modules, roles and playbooks.",
-                    linenumber=data[LINE_NUMBER_KEY],
+                    lineno=data[LINE_NUMBER_KEY],
                     tag="fqcn[keyword]",
                     filename=file,
                 ),

--- a/src/ansiblelint/rules/galaxy.py
+++ b/src/ansiblelint/rules/galaxy.py
@@ -88,7 +88,7 @@ class GalaxyRule(AnsibleLintRule):
             results.append(
                 self.create_matcherror(
                     message="galaxy.yaml should have version tag.",
-                    linenumber=data[LINE_NUMBER_KEY],
+                    lineno=data[LINE_NUMBER_KEY],
                     tag="galaxy[version-missing]",
                     filename=file,
                 ),
@@ -103,7 +103,7 @@ class GalaxyRule(AnsibleLintRule):
                 self.create_matcherror(
                     message="collection version should be greater than or equal to 1.0.0",
                     # pylint: disable=protected-access
-                    linenumber=version._line_number,
+                    lineno=version._line_number,
                     tag="galaxy[version-incorrect]",
                     filename=file,
                 ),

--- a/src/ansiblelint/rules/jinja.py
+++ b/src/ansiblelint/rules/jinja.py
@@ -136,7 +136,7 @@ class JinjaRule(AnsibleLintRule):
                             result.append(
                                 self.create_matcherror(
                                     message=str(exc),
-                                    linenumber=_get_error_line(task, path),
+                                    lineno=_get_error_line(task, path),
                                     filename=file,
                                     tag=f"{self.id}[invalid]",
                                 ),
@@ -155,7 +155,7 @@ class JinjaRule(AnsibleLintRule):
                                     value=v,
                                     reformatted=reformatted,
                                 ),
-                                linenumber=_get_error_line(task, path),
+                                lineno=_get_error_line(task, path),
                                 details=details,
                                 filename=file,
                                 tag=f"{self.id}[{tag}]",
@@ -190,7 +190,7 @@ class JinjaRule(AnsibleLintRule):
                                     value=v,
                                     reformatted=reformatted,
                                 ),
-                                linenumber=v.ansible_pos[1],
+                                lineno=v.ansible_pos[1],
                                 details=details,
                                 filename=file,
                                 tag=f"{self.id}[{tag}]",
@@ -199,8 +199,8 @@ class JinjaRule(AnsibleLintRule):
             if raw_results:
                 lines = file.content.splitlines()
                 for match in raw_results:
-                    # linenumber starts with 1, not zero
-                    skip_list = get_rule_skips_from_line(lines[match.linenumber - 1])
+                    # lineno starts with 1, not zero
+                    skip_list = get_rule_skips_from_line(lines[match.lineno - 1])
                     if match.rule.id not in skip_list and match.tag not in skip_list:
                         results.append(match)
         else:
@@ -388,7 +388,7 @@ if "pytest" in sys.modules:  # noqa: C901
         collection.register(JinjaRule())
         lintable = Lintable("examples/playbooks/jinja-spacing.yml")
         results = Runner(lintable, rules=collection).run()
-        return list(map(lambda item: item.linenumber, results))
+        return list(map(lambda item: item.lineno, results))
 
     def test_jinja_spacing_playbook(
         error_expected_lines: list[int],
@@ -411,7 +411,7 @@ if "pytest" in sys.modules:  # noqa: C901
         error_expected_lineno = [14, 15, 16, 17, 18, 19, 32]
         assert len(results) == len(error_expected_lineno)
         for idx, err in enumerate(results):
-            assert err.linenumber == error_expected_lineno[idx]
+            assert err.lineno == error_expected_lineno[idx]
 
     @pytest.mark.parametrize(
         ("text", "expected", "tag"),
@@ -702,10 +702,10 @@ if "pytest" in sys.modules:  # noqa: C901
         assert len(errs) == 2
         assert errs[0].tag == "jinja[spacing]"
         assert errs[0].rule.id == "jinja"
-        assert errs[0].linenumber == 9
+        assert errs[0].lineno == 9
         assert errs[1].tag == "jinja[invalid]"
         assert errs[1].rule.id == "jinja"
-        assert errs[1].linenumber == 9
+        assert errs[1].lineno == 9
 
     def test_jinja_valid() -> None:
         """Tests our ability to parse jinja, even when variables may not be defined."""

--- a/src/ansiblelint/rules/meta_incorrect.py
+++ b/src/ansiblelint/rules/meta_incorrect.py
@@ -47,7 +47,7 @@ class MetaChangeFromDefaultRule(AnsibleLintRule):
                 results.append(
                     self.create_matcherror(
                         filename=file,
-                        linenumber=file.data[LINE_NUMBER_KEY],
+                        lineno=file.data[LINE_NUMBER_KEY],
                         message=f"Should change default metadata: {field}",
                     ),
                 )

--- a/src/ansiblelint/rules/name.py
+++ b/src/ansiblelint/rules/name.py
@@ -38,7 +38,7 @@ class NameRule(AnsibleLintRule, TransformMixin):
             return [
                 self.create_matcherror(
                     message="All plays should be named.",
-                    linenumber=data[LINE_NUMBER_KEY],
+                    lineno=data[LINE_NUMBER_KEY],
                     tag="name[play]",
                     filename=file,
                 ),
@@ -47,7 +47,7 @@ class NameRule(AnsibleLintRule, TransformMixin):
             self._check_name(
                 data["name"],
                 lintable=file,
-                linenumber=data[LINE_NUMBER_KEY],
+                lineno=data[LINE_NUMBER_KEY],
             ),
         )
         return results
@@ -63,7 +63,7 @@ class NameRule(AnsibleLintRule, TransformMixin):
             results.append(
                 self.create_matcherror(
                     message="All tasks should be named.",
-                    linenumber=task[LINE_NUMBER_KEY],
+                    lineno=task[LINE_NUMBER_KEY],
                     tag="name[missing]",
                     filename=file,
                 ),
@@ -73,7 +73,7 @@ class NameRule(AnsibleLintRule, TransformMixin):
                 self._prefix_check(
                     name,
                     lintable=file,
-                    linenumber=task[LINE_NUMBER_KEY],
+                    lineno=task[LINE_NUMBER_KEY],
                 ),
             )
         return results
@@ -82,7 +82,7 @@ class NameRule(AnsibleLintRule, TransformMixin):
         self,
         name: str,
         lintable: Lintable | None,
-        linenumber: int,
+        lineno: int,
     ) -> list[MatchError]:
         results: list[MatchError] = []
         effective_name = name
@@ -94,7 +94,7 @@ class NameRule(AnsibleLintRule, TransformMixin):
                 self._check_name(
                     effective_name,
                     lintable=lintable,
-                    linenumber=linenumber,
+                    lineno=lineno,
                 ),
             )
         return results
@@ -103,7 +103,7 @@ class NameRule(AnsibleLintRule, TransformMixin):
         self,
         name: str,
         lintable: Lintable | None,
-        linenumber: int,
+        lineno: int,
     ) -> list[MatchError]:
         # This rules applies only to languages that do have uppercase and
         # lowercase letter, so we ignore anything else. On Unicode isupper()
@@ -124,7 +124,7 @@ class NameRule(AnsibleLintRule, TransformMixin):
                         results.append(
                             self.create_matcherror(
                                 message=f"Task name should start with '{prefix}'.",
-                                linenumber=linenumber,
+                                lineno=lineno,
                                 tag="name[prefix]",
                                 filename=lintable,
                             ),
@@ -141,7 +141,7 @@ class NameRule(AnsibleLintRule, TransformMixin):
             results.append(
                 self.create_matcherror(
                     message="All names should start with an uppercase letter.",
-                    linenumber=linenumber,
+                    lineno=lineno,
                     tag="name[casing]",
                     filename=lintable,
                 ),
@@ -150,7 +150,7 @@ class NameRule(AnsibleLintRule, TransformMixin):
             results.append(
                 self.create_matcherror(
                     message="Jinja templates should only be at the end of 'name'",
-                    linenumber=linenumber,
+                    lineno=lineno,
                     tag="name[template]",
                     filename=lintable,
                 ),

--- a/src/ansiblelint/rules/no_free_form.py
+++ b/src/ansiblelint/rules/no_free_form.py
@@ -44,7 +44,7 @@ class NoFreeFormRule(AnsibleLintRule):
                     results.append(
                         self.create_matcherror(
                             message="Avoid embedding `executable=` inside raw calls, use explicit args dictionary instead.",
-                            linenumber=task[LINE_NUMBER_KEY],
+                            lineno=task[LINE_NUMBER_KEY],
                             filename=file,
                             tag=f"{self.id}[raw]",
                         ),
@@ -53,7 +53,7 @@ class NoFreeFormRule(AnsibleLintRule):
                 results.append(
                     self.create_matcherror(
                         message="Passing a non string value to `raw` module is neither documented or supported.",
-                        linenumber=task[LINE_NUMBER_KEY],
+                        lineno=task[LINE_NUMBER_KEY],
                         filename=file,
                         tag=f"{self.id}[raw-non-string]",
                     ),
@@ -78,7 +78,7 @@ class NoFreeFormRule(AnsibleLintRule):
                 results.append(
                     self.create_matcherror(
                         message=f"Avoid using free-form when calling module actions. ({action})",
-                        linenumber=task[LINE_NUMBER_KEY],
+                        lineno=task[LINE_NUMBER_KEY],
                         filename=file,
                     ),
                 )

--- a/src/ansiblelint/rules/no_jinja_when.py
+++ b/src/ansiblelint/rules/no_jinja_when.py
@@ -49,7 +49,7 @@ class NoFormattingInWhenRule(AnsibleLintRule):
                         self.create_matcherror(
                             details=str({"when": role}),
                             filename=file,
-                            linenumber=role[LINE_NUMBER_KEY],
+                            lineno=role[LINE_NUMBER_KEY],
                         ),
                     )
         return errors

--- a/src/ansiblelint/rules/no_prompting.py
+++ b/src/ansiblelint/rules/no_prompting.py
@@ -37,7 +37,7 @@ class NoPromptingRule(AnsibleLintRule):
         return [
             self.create_matcherror(
                 message="Play uses vars_prompt",
-                linenumber=vars_prompt[0][LINE_NUMBER_KEY],
+                lineno=vars_prompt[0][LINE_NUMBER_KEY],
                 filename=file,
             ),
         ]

--- a/src/ansiblelint/rules/no_tabs.py
+++ b/src/ansiblelint/rules/no_tabs.py
@@ -61,6 +61,6 @@ if "pytest" in sys.modules:
             "examples/playbooks/rule-no-tabs.yml",
             rules=default_rules_collection,
         ).run()
-        assert results[0].linenumber == 10
+        assert results[0].lineno == 10
         assert results[0].message == NoTabsRule().shortdesc
         assert len(results) == 2

--- a/src/ansiblelint/rules/partial_become.py
+++ b/src/ansiblelint/rules/partial_become.py
@@ -109,7 +109,7 @@ class BecomeUserWithoutBecomeRule(AnsibleLintRule):
                     self.create_matcherror(
                         message=self.shortdesc,
                         filename=file,
-                        linenumber=data[LINE_NUMBER_KEY],
+                        lineno=data[LINE_NUMBER_KEY],
                     ),
                 ]
         return []

--- a/src/ansiblelint/rules/role_name.py
+++ b/src/ansiblelint/rules/role_name.py
@@ -74,7 +74,7 @@ class RoleNames(AnsibleLintRule):
                     self.create_matcherror(
                         f"Avoid using paths when importing roles. ({name})",
                         filename=file,
-                        linenumber=task["action"].get("__line__", task["__line__"]),
+                        lineno=task["action"].get("__line__", task["__line__"]),
                         tag=f"{self.id}[path]",
                     ),
                 )
@@ -104,7 +104,7 @@ class RoleNames(AnsibleLintRule):
                                 self.create_matcherror(
                                     f"Avoid using paths when importing roles. ({role_name})",
                                     filename=file,
-                                    linenumber=line,
+                                    lineno=line,
                                     tag=f"{self.id}[path]",
                                 ),
                             )

--- a/src/ansiblelint/rules/run_once.py
+++ b/src/ansiblelint/rules/run_once.py
@@ -39,7 +39,7 @@ class RunOnce(AnsibleLintRule):
                 filename=file,
                 tag=f"{self.id}[play]",
                 # pylint: disable=protected-access
-                linenumber=strategy._line_number,
+                lineno=strategy._line_number,
             ),
         ]
 
@@ -60,7 +60,7 @@ class RunOnce(AnsibleLintRule):
                 message="Using run_once may behave differently if strategy is set to free.",
                 filename=file,
                 tag=f"{self.id}[task]",
-                linenumber=task[LINE_NUMBER_KEY],
+                lineno=task[LINE_NUMBER_KEY],
             ),
         ]
 

--- a/src/ansiblelint/rules/sanity.py
+++ b/src/ansiblelint/rules/sanity.py
@@ -81,7 +81,7 @@ class CheckSanityIgnoreFiles(AnsibleLintRule):
                                 self.create_matcherror(
                                     message=f"Ignore file contains {test} at line {line_num}, which is not a permitted ignore.",
                                     tag="sanity[cannot-ignore]",
-                                    linenumber=line_num,
+                                    lineno=line_num,
                                     filename=file,
                                 ),
                             )
@@ -91,7 +91,7 @@ class CheckSanityIgnoreFiles(AnsibleLintRule):
                             self.create_matcherror(
                                 message=f"Ignore file entry at {line_num} is formatted incorrectly. Please review.",
                                 tag="sanity[bad-ignore]",
-                                linenumber=line_num,
+                                lineno=line_num,
                                 filename=file,
                             ),
                         )

--- a/src/ansiblelint/rules/syntax_check.py
+++ b/src/ansiblelint/rules/syntax_check.py
@@ -132,7 +132,7 @@ class AnsibleSyntaxCheckRule(AnsibleLintRule):
         if run.returncode != 0:
             message = None
             filename = lintable
-            linenumber = 1
+            lineno = 1
             column = None
             tag = None
 
@@ -152,7 +152,7 @@ class AnsibleSyntaxCheckRule(AnsibleLintRule):
                     groups = match.groupdict()
                     title = groups.get("title", match.group(0))
                     details = groups.get("details", "")
-                    linenumber = int(groups.get("line", 1))
+                    lineno = int(groups.get("line", 1))
 
                     if "filename" in groups:
                         filename = Lintable(groups["filename"])
@@ -163,7 +163,7 @@ class AnsibleSyntaxCheckRule(AnsibleLintRule):
                         MatchError(
                             message=title,
                             filename=filename,
-                            linenumber=linenumber,
+                            lineno=lineno,
                             column=column,
                             rule=rule,
                             details=details,
@@ -181,7 +181,7 @@ class AnsibleSyntaxCheckRule(AnsibleLintRule):
                     MatchError(
                         message=message,
                         filename=filename,
-                        linenumber=linenumber,
+                        lineno=lineno,
                         column=column,
                         rule=rule,
                         details=details,
@@ -205,7 +205,7 @@ if "pytest" in sys.modules:
         )
         # pylint: disable=protected-access
         result = AnsibleSyntaxCheckRule._get_ansible_syntax_check_matches(lintable)
-        assert result[0].linenumber == 4
+        assert result[0].lineno == 4
         assert result[0].column == 7
         assert (
             result[0].message
@@ -221,7 +221,7 @@ if "pytest" in sys.modules:
         lintable = Lintable("examples/playbooks/empty_playbook.yml", kind="playbook")
         # pylint: disable=protected-access
         result = AnsibleSyntaxCheckRule._get_ansible_syntax_check_matches(lintable)
-        assert result[0].linenumber == 1
+        assert result[0].lineno == 1
         # We internally convert absolute paths returned by ansible into paths
         # relative to current directory.
         assert result[0].filename.endswith("/empty_playbook.yml")
@@ -253,7 +253,7 @@ if "pytest" in sys.modules:
         rules = RulesCollection()
         result = Runner(lintable, rules=rules).run()
         assert len(result) == 1, result
-        assert result[0].linenumber == 2
+        assert result[0].lineno == 2
         assert result[0].filename == "examples/roles/invalid_due_syntax/tasks/main.yml"
         assert result[0].tag == "syntax-check[specific]"
         assert result[0].message == "no module/action detected in task."

--- a/src/ansiblelint/rules/var_naming.py
+++ b/src/ansiblelint/rules/var_naming.py
@@ -78,7 +78,7 @@ class VariableNamingRule(AnsibleLintRule):
                 raw_results.append(
                     self.create_matcherror(
                         filename=file,
-                        linenumber=key.ansible_pos[1]
+                        lineno=key.ansible_pos[1]
                         if isinstance(key, AnsibleUnicode)
                         else our_vars[LINE_NUMBER_KEY],
                         message="Play defines variable '"
@@ -90,8 +90,8 @@ class VariableNamingRule(AnsibleLintRule):
         if raw_results:
             lines = file.content.splitlines()
             for match in raw_results:
-                # linenumber starts with 1, not zero
-                skip_list = get_rule_skips_from_line(lines[match.linenumber - 1])
+                # lineno starts with 1, not zero
+                skip_list = get_rule_skips_from_line(lines[match.lineno - 1])
                 if match.rule.id not in skip_list and match.tag not in skip_list:
                     results.append(match)
 
@@ -111,7 +111,7 @@ class VariableNamingRule(AnsibleLintRule):
                 results.append(
                     self.create_matcherror(
                         filename=file,
-                        linenumber=our_vars[LINE_NUMBER_KEY],
+                        lineno=our_vars[LINE_NUMBER_KEY],
                         message=f"Task defines variable within 'vars' section that violates variable naming standards: {key}",
                         tag=f"var-naming[{key}]",
                     ),
@@ -128,7 +128,7 @@ class VariableNamingRule(AnsibleLintRule):
                     results.append(
                         self.create_matcherror(
                             filename=file,
-                            linenumber=task["action"][LINE_NUMBER_KEY],
+                            lineno=task["action"][LINE_NUMBER_KEY],
                             message=f"Task uses 'set_fact' to define variables that violates variable naming standards: {key}",
                             tag=f"var-naming[{key}]",
                         ),
@@ -140,7 +140,7 @@ class VariableNamingRule(AnsibleLintRule):
             results.append(
                 self.create_matcherror(
                     filename=file,
-                    linenumber=task[LINE_NUMBER_KEY],
+                    lineno=task[LINE_NUMBER_KEY],
                     message=f"Task registers a variable that violates variable naming standards: {registered_var}",
                     tag=f"var-naming[{registered_var}]",
                 ),
@@ -161,7 +161,7 @@ class VariableNamingRule(AnsibleLintRule):
                     raw_results.append(
                         self.create_matcherror(
                             filename=file,
-                            linenumber=key.ansible_pos[1],
+                            lineno=key.ansible_pos[1],
                             message="File defines variable '"
                             + key
                             + "' that violates variable naming standards",
@@ -170,8 +170,8 @@ class VariableNamingRule(AnsibleLintRule):
             if raw_results:
                 lines = file.content.splitlines()
                 for match in raw_results:
-                    # linenumber starts with 1, not zero
-                    skip_list = get_rule_skips_from_line(lines[match.linenumber - 1])
+                    # lineno starts with 1, not zero
+                    skip_list = get_rule_skips_from_line(lines[match.lineno - 1])
                     if match.rule.id not in skip_list and match.tag not in skip_list:
                         results.append(match)
         else:
@@ -221,7 +221,7 @@ if "pytest" in sys.modules:
 
         # list unexpected error lines or non-matching error lines
         expected_error_lines = [2, 6]
-        lines = [i.linenumber for i in results]
+        lines = [i.lineno for i in results]
         error_lines_difference = list(
             set(expected_error_lines).symmetric_difference(set(lines)),
         )

--- a/src/ansiblelint/rules/yaml_rule.py
+++ b/src/ansiblelint/rules/yaml_rule.py
@@ -52,7 +52,7 @@ class YamllintRule(AnsibleLintRule):
                 self.create_matcherror(
                     # yamllint does return lower-case sentences
                     message=problem.desc.capitalize(),
-                    linenumber=problem.line,
+                    lineno=problem.line,
                     details="",
                     filename=file,
                     tag=f"yaml[{problem.rule}]",

--- a/src/ansiblelint/runner.py
+++ b/src/ansiblelint/runner.py
@@ -185,7 +185,7 @@ class Runner:
             filter(
                 lambda match: not self.is_excluded(Lintable(match.filename))
                 and hasattr(match, "lintable")
-                and match.tag not in match.lintable.line_skips[match.linenumber],
+                and match.tag not in match.lintable.line_skips[match.lineno],
                 matches,
             ),
         )

--- a/src/ansiblelint/transformer.py
+++ b/src/ansiblelint/transformer.py
@@ -131,11 +131,11 @@ class Transformer:
             if file_is_yaml and not match.yaml_path:
                 data = cast(Union[CommentedMap, CommentedSeq], data)
                 if match.match_type == "play":
-                    match.yaml_path = get_path_to_play(file, match.linenumber, data)
+                    match.yaml_path = get_path_to_play(file, match.lineno, data)
                 elif match.task or file.kind in (
                     "tasks",
                     "handlers",
                     "playbook",
                 ):
-                    match.yaml_path = get_path_to_task(file, match.linenumber, data)
+                    match.yaml_path = get_path_to_task(file, match.lineno, data)
             match.rule.transform(match, file, data)

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -607,7 +607,7 @@ def normalize_task_v2(task: dict[str, Any]) -> dict[str, Any]:
             rule=AnsibleParserErrorRule(),
             message=exc.message,
             filename=task.get(FILENAME_KEY, "Unknown"),
-            linenumber=task.get(LINE_NUMBER_KEY, 0),
+            lineno=task.get(LINE_NUMBER_KEY, 0),
         )
 
     # denormalize shell -> command conversion

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -40,7 +40,7 @@ def test_example_syntax_error(
     assert result[0].rule.id == "syntax-check"
     # This also ensures that line and column numbers start at 1, so they
     # match what editors will show (or output from other linters)
-    assert result[0].linenumber == line
+    assert result[0].lineno == line
     assert result[0].column == column
 
 

--- a/test/test_formatter.py
+++ b/test/test_formatter.py
@@ -36,7 +36,7 @@ def test_format_coloured_string() -> None:
     """Test formetting colored."""
     match = MatchError(
         message="message",
-        linenumber=1,
+        lineno=1,
         details=DETAILS,
         filename=Lintable("filename.yml", content=""),
         rule=rule,
@@ -48,7 +48,7 @@ def test_unicode_format_string() -> None:
     """Test formatting unicode."""
     match = MatchError(
         message="\U0001f427",
-        linenumber=1,
+        lineno=1,
         details=DETAILS,
         filename=Lintable("filename.yml", content=""),
         rule=rule,
@@ -60,7 +60,7 @@ def test_dict_format_line() -> None:
     """Test formatting dictionary details."""
     match = MatchError(
         message="xyz",
-        linenumber=1,
+        lineno=1,
         details={"hello": "world"},  # type: ignore
         filename=Lintable("filename.yml", content=""),
         rule=rule,

--- a/test/test_formatter_json.py
+++ b/test/test_formatter_json.py
@@ -30,7 +30,7 @@ class TestCodeclimateJSONFormatter:
         self.matches.append(
             MatchError(
                 message="message",
-                linenumber=1,
+                lineno=1,
                 details="hello",
                 filename=Lintable("filename.yml", content=""),
                 rule=self.rule,
@@ -39,7 +39,7 @@ class TestCodeclimateJSONFormatter:
         self.matches.append(
             MatchError(
                 message="message",
-                linenumber=2,
+                lineno=2,
                 details="hello",
                 filename=Lintable("filename.yml", content=""),
                 rule=self.rule,
@@ -94,7 +94,7 @@ class TestCodeclimateJSONFormatter:
         assert "path" in single_match["location"]
         assert single_match["location"]["path"] == self.matches[0].filename
         assert "lines" in single_match["location"]
-        assert single_match["location"]["lines"]["begin"] == self.matches[0].linenumber
+        assert single_match["location"]["lines"]["begin"] == self.matches[0].lineno
         assert "positions" not in single_match["location"]
         # check that the 2nd match is marked as 'minor' because it was created with ignored=True
         assert result[1]["severity"] == "minor"
@@ -107,7 +107,7 @@ class TestCodeclimateJSONFormatter:
                 [
                     MatchError(
                         message="message",
-                        linenumber=1,
+                        lineno=1,
                         column=42,
                         details="hello",
                         filename=Lintable("filename.yml", content=""),

--- a/test/test_formatter_sarif.py
+++ b/test/test_formatter_sarif.py
@@ -35,7 +35,7 @@ class TestSarifFormatter:
         self.matches.append(
             MatchError(
                 message="message",
-                linenumber=1,
+                lineno=1,
                 column=10,
                 details="details",
                 filename=Lintable("filename.yml", content=""),
@@ -46,7 +46,7 @@ class TestSarifFormatter:
         self.matches.append(
             MatchError(
                 message="message",
-                linenumber=2,
+                lineno=2,
                 details="",
                 filename=Lintable("filename.yml", content=""),
                 rule=self.rule,
@@ -114,7 +114,7 @@ class TestSarifFormatter:
             )
             assert (
                 result["locations"][0]["physicalLocation"]["region"]["startLine"]
-                == self.matches[i].linenumber
+                == self.matches[i].lineno
             )
             if self.matches[i].column:
                 assert (

--- a/test/test_rules_collection.py
+++ b/test/test_rules_collection.py
@@ -63,7 +63,7 @@ def test_run_collection(
     """Test that default rules match pre-meditated violations."""
     matches = test_rules_collection.run(ematchtestfile)
     assert len(matches) == 4  # 3 occurrences of BANNED using TEST0001 + 1 for raw-task
-    assert matches[0].linenumber == 3
+    assert matches[0].lineno == 3
 
 
 def test_tags(

--- a/test/test_yaml_utils.py
+++ b/test/test_yaml_utils.py
@@ -277,7 +277,7 @@ def fixture_ruamel_data(lintable: Lintable) -> CommentedMap | CommentedSeq:
 
 
 @pytest.mark.parametrize(
-    ("file_path", "line_number", "expected_path"),
+    ("file_path", "lineno", "expected_path"),
     (
         # ignored lintables
         pytest.param(
@@ -504,21 +504,21 @@ def fixture_ruamel_data(lintable: Lintable) -> CommentedMap | CommentedSeq:
 )
 def test_get_path_to_play(
     lintable: Lintable,
-    line_number: int,
+    lineno: int,
     ruamel_data: CommentedMap | CommentedSeq,
     expected_path: list[int | str],
 ) -> None:
     """Ensure ``get_path_to_play`` returns the expected path given a file + line."""
     path_to_play = ansiblelint.yaml_utils.get_path_to_play(
         lintable,
-        line_number,
+        lineno,
         ruamel_data,
     )
     assert path_to_play == expected_path
 
 
 @pytest.mark.parametrize(
-    ("file_path", "line_number", "expected_path"),
+    ("file_path", "lineno", "expected_path"),
     (
         # ignored lintables
         pytest.param("examples/playbooks/vars/other.yml", 2, [], id="ignore_vars_file"),
@@ -877,21 +877,21 @@ def test_get_path_to_play(
 )
 def test_get_path_to_task(
     lintable: Lintable,
-    line_number: int,
+    lineno: int,
     ruamel_data: CommentedMap | CommentedSeq,
     expected_path: list[int | str],
 ) -> None:
     """Ensure ``get_task_to_play`` returns the expected path given a file + line."""
     path_to_task = ansiblelint.yaml_utils.get_path_to_task(
         lintable,
-        line_number,
+        lineno,
         ruamel_data,
     )
     assert path_to_task == expected_path
 
 
 @pytest.mark.parametrize(
-    ("file_path", "line_number"),
+    ("file_path", "lineno"),
     (
         pytest.param("examples/playbooks/become.yml", 0, id="1_play_playbook"),
         pytest.param(
@@ -903,34 +903,34 @@ def test_get_path_to_task(
         pytest.param("examples/playbooks/become.yml", 0, id="1_task_playbook"),
     ),
 )
-def test_get_path_to_play_raises_value_error_for_bad_line_number(
+def test_get_path_to_play_raises_value_error_for_bad_lineno(
     lintable: Lintable,
-    line_number: int,
+    lineno: int,
     ruamel_data: CommentedMap | CommentedSeq,
 ) -> None:
-    """Ensure ``get_path_to_play`` raises ValueError for line_number < 1."""
+    """Ensure ``get_path_to_play`` raises ValueError for lineno < 1."""
     with pytest.raises(
         ValueError,
-        match=f"expected line_number >= 1, got {line_number}",
+        match=f"expected lineno >= 1, got {lineno}",
     ):
-        ansiblelint.yaml_utils.get_path_to_play(lintable, line_number, ruamel_data)
+        ansiblelint.yaml_utils.get_path_to_play(lintable, lineno, ruamel_data)
 
 
 @pytest.mark.parametrize(
-    ("file_path", "line_number"),
+    ("file_path", "lineno"),
     (pytest.param("examples/roles/more_complex/tasks/main.yml", 0, id="tasks"),),
 )
-def test_get_path_to_task_raises_value_error_for_bad_line_number(
+def test_get_path_to_task_raises_value_error_for_bad_lineno(
     lintable: Lintable,
-    line_number: int,
+    lineno: int,
     ruamel_data: CommentedMap | CommentedSeq,
 ) -> None:
-    """Ensure ``get_task_to_play`` raises ValueError for line_number < 1."""
+    """Ensure ``get_task_to_play`` raises ValueError for lineno < 1."""
     with pytest.raises(
         ValueError,
-        match=f"expected line_number >= 1, got {line_number}",
+        match=f"expected lineno >= 1, got {lineno}",
     ):
-        ansiblelint.yaml_utils.get_path_to_task(lintable, line_number, ruamel_data)
+        ansiblelint.yaml_utils.get_path_to_task(lintable, lineno, ruamel_data)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Uses lineno like python core itself instead of linenumber and line_number and prevents further use of it.

On python code there were >4700 occurrences of lineno, and the other two variants had less than 100 each.

Note that this translate into API change, as it might affect users of custom rules.
