### PR TITLE
Remove useless . from additional_dependencies in pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -16,5 +16,4 @@
     # If you want to use specific version of ansible-core or ansible, feel
     # free to override `additional_dependencies` in your own hook config
     # file.
-    - .
     - ansible-core>=2.13.3


### PR DESCRIPTION
I was looking at `.pre-commit-hooks.yaml` and noticed the following construct:

```yaml
additional_dependencies:
  - .
```

Wondering what the `.` (dot, period) means, I asked on Stack Overflow [here](https://stackoverflow.com/q/76086122/7391331). I got an answer. According to author of pre-commit the `.` does nothing and can be removed.

> in this case it does nothing, it is a mistake. I believe an older version of this was selecting specific extras like .[core] and this is an artifact of that
>
>. is always installed and is the hook repository (in this case ansible-lint)

So this pull request removes the `.`.
