### PR TITLE
Remove `G` from ruff ignores

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -225,7 +225,6 @@ ignore = [
   "SIM",
   "BLE",
   "D",
-  "G",
   "RET",
   "N",
   "EM",

--- a/src/ansiblelint/logger.py
+++ b/src/ansiblelint/logger.py
@@ -16,7 +16,7 @@ def timed_info(msg: Any, *args: Any) -> Iterator[None]:
         yield
     finally:
         elapsed = time.time() - start
-        _logger.info(msg, " (%.2fs)", *(*args, elapsed))
+        _logger.info(msg + " (%.2fs)", *(*args, elapsed))  # noqa: G003
 
 
 def warn_or_fail(message: str) -> None:

--- a/src/ansiblelint/logger.py
+++ b/src/ansiblelint/logger.py
@@ -16,7 +16,7 @@ def timed_info(msg: Any, *args: Any) -> Iterator[None]:
         yield
     finally:
         elapsed = time.time() - start
-        _logger.info(msg + " (%.2fs)", *(*args, elapsed))
+        _logger.info("%s (%.2fs)", msg, *(*args, elapsed))
 
 
 def warn_or_fail(message: str) -> None:

--- a/src/ansiblelint/logger.py
+++ b/src/ansiblelint/logger.py
@@ -16,7 +16,7 @@ def timed_info(msg: Any, *args: Any) -> Iterator[None]:
         yield
     finally:
         elapsed = time.time() - start
-        _logger.info("%s (%.2fs)", msg, *(*args, elapsed))
+        _logger.info(msg, " (%.2fs)", *(*args, elapsed))
 
 
 def warn_or_fail(message: str) -> None:

--- a/src/ansiblelint/skip_utils.py
+++ b/src/ansiblelint/skip_utils.py
@@ -97,7 +97,7 @@ def append_skipped_rules(
         yaml_skip = _append_skipped_rules(pyyaml_data, lintable)
     except RuntimeError:
         # Notify user of skip error, do not stop, do not change exit code
-        _logger.error("Error trying to append skipped rules", exc_info=True)
+        _logger.exception("Error trying to append skipped rules")
         return pyyaml_data
 
     if not yaml_skip:


### PR DESCRIPTION
While logging, use `_logger.exception` that bydefault uses log level of error and eliminates the need
to use `exc_info=True` as this bydefault captures the full stack trace.

Using `# noqa: G003` as other string logging format options are also not supported 
by ruff: https://beta.ruff.rs/docs/rules/#flake8-logging-format-g