### PR TITLE
Remove `ISC` from ruff ignores

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,7 +237,6 @@ ignore = [
   "EXE",
   "FBT",
   "INP",
-  "ISC",
   "PGH",
   "PTH",
   "PLR",

--- a/src/ansiblelint/cli.py
+++ b/src/ansiblelint/cli.py
@@ -17,11 +17,7 @@ from ansiblelint.config import (
     Options,
     log_entries,
 )
-from ansiblelint.constants import (
-    CUSTOM_RULESDIR_ENVVAR,
-    DEFAULT_RULESDIR,
-    RC,
-)
+from ansiblelint.constants import CUSTOM_RULESDIR_ENVVAR, DEFAULT_RULESDIR, RC
 from ansiblelint.file_utils import (
     Lintable,
     abspath,
@@ -428,7 +424,7 @@ def get_cli_parser() -> argparse.ArgumentParser:
         action=AbspathArgAction,
         type=Path,
         default=[],
-        help="path to directories or files to skip. " "This option is repeatable.",
+        help="path to directories or files to skip. This option is repeatable.",
     )
     parser.add_argument(
         "-c",

--- a/src/ansiblelint/rules/deprecated_bare_vars.py
+++ b/src/ansiblelint/rules/deprecated_bare_vars.py
@@ -92,10 +92,7 @@ class UsingBareVariablesIsDeprecatedRule(AnsibleLintRule):
                 has_jinja(varstring) or varstring.endswith(os.sep),
             )
             if not valid:
-                message = (
-                    "Possible bare variable '{0}' used in a '{1}' loop."
-                    + " You should use the full variable syntax ('{{{{ {0} }}}}') or convert it to a list if that is not really a variable."
-                )
+                message = "Possible bare variable '{0}' used in a '{1}' loop. You should use the full variable syntax ('{{{{ {0} }}}}') or convert it to a list if that is not really a variable."
                 return message.format(task[loop_type], loop_type)
         return False
 

--- a/test/rules/fixtures/ematcher.py
+++ b/test/rules/fixtures/ematcher.py
@@ -7,7 +7,7 @@ class EMatcherRule(AnsibleLintRule):
 
     id = "TEST0001"
     description = (
-        "This is a test custom rule that looks for lines " + "containing BANNED string"
+        "This is a test custom rule that looks for lines containing BANNED string"
     )
     tags = ["fake", "dummy", "test1"]
 

--- a/test/rules/fixtures/unset_variable_matcher.py
+++ b/test/rules/fixtures/unset_variable_matcher.py
@@ -7,8 +7,7 @@ class UnsetVariableMatcherRule(AnsibleLintRule):
 
     id = "TEST0002"
     description = (
-        "This is a test rule that looks for lines "
-        + "post templating that still contain {{"
+        "This is a test rule that looks for lines post templating that still contain {{"
     )
     tags = ["fake", "dummy", "test2"]
 

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -63,7 +63,7 @@ def test_get_version_warning(
     outlen: int,
 ) -> None:
     """Assert get_version_warning working as expected."""
-    data = '{"html_url": "https://127.0.0.1", "tag_name": "' + f"{ver_diff}" + '"}'
+    data = f'{{"html_url": "https://127.0.0.1", "tag_name": "{ver_diff}"}}'
     # simulate cache file
     mocker.patch("os.path.exists", return_value=True)
     mocker.patch("os.path.getmtime", return_value=time.time())


### PR DESCRIPTION
String concatenation refactoring in order to address ISC from ruff ignores.