### PR TITLE
Correct docs on navigator schema location

### DIFF
--- a/src/ansiblelint/rules/schema.md
+++ b/src/ansiblelint/rules/schema.md
@@ -22,13 +22,6 @@ project:
 
 - `schema[ansible-lint-config]` validates
   [ansible-lint configuration](https://github.com/ansible/ansible-lint/blob/main/src/ansiblelint/schemas/ansible-lint-config.json)
-
-Maintained in the
-[ansible-navigator](https://github.com/ansible/ansible-navigator) project:
-
-- `schema[ansible-navigator]` validates
-  [ansible-navigator configuration](https://github.com/ansible/ansible-navigator/blob/main/src/ansible_navigator/data/ansible-navigator.json)
-
 - `schema[role-arg-spec]` validates
   [role argument specs](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_reuse_roles.html#specification-format)
   which is a little bit different than the module argument spec.
@@ -55,6 +48,12 @@ Maintained in the
 - `schema[vars]` validates Ansible
   [variables](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_variables.html)
   that match `vars/*.yml` and `defaults/*.yml`.
+
+Maintained in the
+[ansible-navigator](https://github.com/ansible/ansible-navigator) project:
+
+- `schema[ansible-navigator]` validates
+  [ansible-navigator configuration](https://github.com/ansible/ansible-navigator/blob/main/src/ansible_navigator/data/ansible-navigator.json)
 
 ## schema[meta]
 


### PR DESCRIPTION
In https://github.com/ansible/ansible-lint/commit/8885f24d3aeb0265b2b2a682337859a185492e48#diff-4910f943dc71017d97500400fb0d65754d420a07569861bdfc8c5c841978d5a8 the schemas project was assimilated, but the docs changed on a way that they misleadingly make you think they were assimilated into `ansible-navigator` instead.