### PR TITLE
Add Amazon Linux 2023 as a supported platform

### DIFF
--- a/src/ansiblelint/schemas/meta.json
+++ b/src/ansiblelint/schemas/meta.json
@@ -91,6 +91,25 @@
       "title": "Amazon Linux 2PlatformModel",
       "type": "object"
     },
+    "Amazon_Linux_2023PlatformModel": {
+      "properties": {
+        "name": {
+          "const": "Amazon Linux 2023",
+          "title": "Name",
+          "type": "string"
+        },
+        "versions": {
+          "default": "all",
+          "items": {
+            "enum": ["all"],
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "title": "Amazon Linux 2023PlatformModel",
+      "type": "object"
+    },
     "ArchLinuxPlatformModel": {
       "properties": {
         "name": {

--- a/src/ansiblelint/schemas/meta.json
+++ b/src/ansiblelint/schemas/meta.json
@@ -72,36 +72,17 @@
       "title": "AmazonPlatformModel",
       "type": "object"
     },
-    "Amazon_Linux_2023PlatformModel": {
+    "AmazonLinuxPlatformModel": {
       "properties": {
         "name": {
-          "const": "Amazon Linux 2023",
+          "const": "Amazon Linux",
           "title": "Name",
           "type": "string"
         },
         "versions": {
           "default": "all",
           "items": {
-            "enum": ["all"],
-            "type": "string"
-          },
-          "type": "array"
-        }
-      },
-      "title": "Amazon Linux 2023PlatformModel",
-      "type": "object"
-    },
-    "Amazon_Linux_2PlatformModel": {
-      "properties": {
-        "name": {
-          "const": "Amazon Linux 2",
-          "title": "Name",
-          "type": "string"
-        },
-        "versions": {
-          "default": "all",
-          "items": {
-            "enum": ["all"],
+            "enum": ["all", "1", "2", "2013"],
             "type": "string"
           },
           "type": "array"
@@ -1225,7 +1206,7 @@
             "$ref": "#/$defs/AmazonPlatformModel"
           },
           {
-            "$ref": "#/$defs/Amazon_Linux_2PlatformModel"
+            "$ref": "#/$defs/AmazonLinuxPlatformModel"
           },
           {
             "$ref": "#/$defs/aosPlatformModel"

--- a/src/ansiblelint/schemas/meta.json
+++ b/src/ansiblelint/schemas/meta.json
@@ -72,25 +72,6 @@
       "title": "AmazonPlatformModel",
       "type": "object"
     },
-    "Amazon_Linux_2PlatformModel": {
-      "properties": {
-        "name": {
-          "const": "Amazon Linux 2",
-          "title": "Name",
-          "type": "string"
-        },
-        "versions": {
-          "default": "all",
-          "items": {
-            "enum": ["all"],
-            "type": "string"
-          },
-          "type": "array"
-        }
-      },
-      "title": "Amazon Linux 2PlatformModel",
-      "type": "object"
-    },
     "Amazon_Linux_2023PlatformModel": {
       "properties": {
         "name": {
@@ -108,6 +89,25 @@
         }
       },
       "title": "Amazon Linux 2023PlatformModel",
+      "type": "object"
+    },
+    "Amazon_Linux_2PlatformModel": {
+      "properties": {
+        "name": {
+          "const": "Amazon Linux 2",
+          "title": "Name",
+          "type": "string"
+        },
+        "versions": {
+          "default": "all",
+          "items": {
+            "enum": ["all"],
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "title": "Amazon Linux 2PlatformModel",
       "type": "object"
     },
     "ArchLinuxPlatformModel": {

--- a/src/ansiblelint/schemas/meta.json
+++ b/src/ansiblelint/schemas/meta.json
@@ -38,6 +38,25 @@
       "title": "AlpinePlatformModel",
       "type": "object"
     },
+    "AmazonLinuxPlatformModel": {
+      "properties": {
+        "name": {
+          "const": "Amazon Linux",
+          "title": "Name",
+          "type": "string"
+        },
+        "versions": {
+          "default": "all",
+          "items": {
+            "enum": ["all", "1", "2", "2023"],
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "title": "Amazon Linux 2PlatformModel",
+      "type": "object"
+    },
     "AmazonPlatformModel": {
       "properties": {
         "name": {
@@ -70,25 +89,6 @@
         }
       },
       "title": "AmazonPlatformModel",
-      "type": "object"
-    },
-    "AmazonLinuxPlatformModel": {
-      "properties": {
-        "name": {
-          "const": "Amazon Linux",
-          "title": "Name",
-          "type": "string"
-        },
-        "versions": {
-          "default": "all",
-          "items": {
-            "enum": ["all", "1", "2", "2013"],
-            "type": "string"
-          },
-          "type": "array"
-        }
-      },
-      "title": "Amazon Linux 2PlatformModel",
       "type": "object"
     },
     "ArchLinuxPlatformModel": {


### PR DESCRIPTION
Amazon Linux 2023 is a supported platform on Ansible Galaxy now - 
![image](https://user-images.githubusercontent.com/6969296/236513041-adcf7ef9-a6a6-4c4f-a0ce-3714cac3ce20.png)

https://galaxy.ansible.com/api/v1/platforms/?search=Amazon+Linux+2023

So add the platform to ansible-lint's meta checks. And fix these failing linting errors that should pass :) 

https://github.com/artis3n/ansible-role-tailscale/actions/runs/4873967123/jobs/8694284112?pr=329#step:6:16

Fixes: #3411