### PR TITLE
Ensure that we also lint files from git submodules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -151,6 +151,7 @@ repos:
           - cryptography>=39.0.1
           - filelock
           - jinja2
+          - pytest-mock
           - pytest>=7.2.2
           - rich>=13.2.0
           - ruamel-yaml>=0.17.26
@@ -180,6 +181,7 @@ repos:
           - docutils
           - filelock
           - jsonschema>=4.9.0
+          - pytest-mock
           - pytest>=7.2.2
           - pyyaml
           - rich>=13.2.0

--- a/src/ansiblelint/schemas/__store__.json
+++ b/src/ansiblelint/schemas/__store__.json
@@ -24,7 +24,7 @@
     "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/inventory.json"
   },
   "meta": {
-    "etag": "7cbcda4e9454961d843f5b2b37349bafdf387d01e8ad6772e0a4c89868aaa55c",
+    "etag": "24aa044eddbf2fc92e31775bcc625fd8e7689cb14542ac59c0e3b94d9a9b163a",
     "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/meta.json"
   },
   "meta-runtime": {

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -5,9 +5,9 @@ import subprocess
 import sys
 import time
 from pathlib import Path
-from typing import Any
 
 import pytest
+from pytest_mock import MockerFixture
 
 from ansiblelint.config import get_version_warning
 
@@ -58,7 +58,7 @@ def test_call_from_outside_venv(expected_warning: bool) -> None:
     ),
 )
 def test_get_version_warning(
-    mocker: Any,
+    mocker: MockerFixture,
     ver_diff: str,
     found: bool,
     check: str,

--- a/test/test_mockings.py
+++ b/test/test_mockings.py
@@ -1,12 +1,17 @@
 """Test mockings module."""
+from typing import Any
+
 import pytest
 
 from ansiblelint._mockings import _make_module_stub
+from ansiblelint.config import options
 from ansiblelint.constants import RC
 
 
-def test_make_module_stub() -> None:
+def test_make_module_stub(mocker: Any) -> None:
     """Test make module stub."""
+    mocker.patch("ansiblelint.config.options.cache_dir", return_value=".")
+    assert options.cache_dir is not None
     with pytest.raises(SystemExit) as exc:
         _make_module_stub("")
     assert exc.type == SystemExit

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -301,8 +301,7 @@ def test_cli_auto_detect(capfd: CaptureFixture[str]) -> None:
     out, err = capfd.readouterr()
 
     # Confirmation that it runs in auto-detect mode
-    assert "Discovered files to lint using: git" in err
-    assert "Excluded removed files using: git" in err
+    assert "Discovered files to lint using git" in err
     # An expected rule match from our examples
     assert (
         "examples/playbooks/empty_playbook.yml:1:1: "


### PR DESCRIPTION
Initial implementation based on git tracked files did not look into submodules. From now on, we would also look into submodules and report the outcomes.
