### PR TITLE
Suggest correct alternative for `with_filetree`

### DIFF
--- a/src/ansiblelint/rules/schema.py
+++ b/src/ansiblelint/rules/schema.py
@@ -37,7 +37,7 @@ pre_checks = {
             "tag": "moves",
         },
         "with_filetree": {
-            "msg": "with_filetree was moved to with_community.general.flattened in 2.10",
+            "msg": "with_filetree was moved to with_community.general.filetree in 2.10",
             "tag": "moves",
         },
         "with_cartesian": {


### PR DESCRIPTION
When using the lookup plugin `with_filetree` in a task such as this:

```yaml
- name: Create configuration files
  ansible.builtin.copy:
    src: "{{ item.src }}"
    dest: "{{ config_directory }}/{{ item.path }}"
    mode: u=rw,g=r,o=r
  with_filetree: data/
  when: item.state == "file"
```

Ansible Lint (both v6.16.0 and the latest `main`) will give the following error:

```
schema[moves]: with_filetree was moved to with_community.general.flattened in 2.10
```

This suggestion is not correct, the correct alternative should be `with_community.general.filetree`.