### PR TITLE
Add Kali Linux as a supported platform

### DIFF
--- a/src/ansiblelint/schemas/meta.json
+++ b/src/ansiblelint/schemas/meta.json
@@ -662,6 +662,36 @@
       "title": "JunosPlatformModel",
       "type": "object"
     },
+    "KaliPlatformModel": {
+      "properties": {
+        "name": {
+          "const": "Kali",
+          "title": "Name",
+          "type": "string"
+        },
+        "versions": {
+          "default": "all",
+          "items": {
+            "enum": [
+              "2.0",
+              "2016",
+              "2017",
+              "2018",
+              "2019",
+              "2020",
+              "2021",
+              "2022",
+              "2023",
+              "all"
+            ],
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "title": "KaliPlatformModel",
+      "type": "object"
+    },
     "MacOSXPlatformModel": {
       "properties": {
         "name": {
@@ -1264,6 +1294,9 @@
           },
           {
             "$ref": "#/$defs/JunosPlatformModel"
+          },
+          {
+            "$ref": "#/$defs/KaliPlatformModel"
           },
           {
             "$ref": "#/$defs/macOSPlatformModel"


### PR DESCRIPTION
Kali LInux is a supported platform as of the close of https://github.com/ansible/galaxy/issues/3059 and this can be verified at https://galaxy.ansible.com/api/v1/platforms/?search=Kali. This pull request adds it to the metadata schema so that roles listing it as a supported platform can pass linting.