### PR TITLE
Adding 2.16 to the list of allowed ansible-core versions in meta-runtime rule

### DIFF
--- a/src/ansiblelint/rules/meta_runtime.md
+++ b/src/ansiblelint/rules/meta_runtime.md
@@ -14,6 +14,7 @@ Currently supported versions of ansible-core are:
 - `2.13.x`
 - `2.14.x`
 - `2.15.x`
+- `2.16.x` (in development)
 
 This rule can produce messages such as:
 

--- a/src/ansiblelint/rules/meta_runtime.py
+++ b/src/ansiblelint/rules/meta_runtime.py
@@ -30,7 +30,7 @@ class CheckRequiresAnsibleVersion(AnsibleLintRule):
 
     # Refer to https://access.redhat.com/support/policy/updates/ansible-automation-platform
     # Also add devel to this list
-    supported_ansible = ["2.9.10", "2.11.", "2.12.", "2.13.", "2.14.", "2.15."]
+    supported_ansible = ["2.9.10", "2.11.", "2.12.", "2.13.", "2.14.", "2.15.", "2.16."]
 
     def matchyaml(self, file: Lintable) -> list[MatchError]:
         """Find violations inside meta files.


### PR DESCRIPTION
Adding `2.16.` to the list of allowed versions in the `meta-runtime` rule, now that ansible-core 2.15.0 is GA and ansible:devel is 2.16.x.

List in the `meta-runtime` rule is now: `["2.9.10", "2.11.", "2.12.", "2.13.", "2.14.", "2.15.", "2.16."]`