### PR TITLE
Fix for var-naming rule to not break on include_tasks and vars

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -59,7 +59,7 @@ jobs:
       WSLENV: FORCE_COLOR:PYTEST_REQPASS:TOXENV:GITHUB_STEP_SUMMARY
       # Number of expected test passes, safety measure for accidental skip of
       # tests. Update value if you add/remove tests.
-      PYTEST_REQPASS: 797
+      PYTEST_REQPASS: 798
     steps:
       - name: Activate WSL1
         if: "contains(matrix.shell, 'wsl')"

--- a/examples/playbooks/tasks/included-task-with-vars.yml
+++ b/examples/playbooks/tasks/included-task-with-vars.yml
@@ -1,0 +1,4 @@
+---
+- name: included-task-with-vars | Test
+  ansible.builtin.debug:
+    msg: "{{ foo }}"

--- a/examples/roles/var_naming_pattern/tasks/include_task_with_vars.yml
+++ b/examples/roles/var_naming_pattern/tasks/include_task_with_vars.yml
@@ -1,0 +1,5 @@
+---
+- name: include_task_with_vars | Foo
+  ansible.builtin.include_tasks: ../tasks/included-task-with-vars.yml
+  vars:
+    var_naming_pattern_foo: bar

--- a/src/ansiblelint/rules/var_naming.py
+++ b/src/ansiblelint/rules/var_naming.py
@@ -10,7 +10,7 @@ from ansible.parsing.yaml.objects import AnsibleUnicode
 from ansible.vars.reserved import get_reserved_names
 
 from ansiblelint.config import options
-from ansiblelint.constants import LINE_NUMBER_KEY, RC
+from ansiblelint.constants import ANNOTATION_KEYS, LINE_NUMBER_KEY, RC
 from ansiblelint.errors import MatchError
 from ansiblelint.file_utils import Lintable
 from ansiblelint.rules import AnsibleLintRule, RulesCollection
@@ -48,6 +48,9 @@ class VariableNamingRule(AnsibleLintRule):
                 message="Variables names must be strings.",
                 rule=self,
             )
+
+        if ident in ANNOTATION_KEYS:
+            return None
 
         try:
             ident.encode("ascii")
@@ -262,5 +265,12 @@ if "pytest" in sys.modules:
             f"--config-file={conf_path}",
             role_path,
         )
+        assert result.returncode == RC.SUCCESS
+        assert "var-naming" not in result.stdout
+
+    def test_var_naming_with_include_tasks_and_vars() -> None:
+        """Test with include tasks and vars."""
+        role_path = "examples/roles/var_naming_pattern/tasks/include_task_with_vars.yml"
+        result = run_ansible_lint(role_path)
         assert result.returncode == RC.SUCCESS
         assert "var-naming" not in result.stdout

--- a/src/ansiblelint/yaml_utils.py
+++ b/src/ansiblelint/yaml_utils.py
@@ -27,7 +27,6 @@ from ansiblelint.constants import (
     ANNOTATION_KEYS,
     NESTED_TASK_KEYS,
     PLAYBOOK_TASK_KEYWORDS,
-    SKIPPED_RULES_KEY,
 )
 from ansiblelint.utils import Task
 
@@ -212,7 +211,7 @@ def _nested_items_path(
         msg = f"Expected a dict or a list but got {data_collection!r} of type '{type(data_collection)}'"
         raise TypeError(msg)
     for key, value in convert_data_collection_to_tuples():
-        if key in (SKIPPED_RULES_KEY, "__file__", "__line__", *ignored_keys):
+        if key in (*ANNOTATION_KEYS, *ignored_keys):
             continue
         yield key, value, parent_path
         if isinstance(value, (dict, list)):


### PR DESCRIPTION
Fixes: #3453
