### PR TITLE
var-naming now prevents use of Ansible reserved names

### DIFF
--- a/examples/playbooks/vars/rule_var_naming_fail.yml
+++ b/examples/playbooks/vars/rule_var_naming_fail.yml
@@ -6,5 +6,6 @@ this_is_valid: # valid because content is a dict, not a variable
 ALL_CAPS_ARE_BAD_TOO: ... # invalid
 "{{ 'test_' }}var": "value" # noqa: schema
 CamelCaseButErrorIgnored: true # noqa: var-naming
-assert: true # invalid due to reserved keyword
+assert: true # invalid due to being Python reserved keyword
 é: true # invalid due to non-ascii character
+hosts: true # invalid as being Ansible reserved name

--- a/src/ansiblelint/rules/var_naming.md
+++ b/src/ansiblelint/rules/var_naming.md
@@ -18,6 +18,7 @@ Possible errors messages:
 - `var-naming[pattern]`: Variables names should match ... regex.
 - `var-naming[no-role-prefix]`: Variables names from within roles should use
   `role_name_` as a prefix.
+- `var-naming[no-reserved]`: Variables names must not be Ansible reserved names.
 
 ## Settings
 
@@ -38,6 +39,7 @@ var_naming_pattern: "^[a-z_][a-z0-9_]*$"
     CamelCase: true # <- Contains a mix of lowercase and uppercase characters.
     ALL_CAPS: bar # <- Contains only uppercase characters.
     v@r!able: baz # <- Contains special characters.
+    hosts: [] # <- hosts is an Ansible reserved name
 ```
 
 ## Correct Code
@@ -50,6 +52,7 @@ var_naming_pattern: "^[a-z_][a-z0-9_]*$"
     lowercase: true # <- Contains only lowercase characters.
     no_caps: bar # <- Does not contains uppercase characters.
     variable: baz # <- Does not contain special characters.
+    my_hosts: [] # <- Does not use a reserved names.
 ```
 
 [cop]: https://redhat-cop.github.io/automation-good-practices/#_naming_things

--- a/src/ansiblelint/runner.py
+++ b/src/ansiblelint/runner.py
@@ -147,7 +147,6 @@ class Runner:
                         )
                     else:
                         filename = warn.source
-                        # breakpoint()
                         match = MatchError(
                             message=warn.message
                             if isinstance(warn.message, str)


### PR DESCRIPTION
Related: #3456
