### PR TITLE
Do not ever exclude files given as arguments

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -59,7 +59,7 @@ jobs:
       WSLENV: FORCE_COLOR:PYTEST_REQPASS:TOXENV:GITHUB_STEP_SUMMARY
       # Number of expected test passes, safety measure for accidental skip of
       # tests. Update value if you add/remove tests.
-      PYTEST_REQPASS: 799
+      PYTEST_REQPASS: 800
     steps:
       - name: Activate WSL1
         if: "contains(matrix.shell, 'wsl')"

--- a/examples/playbooks/deep/empty.yml
+++ b/examples/playbooks/deep/empty.yml
@@ -1,0 +1,4 @@
+---
+- name: some playbook with incorrect name # <- should raise name[casing]
+  hosts: localhost
+  tasks: []

--- a/src/ansiblelint/file_utils.py
+++ b/src/ansiblelint/file_utils.py
@@ -197,6 +197,7 @@ class Lintable:
         self.line_skips: dict[int, set[str]] = defaultdict(set)
         self.exc: Exception | None = None  # Stores data loading exceptions
         self.parent = parent
+        self.explicit = False  # Indicates if the file was explicitly provided or was indirectly included.
 
         if isinstance(name, str):
             name = Path(name)

--- a/src/ansiblelint/schemas/__store__.json
+++ b/src/ansiblelint/schemas/__store__.json
@@ -1,6 +1,6 @@
 {
   "ansible-lint-config": {
-    "etag": "0c180fc60da7bfbbf70d0ffa6dd4871aefce5e6f987f9c8073cb203dacd991b2",
+    "etag": "b5caa5405047dad89bb9fb419a17d8a67750f3a7ecdbabe16e0eb1897d316c5a",
     "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/ansible-lint-config.json"
   },
   "ansible-navigator-config": {


### PR DESCRIPTION
If a file or folder is given as an argument to the linter, it will be treated as explicit and exclude rules will not apply to it.

This will allow linting of files outside current project too.

Fixes: #2628
