### PR TITLE
Hide pip error if not present

### DIFF
--- a/src/ansiblelint/config.py
+++ b/src/ansiblelint/config.py
@@ -232,8 +232,9 @@ def guess_install_method() -> str:
                 logging.debug("Skipping %s as it is not installed.", package_name)
                 use_pip = False
     # pylint: disable=broad-except
-    except AttributeError as exc:
+    except (AttributeError, ModuleNotFoundError) as exc:
         # On Fedora 36, we got a AttributeError exception from pip that we want to avoid
+        # On NixOS, we got a ModuleNotFoundError exception from pip that we want to avoid
         logging.debug(exc)
         use_pip = False
 


### PR DESCRIPTION
```python
    ansible-lint 6.16.1 using ansible-core:2.15.0 ruamel-yaml:0.17.26 ruamel-yaml-clib:0.2.7
    Traceback (most recent call last):
      File "/nix/store/2cc72ssf4x1j646zgn8kfyp5kb3f1c0r-ansible-lint-6.16.1/bin/.ansible-lint-wrapped", line 9, in <module>
        sys.exit(_run_cli_entrypoint())
      File "/nix/store/2cc72ssf4x1j646zgn8kfyp5kb3f1c0r-ansible-lint-6.16.1/lib/python3.10/site-packages/ansiblelint/__main__.py", line 310, in _run_cli_entrypoint
        sys.exit(main(sys.argv))
      File "/nix/store/2cc72ssf4x1j646zgn8kfyp5kb3f1c0r-ansible-lint-6.16.1/lib/python3.10/site-packages/ansiblelint/__main__.py", line 223, in main
        msg = get_version_warning()
      File "/nix/store/2cc72ssf4x1j646zgn8kfyp5kb3f1c0r-ansible-lint-6.16.1/lib/python3.10/site-packages/ansiblelint/config.py", line 302, in get_version_warning
        pip = guess_install_method()
      File "/nix/store/2cc72ssf4x1j646zgn8kfyp5kb3f1c0r-ansible-lint-6.16.1/lib/python3.10/site-packages/ansiblelint/config.py", line 223, in guess_install_method
        from pip._internal.metadata import get_default_environment
    ModuleNotFoundError: No module named 'pip'
```