### PR TITLE
exclude .github directory

### DIFF
--- a/src/ansiblelint/cli.py
+++ b/src/ansiblelint/cli.py
@@ -476,7 +476,7 @@ def merge_config(file_config: dict[Any, Any], cli_config: Options) -> Options:
     )
     # maps lists to their default config values
     lists_map = {
-        "exclude_paths": [".cache", ".git", ".hg", ".svn", ".tox"],
+        "exclude_paths": [".cache", ".git", ".github", ".hg", ".svn", ".tox"],
         "rulesdir": [],
         "skip_list": [],
         "tags": [],


### PR DESCRIPTION
This PR:
- adds the `.github`  directory to the exclude list.

```sh
$ ansible-lint
WARNING  Listing 7 violation(s) that are fatal
yaml[truthy]: Truthy value should be one of [false, true]
.github/workflows/issues.yml:3

yaml[truthy]: Truthy value should be one of [false, true]
.github/workflows/lint.yml:1

yaml[truthy]: Truthy value should be one of [false, true]
.github/workflows/schedlint.yml:1

yaml[truthy]: Truthy value should be one of [false, true]
.github/workflows/schedmainlint.yml:2

yaml[truthy]: Truthy value should be one of [false, true]
.github/workflows/scorecards.yml:2

yaml[brackets]: Too many spaces inside brackets
.github/workflows/scorecards.yml:8

yaml[truthy]: Truthy value should be one of [false, true]
.github/workflows/slsa.yml:3

Read documentation for instructions on how to ignore specific rule violations.

              Rule Violation Summary
 count tag            profile rule associated tags
     1 yaml[brackets] basic   formatting, yaml
     6 yaml[truthy]   basic   formatting, yaml

Failed after min profile: 7 failure(s), 0 warning(s) on 44 files.
```
