### PR TITLE
Make refresh_schemas handle firewalls that cut the file transfer midway

### DIFF
--- a/src/ansiblelint/schemas/__main__.py
+++ b/src/ansiblelint/schemas/__main__.py
@@ -7,6 +7,7 @@ import time
 import urllib.request
 from collections import defaultdict
 from functools import cache
+from http.client import HTTPException
 from pathlib import Path
 from typing import Any
 from urllib.request import Request
@@ -88,7 +89,7 @@ def refresh_schemas(min_age_seconds: int = 3600 * 24) -> int:
                         # unload possibly loaded schema
                         if kind in _schema_cache:  # pragma: no cover
                             del _schema_cache[kind]
-        except (ConnectionError, OSError) as exc:
+        except (ConnectionError, OSError, HTTPException) as exc:
             if (
                 isinstance(exc, urllib.error.HTTPError)
                 and getattr(exc, "code", None) == 304


### PR DESCRIPTION
Our inspecting firewall has a tendency to cut connections in the middle of transfers. `refresh_schemas` has mechanisms to detect some such behaviors, and falling back to using the already existing schemas. It does not, however, handle the `http.client.IncompleteRead` exception that shows up in our case:

```text
$ ansible-lint --version
ansible-lint 6.16.0 using ansible 2.14.6

$ ansible-lint $ANSIBLE_LINT_CLI_OPTS -x yaml $ANSIBLE_LINT_LINTABLES
  :
Traceback (most recent call last):
  File "/usr/local/bin/ansible-lint", line 8, in <module>
    sys.exit(_run_cli_entrypoint())
             ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/ansiblelint/__main__.py", line 291, in _run_cli_entrypoint
    sys.exit(main(sys.argv))
             ^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/ansiblelint/__main__.py", line 232, in main
    refresh_schemas()
  File "/usr/local/lib/python3.11/site-packages/ansiblelint/schemas/__main__.py", line 78, in refresh_schemas
    content = response.read().decode("utf-8").rstrip()
              ^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/http/client.py", line 482, in read
    s = self._safe_read(self.length)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/http/client.py", line 633, in _safe_read
    raise IncompleteRead(data, amt-len(data))
http.client.IncompleteRead: IncompleteRead(26510 bytes read, 7406 more expected)
```

This PR adds `http.client.HTTPException` (super class of `IncompleteRead`) to the exceptions that will lead to ansible-lint continuing gracefully for partial reads.
