### PR TITLE
Rename marketplace action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 ---
-name: ansible-lint
+name: ansible-lint-action
 description: Run Ansible Lint
 author: Ansible by Red Hat <info@ansible.com>
 branding:


### PR DESCRIPTION
As GitHub team was not able to make the required changes to reused
the 'ansible-lint' namespace, we will be using 'ansible-lint-action'
instead.
