### PR TITLE
Preload test dependencies

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -32,7 +32,9 @@ jobs:
           max_python: "3.11"
           other_names: |
             lint
-            pkg,hook,docs
+            pkg
+            hook
+            docs
             schemas
             eco
             py-devel
@@ -84,14 +86,16 @@ jobs:
             ~/.cache/pre-commit
           key: pre-commit-${{ matrix.name || matrix.passed_name }}-${{ hashFiles('.pre-commit-config.yaml') }}
 
-      - name: Set eco cache
+      - name: Set ansible cache(s)
         uses: actions/cache@v3
-        if: ${{ matrix.passed_name == 'eco' }}
         with:
           path: |
             .cache/eco
+            examples/playbooks/collections/ansible_collections
             ~/.cache/ansible-compat
-          key: eco-${{ matrix.name || matrix.passed_name }}-${{ hashFiles('tools/test-eco.sh') }}
+            ~/.ansible/collections
+            ~/.ansible/roles
+          key: ${{ matrix.name || matrix.passed_name }}-${{ hashFiles('tools/test-eco.sh', 'requirements.yml') }}
 
       - name: Set galaxy cache
         uses: actions/cache@v3

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,9 @@
+---
+# This is used during the ansible-lint own testing.
+collections:
+  - ansible.posix
+  - ansible.windows
+  - community.crypto
+  - community.docker
+  - community.general
+  - community.molecule

--- a/src/ansiblelint/__main__.py
+++ b/src/ansiblelint/__main__.py
@@ -244,12 +244,6 @@ def main(argv: list[str] | None = None) -> int:
     from ansiblelint.rules import RulesCollection
     from ansiblelint.runner import _get_matches
 
-    rules = RulesCollection(
-        options.rulesdirs,
-        profile_name=options.profile,
-        options=options,
-    )
-
     if options.list_profiles:
         from ansiblelint.generate_docs import profiles_as_rich
 

--- a/src/ansiblelint/testing/fixtures.py
+++ b/src/ansiblelint/testing/fixtures.py
@@ -28,8 +28,12 @@ def fixture_default_rules_collection() -> RulesCollection:
     """Return default rule collection."""
     assert DEFAULT_RULESDIR.is_dir()
     # For testing we want to manually enable opt-in rules
-    options.enable_list = ["no-same-owner"]
-    return RulesCollection(rulesdirs=[DEFAULT_RULESDIR], options=options)
+    test_options = copy.deepcopy(options)
+    test_options.enable_list = ["no-same-owner"]
+    # That is instantiated very often and do want to avoid ansible-galaxy
+    # install errors due to concurrency.
+    test_options.offline = True
+    return RulesCollection(rulesdirs=[DEFAULT_RULESDIR], options=test_options)
 
 
 @pytest.fixture()

--- a/tools/install-reqs.sh
+++ b/tools/install-reqs.sh
@@ -1,24 +1,4 @@
 #!/bin/bash
 set -euo pipefail
-pushd examples/playbooks/collections >/dev/null
-MISSING=()
-export ANSIBLE_COLLECTIONS_PATH=.
-for COLLECTION in ansible.posix community.docker community.general community.molecule ansible.windows community.crypto;
-do
-    COL_NAME=${COLLECTION//\./-}
-    FILENAME=$(find . -maxdepth 1 -name "$COL_NAME*" -print -quit)
-    if test -n "$FILENAME"
-    then
-        echo "Already cached $COL_NAME as $FILENAME"
-    else
-        MISSING+=("${COLLECTION}")
-    fi
-    if [ ${#MISSING[@]} -ne 0 ]; then
-        ansible-galaxy collection download -p . -v "${MISSING[@]}"
-    fi
-done
-
 echo "Install requirements.yml ..."
-ansible-galaxy collection install *.tar.gz -p .
-ansible-galaxy collection list
-popd >/dev/null
+ansible-galaxy collection install -r requirements.yml -p examples/playbooks/collections


### PR DESCRIPTION
In order to speed-up testing and lower the chance of having concurrency issues, we do install test collection dependencies before running pytest.

Fixes: #3560