### PR TITLE
✨ Allow config file to have `.yaml` extension

### DIFF
--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -12,8 +12,9 @@ example `exclude_paths`) and **True** is preferred for boolean values like
 
 ## Using local configuration files
 
-Specify Ansible-lint configuration in either `.ansible-lint` or
-`.config/ansible-lint.yml` in your current working directory.
+Specify Ansible-lint configuration in either `.ansible-lint`,
+`.config/ansible-lint.yml`, or `.config/ansible-lint.yaml` in your current
+working directory.
 
 !!! note
 

--- a/src/ansiblelint/cli.py
+++ b/src/ansiblelint/cli.py
@@ -104,7 +104,11 @@ def get_config_path(config_file: str | None = None) -> str | None:
     if config_file:
         project_filenames = [config_file]
     else:
-        project_filenames = [".ansible-lint", ".config/ansible-lint.yml"]
+        project_filenames = [
+            ".ansible-lint",
+            ".config/ansible-lint.yml",
+            ".config/ansible-lint.yaml",
+        ]
     parent = tail = os.getcwd()
     while tail:
         for project_filename in project_filenames:
@@ -433,7 +437,7 @@ def get_cli_parser() -> argparse.ArgumentParser:
         "-c",
         "--config-file",
         dest="config_file",
-        help="Specify configuration file to use. By default it will look for '.ansible-lint' or '.config/ansible-lint.yml'",
+        help="Specify configuration file to use. By default it will look for '.ansible-lint', '.config/ansible-lint.yml', or '.config/ansible-lint.yaml'",
     )
     parser.add_argument(
         "-i",

--- a/src/ansiblelint/constants.py
+++ b/src/ansiblelint/constants.py
@@ -165,7 +165,7 @@ ROLE_IMPORT_ACTION_NAMES = {
 # https://github.com/ansible/ansible-lint-action/issues/138
 GIT_CMD = ["git", "-c", f"safe.directory={Path.cwd()}"]
 
-CONFIG_FILENAMES = [".ansible-lint", ".config/ansible-lint.yml"]
+CONFIG_FILENAMES = [".ansible-lint", ".config/ansible-lint.yml", ".config/ansible-lint.yaml"]
 
 
 class States(Enum):

--- a/src/ansiblelint/schemas/ansible-lint-config.json
+++ b/src/ansiblelint/schemas/ansible-lint-config.json
@@ -17,7 +17,7 @@
   "$id": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/ansible-lint-config.json",
   "$schema": "http://json-schema.org/draft-07/schema",
   "additionalProperties": false,
-  "examples": [".ansible-lint", ".config/ansible-lint.yml"],
+  "examples": [".ansible-lint", ".config/ansible-lint.yml", ".config/ansible-lint.yaml"],
   "properties": {
     "display_relative_path": {
       "default": true,


### PR DESCRIPTION
Allow configuration file lookup to include the `.yaml` extension *(i.e. `.config/ansible-lint.yaml`)*.
Many people choose to name their YAML files with the `.yaml` instead of the `.yml` extension.