### PR TITLE
Adopt standalone utils functions into Runner

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -156,7 +156,7 @@ repos:
           - rich>=13.2.0
           - ruamel-yaml>=0.17.31
           - ruamel-yaml-clib>=0.2.7
-          - spdx-tools
+          - spdx-tools>=0.7.1
           - subprocess-tee
           - types-PyYAML
           - types-jsonschema>=4.4.2
@@ -187,7 +187,7 @@ repos:
           - rich>=13.2.0
           - ruamel-yaml>=0.17.31
           - ruamel-yaml-clib>=0.2.7
-          - spdx-tools
+          - spdx-tools>=0.7.1
           - typing_extensions
           - wcmatch
           - yamllint

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -402,9 +402,11 @@ def test_get_rules_dirs_with_custom_rules(
     assert get_rules_dirs(user_ruledirs, use_default=use_default) == expected
 
 
-def test_find_children() -> None:
+def test_find_children(default_rules_collection: RulesCollection) -> None:
     """Verify correct function of find_children()."""
-    utils.find_children(Lintable("examples/playbooks/find_children.yml"))
+    Runner(
+        rules=default_rules_collection,
+    ).find_children(Lintable("examples/playbooks/find_children.yml"))
 
 
 def test_find_children_in_task(default_rules_collection: RulesCollection) -> None:


### PR DESCRIPTION
This change moves a chain of standalone functions into Runner in order
to make it possible to access app instance from it.

_emit_matches --> find_children --> play_children --> _taskshandlers_children --> _roles_children --> _rolepath
