### PR TITLE
Avoid testing errors with outdated setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-  "setuptools >= 63.0.0", # required by pyproject+setuptools_scm integration
+  "setuptools >= 65.3.0", # required by pyproject+setuptools_scm integration and editable installs
   "setuptools_scm[toml] >= 7.0.5", # required for "no-local-version" scheme
 
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # spell-checker:ignore linkcheck basepython changedir envdir envlist envname envsitepackagesdir passenv setenv testenv toxinidir toxworkdir usedevelop doctrees envpython posargs
 [tox]
-minversion = 4.5.1
+minversion = 4.6.3
 envlist =
   lint
   pkg
@@ -12,6 +12,9 @@ envlist =
   eco
 isolated_build = true
 skip_missing_interpreters = True
+requires =
+  tox >= 4.6.3
+  setuptools >= 65.3.0 # editable installs
 
 [testenv]
 description =


### PR DESCRIPTION
As performing editable installs requires a newer
setuptools, we now require it. This should fix some problems
we observed running tests via tox on Ubuntu 22.10
