### PR TITLE
Avoid concurrency issues installing dependencies in parallel

### DIFF
--- a/src/ansiblelint/testing/__init__.py
+++ b/src/ansiblelint/testing/__init__.py
@@ -34,7 +34,7 @@ class RunFromText:
         # Emulate command line execution initialization as without it Ansible module
         # would be loaded with incomplete module/role/collection list.
         if not self.app:  # pragma: no cover
-            self.app = get_app()
+            self.app = get_app(offline=True)
 
         self.collection = collection
 

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -557,7 +557,7 @@ def _rolepath(basedir: str, role: str) -> str | None:
         path_dwim(basedir, os.path.join("..", role)),
     ]
 
-    for loc in get_app().runtime.config.default_roles_path:
+    for loc in get_app(offline=True).runtime.config.default_roles_path:
         loc = os.path.expanduser(loc)
         possible_paths.append(path_dwim(loc, role))
 

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -46,7 +46,7 @@ def test_example_syntax_error(
 
 def test_example_custom_module(default_rules_collection: RulesCollection) -> None:
     """custom_module.yml is expected to pass."""
-    app = get_app()
+    app = get_app(offline=True)
     result = Runner(
         "examples/playbooks/custom_module.yml",
         rules=default_rules_collection,


### PR DESCRIPTION
This should mainly affect the testing.