### PR TITLE
Allow to set gather_facts as templated boolean

### DIFF
--- a/src/ansiblelint/schemas/ansible.json
+++ b/src/ansiblelint/schemas/ansible.json
@@ -348,8 +348,8 @@
           "type": "boolean"
         },
         "gather_facts": {
-          "title": "Gather Facts",
-          "type": "boolean"
+          "$ref": "#/$defs/templated-boolean",
+          "title": "Gather Facts"
         },
         "gather_subset": {
           "items": {

--- a/src/ansiblelint/schemas/playbook.json
+++ b/src/ansiblelint/schemas/playbook.json
@@ -363,8 +363,8 @@
           "type": "boolean"
         },
         "gather_facts": {
-          "title": "Gather Facts",
-          "type": "boolean"
+          "$ref": "#/$defs/templated-boolean",
+          "title": "Gather Facts"
         },
         "gather_subset": {
           "items": {

--- a/test/schemas/negative_test/playbooks/gather_facts.yml.md
+++ b/test/schemas/negative_test/playbooks/gather_facts.yml.md
@@ -63,7 +63,25 @@
     "params": {
       "type": "boolean"
     },
-    "schemaPath": "#/properties/gather_facts/type"
+    "schemaPath": "#/oneOf/0/type"
+  },
+  {
+    "instancePath": "/0/gather_facts",
+    "keyword": "pattern",
+    "message": "must match pattern \"^\\{[\\{%](.|[\r\n])*[\\}%]\\}$\"",
+    "params": {
+      "pattern": "^\\{[\\{%](.|[\r\n])*[\\}%]\\}$"
+    },
+    "schemaPath": "#/$defs/full-jinja/pattern"
+  },
+  {
+    "instancePath": "/0/gather_facts",
+    "keyword": "oneOf",
+    "message": "must match exactly one schema in oneOf",
+    "params": {
+      "passingSchemas": null
+    },
+    "schemaPath": "#/oneOf"
   },
   {
     "instancePath": "/0",
@@ -113,7 +131,15 @@ stdout:
         },
         {
           "path": "$[0].gather_facts",
+          "message": "'non' is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].gather_facts",
           "message": "'non' is not of type 'boolean'"
+        },
+        {
+          "path": "$[0].gather_facts",
+          "message": "'non' does not match '^\\\\{[\\\\{%](.|[\\r\\n])*[\\\\}%]\\\\}$'"
         }
       ]
     }

--- a/test/schemas/test/playbooks/gather_facts.yml
+++ b/test/schemas/test/playbooks/gather_facts.yml
@@ -4,3 +4,9 @@
   tasks:
     - ansible.builtin.debug:
         msg: foo
+
+- hosts: localhost
+  gather_facts: "{{ facts_var_bool | default(false) }}"
+  tasks:
+    - ansible.builtin.debug:
+        msg: bar


### PR DESCRIPTION
Right now schema does not allow gather_facts to be a templated value, even though it would resolve to a proper boolean. This is quite a valid usecase for operators that have a set of playbooks that run each after another and want facts to be gathered only in some of them, while disable facts gathering conditionally for others.

This should enable users to use variables for facts gathering

Signed-Off-By: Dmitriy Rabotyagov <noonedeadpunk@gmail.com>