### PR TITLE
command-instead-of-module: allow `git rev-parse`

### DIFF
--- a/src/ansiblelint/rules/command_instead_of_module.py
+++ b/src/ansiblelint/rules/command_instead_of_module.py
@@ -68,7 +68,7 @@ class CommandsInsteadOfModulesRule(AnsibleLintRule):
     }
 
     _executable_options = {
-        "git": ["branch", "log", "lfs"],
+        "git": ["branch", "log", "lfs", "rev-parse"],
         "systemctl": ["--version", "kill", "set-default", "show-environment", "status"],
         "yum": ["clean"],
         "rpm": ["--nodeps"],


### PR DESCRIPTION
If a user wants to call `git rev-parse`, allow this without raising a `command-instead-of-module` error.

One use would be to do: `git rev-parse HEAD` which will get the SHA value of the current HEAD of the git repository.

The `ansible.builtin.git` module does not have support for doing this.