### PR TITLE
Update _mockings.py to fix bug created in #3390

### DIFF
--- a/src/ansiblelint/_mockings.py
+++ b/src/ansiblelint/_mockings.py
@@ -122,4 +122,4 @@ def _perform_mockings_cleanup(options: Options) -> None:
         else:
             path = options.cache_dir / "roles" / role_name
         with contextlib.suppress(OSError):
-            path.unlink()
+            path.rmdir()


### PR DESCRIPTION
This moves us back to an rmdir for removing directories, since unlink will never work for the directories.

This is causing issues when we run ansible-lint before a molecule run, as the mocked roles are found before the real role in the namespace link.  ansible effectively finds an empty role, and runs none of the expected tasks.