### PR TITLE
Improve profile information on summary line

### DIFF
--- a/src/ansiblelint/app.py
+++ b/src/ansiblelint/app.py
@@ -332,7 +332,10 @@ class App:
         if self.options.profile:
             msg += f" Profile '{self.options.profile}' was required"
             if summary.passed_profile:
-                msg += f", but only '{summary.passed_profile}' profile passed."
+                if summary.passed_profile == self.options.profile:
+                    msg += ", and it passed."
+                else:
+                    msg += f", but '{summary.passed_profile}' profile passed."
             else:
                 msg += "."
         elif summary.passed_profile:


### PR DESCRIPTION
There are currently two problems with the message in the summary line:

If the required and passed profiles are the same, we output something like "Profile 'production' was required, but only 'production' profile passed." This isn't very clear because it looks like the profile was required, but we did not manage to pass it.

Furthermore, profiles have no relation to each other. We have no way of knowing which profile is superior to the other, so we cannot compare them in any way.

To improve the clarity of the summary line, we remove the word 'only' in case we do not pass the required profile, and if the required and passed profiles are the same, we only state that the profile was passed.