### PR TITLE
Add auto-fixing implementation for `jinja[spacing]` rule

### DIFF
--- a/examples/playbooks/transform-jinja.transformed.yml
+++ b/examples/playbooks/transform-jinja.transformed.yml
@@ -1,0 +1,24 @@
+---
+- name: Fixture
+  hosts: localhost
+  vars:
+    my_list:
+      - foo
+      - bar
+  tasks:
+    - name: A block used to check that we do not identify error at correct level
+      block:
+        - name: Foo # <-- this is valid jinja2
+          ansible.builtin.debug:
+            foo: "{{ 1 }}" # <-- jinja2[spacing]
+            msg: "{{ 'a' b }}" # <-- jinja2[invalid]
+
+    - name: A block used to check that we do not identify error at correct level
+      block:
+        - name: Foo # <-- this is valid jinja2
+          ansible.builtin.debug:
+            msg: "{{ item }}" # <-- jinja2[spacing]
+          with_items:
+            - "{{ items }}"
+# It should be noted that even ansible --syntax-check fails to spot the jinja
+# error above, but ansible will throw a runtime error when running

--- a/examples/playbooks/transform-jinja.transformed.yml
+++ b/examples/playbooks/transform-jinja.transformed.yml
@@ -20,5 +20,21 @@
             msg: "{{ item }}" # <-- jinja2[spacing]
           with_items:
             - "{{ items }}"
+
+    - name: Confirm a deeply nested duplicate error is corrected
+      ansible.builtin.set_fact:
+        fact:
+          dict:
+            dict:
+              list:
+                - one
+                - two
+                - dict:
+                    fix: "{{ 'VALUE_1' | lower }}" # <-- jinja2[spacing]
+                - dict:
+                    fix: "{{ 'VALUE_1' | lower }}" # <-- jinja2[spacing]
+                - dict:
+                    fix: "{{ 'VALUE_2' | lower }}" # <-- jinja2[spacing]
+
 # It should be noted that even ansible --syntax-check fails to spot the jinja
 # error above, but ansible will throw a runtime error when running

--- a/examples/playbooks/transform-jinja.yml
+++ b/examples/playbooks/transform-jinja.yml
@@ -1,0 +1,24 @@
+---
+- name: Fixture
+  hosts: localhost
+  vars:
+    my_list:
+      - foo
+      - bar
+  tasks:
+    - name: A block used to check that we do not identify error at correct level
+      block:
+        - name: Foo # <-- this is valid jinja2
+          ansible.builtin.debug:
+            foo: "{{ 1  }}" # <-- jinja2[spacing]
+            msg: "{{ 'a' b }}" # <-- jinja2[invalid]
+
+    - name: A block used to check that we do not identify error at correct level
+      block:
+        - name: Foo # <-- this is valid jinja2
+          ansible.builtin.debug:
+            msg: "{{ item  }}" # <-- jinja2[spacing]
+          with_items:
+            - "{{ items  }}"
+# It should be noted that even ansible --syntax-check fails to spot the jinja
+# error above, but ansible will throw a runtime error when running

--- a/examples/playbooks/transform-jinja.yml
+++ b/examples/playbooks/transform-jinja.yml
@@ -20,5 +20,21 @@
             msg: "{{ item  }}" # <-- jinja2[spacing]
           with_items:
             - "{{ items  }}"
+
+    - name: Confirm a deeply nested duplicate error is corrected
+      ansible.builtin.set_fact:
+        fact:
+          dict:
+            dict:
+              list:
+                - one
+                - two
+                - dict:
+                    fix: "{{'VALUE_1'|lower}}" # <-- jinja2[spacing]
+                - dict:
+                    fix: "{{'VALUE_1'|lower}}" # <-- jinja2[spacing]
+                - dict:
+                    fix: "{{'VALUE_2'|lower}}" # <-- jinja2[spacing]
+
 # It should be noted that even ansible --syntax-check fails to spot the jinja
 # error above, but ansible will throw a runtime error when running

--- a/src/ansiblelint/errors.py
+++ b/src/ansiblelint/errors.py
@@ -38,6 +38,11 @@ class StrictModeError(RuntimeError):
         super().__init__(message)
 
 
+@dataclass(frozen=True)
+class RuleMatchTransformMeta:
+    """Additional metadata about a match error to be used during transformation."""
+
+
 # pylint: disable=too-many-instance-attributes
 @dataclass(unsafe_hash=True)
 @functools.total_ordering
@@ -65,6 +70,7 @@ class MatchError(ValueError):
     rule: BaseRule = field(hash=False, default=RuntimeErrorRule())
     ignored: bool = False
     fixed: bool = False  # True when a transform has resolved this MatchError
+    transform_meta: RuleMatchTransformMeta | None = None
 
     def __post_init__(self) -> None:
         """Can be use by rules that can report multiple errors type, so we can still filter by them."""

--- a/src/ansiblelint/rules/__init__.py
+++ b/src/ansiblelint/rules/__init__.py
@@ -32,6 +32,8 @@ from ansiblelint.file_utils import Lintable, expand_paths_vars
 if TYPE_CHECKING:
     from ruamel.yaml.comments import CommentedMap, CommentedSeq
 
+    from ansiblelint.errors import RuleMatchTransformMeta
+
 _logger = logging.getLogger(__name__)
 
 match_types = {
@@ -78,6 +80,7 @@ class AnsibleLintRule(BaseRule):
         details: str = "",
         filename: Lintable | None = None,
         tag: str = "",
+        transform_meta: RuleMatchTransformMeta | None = None,
     ) -> MatchError:
         """Instantiate a new MatchError."""
         match = MatchError(
@@ -87,6 +90,7 @@ class AnsibleLintRule(BaseRule):
             lintable=filename or Lintable(""),
             rule=copy.copy(self),
             tag=tag,
+            transform_meta=transform_meta,
         )
         # search through callers to find one of the match* methods
         frame = inspect.currentframe()

--- a/src/ansiblelint/rules/jinja.py
+++ b/src/ansiblelint/rules/jinja.py
@@ -456,7 +456,6 @@ class JinjaRule(AnsibleLintRule, TransformMixin):
                     except (KeyError, TypeError) as exc:
                         err = f"Unable to transform {match.transform_meta}: {exc}"
                         _logger.error(err)
-                        match.fixed = False
                         return
                 try:
                     obj[path[-1]][key] = match.transform_meta.fixed
@@ -465,7 +464,6 @@ class JinjaRule(AnsibleLintRule, TransformMixin):
                 except (KeyError, TypeError) as exc:
                     err = f"Unable to transform {match.transform_meta}: {exc}"
                     _logger.error(err)
-                    match.fixed = False
                 return
 
 

--- a/src/ansiblelint/rules/jinja.py
+++ b/src/ansiblelint/rules/jinja.py
@@ -407,7 +407,7 @@ class JinjaRule(AnsibleLintRule, TransformMixin):
         return reformatted, details, "spacing"
 
     def transform(
-        self,
+        self: JinjaRule,
         match: MatchError,
         lintable: Lintable,
         data: CommentedMap | CommentedSeq | str,
@@ -419,10 +419,10 @@ class JinjaRule(AnsibleLintRule, TransformMixin):
         :param data: data to transform
         """
         if match.tag == "jinja[spacing]":
-            self.transform_spacing(match, data)
+            self._transform_spacing(match, data)
 
-    def transform_spacing(
-        self,
+    def _transform_spacing(
+        self: JinjaRule,
         match: MatchError,
         data: CommentedMap | CommentedSeq | str,
     ) -> None:

--- a/src/ansiblelint/rules/jinja.py
+++ b/src/ansiblelint/rules/jinja.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import logging
 import re
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NamedTuple
 
@@ -12,10 +13,9 @@ import jinja2
 from ansible.errors import AnsibleError, AnsibleParserError
 from ansible.parsing.yaml.objects import AnsibleUnicode
 from jinja2.exceptions import TemplateSyntaxError
-from ruamel.yaml.comments import CommentedMap, CommentedSeq
 
 from ansiblelint.constants import LINE_NUMBER_KEY
-from ansiblelint.errors import MatchError
+from ansiblelint.errors import RuleMatchTransformMeta
 from ansiblelint.file_utils import Lintable
 from ansiblelint.rules import AnsibleLintRule, TransformMixin
 from ansiblelint.skip_utils import get_rule_skips_from_line
@@ -61,6 +61,26 @@ ignored_re = re.compile(
     ),
     flags=re.MULTILINE | re.DOTALL,
 )
+
+
+@dataclass(frozen=True)
+class JinjaRuleTMetaSpacing(RuleMatchTransformMeta):
+    """JinjaRule transform metadata.
+
+    :param key: Key or index within the task
+    :param value: Value of the key
+    :param path: Path to the key
+    :param fixed: Value with spacing fixed
+    """
+
+    key: str | int
+    value: str | int
+    path: tuple[str | int, ...]
+    fixed: str
+
+    def __str__(self) -> str:
+        """Return string representation."""
+        return f"{self.key}={self.value} at {self.path} fixed to {self.fixed}"
 
 
 class JinjaRule(AnsibleLintRule, TransformMixin):
@@ -176,6 +196,12 @@ class JinjaRule(AnsibleLintRule, TransformMixin):
                                 details=details,
                                 filename=file,
                                 tag=f"{self.id}[{tag}]",
+                                transform_meta=JinjaRuleTMetaSpacing(
+                                    key=key,
+                                    value=v,
+                                    path=tuple(path),
+                                    fixed=reformatted,
+                                ),
                             ),
                         )
         except Exception as exc:
@@ -386,27 +412,61 @@ class JinjaRule(AnsibleLintRule, TransformMixin):
         lintable: Lintable,
         data: CommentedMap | CommentedSeq | str,
     ) -> None:
+        """Transform jinja2 errors.
+
+        :param match: MatchError instance
+        :param lintable: Lintable instance
+        :param data: data to transform
+        """
         if match.tag == "jinja[spacing]":
-            target_task = self.seek(match.yaml_path, data)
-            [orig_val, updated_val] = match.message.split(":")[1].split("->")
-            orig_val = orig_val.strip()
-            for _ in range(len(target_task)):
-                k, v = target_task.popitem(False)
-                if isinstance(v, CommentedMap):
-                    for _ in range(len(v)):
-                        module_opt_key, module_opt_value = v.popitem(False)
-                        v[module_opt_key] = (
-                            updated_val.strip()
-                            if orig_val == module_opt_value
-                            else module_opt_value
-                        )
-                elif isinstance(v, CommentedSeq):
-                    for idx, seq_val in enumerate(v):
-                        v[idx] = updated_val.strip() if orig_val == seq_val else seq_val
-                elif isinstance(v, str) and v == orig_val:
-                    v = updated_val.strip()
-                target_task[k] = v
-            match.fixed = True
+            self.transform_spacing(match, data)
+
+    def transform_spacing(
+        self,
+        match: MatchError,
+        data: CommentedMap | CommentedSeq | str,
+    ) -> None:
+        """Transform jinja2 spacing errors.
+
+        The match error was found on a normalized task so we cannot compare the path
+        instead we only compare the key and value, if the task has 2 identical keys with the
+        exact same jinja spacing issue, we may transform them out of order
+
+        :param match: MatchError instance
+        :param data: data to transform
+        """
+        if not isinstance(match.transform_meta, JinjaRuleTMetaSpacing):
+            return
+        if isinstance(data, str):
+            return
+
+        obj = self.seek(match.yaml_path, data)
+        if obj is None:
+            return
+
+        ignored_keys = ("block", "ansible.builtin.block", "ansible.legacy.block")
+        for key, value, path in nested_items_path(
+            data_collection=obj,
+            ignored_keys=ignored_keys,
+        ):
+            if key == match.transform_meta.key and value == match.transform_meta.value:
+                for pth in path[:-1]:
+                    try:
+                        obj = obj[pth]
+                    except (KeyError, TypeError) as exc:
+                        err = f"Unable to transform {match.transform_meta}: {exc}"
+                        _logger.error(err)
+                        match.fixed = False
+                        return
+                try:
+                    obj[path[-1]][key] = match.transform_meta.fixed
+                    match.fixed = True
+
+                except (KeyError, TypeError) as exc:
+                    err = f"Unable to transform {match.transform_meta}: {exc}"
+                    _logger.error(err)
+                    match.fixed = False
+                return
 
 
 def blacken(text: str) -> str:

--- a/test/test_transformer.py
+++ b/test/test_transformer.py
@@ -102,6 +102,12 @@ def fixture_runner_result(
             True,
             id="dep_local_action",
         ),
+        pytest.param(
+            "examples/playbooks/transform-jinja.yml",
+            7,
+            True,
+            id="jinja_spacing",
+        ),
     ),
 )
 def test_transformer(  # pylint: disable=too-many-arguments, too-many-locals


### PR DESCRIPTION
Related: #3634
Depends on #3693 

When finding jina2 spacing errors a recommendation is produced, the key, value and path within the task is known.  This information is added to the MatchError to be used later.

When transforming for a specific MatchError, use the metadata captured during the identification of the spacing issue to iterate the task and when a matching key and value are found, use the previously generated recommendation.

Because the MatchError was generated using a "normalized task" and the transform is operating on the original task, the path cannot be used to locate the key. This introduces the possibility or 2 identical key/value combinations being corrected out of order and is noted in the doc string of the respective function.
