### PR TITLE
Test transformer with block indentation indicators

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -71,7 +71,7 @@ jobs:
       WSLENV: FORCE_COLOR:PYTEST_REQPASS:TOXENV:GITHUB_STEP_SUMMARY
       # Number of expected test passes, safety measure for accidental skip of
       # tests. Update value if you add/remove tests.
-      PYTEST_REQPASS: 815
+      PYTEST_REQPASS: 816
     steps:
       - name: Activate WSL1
         if: "contains(matrix.shell, 'wsl')"

--- a/examples/playbooks/transform-block-indentation-indicator.transformed.yml
+++ b/examples/playbooks/transform-block-indentation-indicator.transformed.yml
@@ -1,0 +1,10 @@
+---
+- name: Demo
+  hosts: all
+  tasks:
+    - name: Demo
+      ansible.builtin.debug:
+        msg: |2
+              multi
+            line
+            message

--- a/examples/playbooks/transform-block-indentation-indicator.yml
+++ b/examples/playbooks/transform-block-indentation-indicator.yml
@@ -1,0 +1,10 @@
+---
+- name: Demo
+  hosts: all
+  tasks:
+    - name: Demo
+      ansible.builtin.debug:
+        msg: |3
+               multi
+             line
+             message

--- a/test/test_transformer.py
+++ b/test/test_transformer.py
@@ -102,6 +102,12 @@ def fixture_runner_result(
             True,
             id="dep_local_action",
         ),
+        pytest.param(
+            "examples/playbooks/transform-block-indentation-indicator.yml",
+            0,
+            True,
+            id="multiline_msg_with_indent_indicator",
+        ),
     ),
 )
 def test_transformer(  # pylint: disable=too-many-arguments, too-many-locals


### PR DESCRIPTION
Fixes: https://github.com/ansible/ansible-lint/issues/2941

With the current version of ruamel.yaml, ansible-lint transform is not producing the stack trace mentioned in the linked issue. And the --write mode behavior is as expected, which we would be testing as part of this PR.