### PR TITLE
Avoid warnings from loading of deprecated modules

### DIFF
--- a/src/ansiblelint/rules/args.py
+++ b/src/ansiblelint/rules/args.py
@@ -8,7 +8,6 @@ import json
 import logging
 import re
 import sys
-from functools import lru_cache
 from typing import TYPE_CHECKING, Any
 
 # pylint: disable=preferred-module
@@ -18,11 +17,11 @@ from unittest.mock import patch
 # pylint: disable=reimported
 import ansible.module_utils.basic as mock_ansible_module
 from ansible.module_utils import basic
-from ansible.plugins.loader import PluginLoadContext, module_loader
 
 from ansiblelint.constants import LINE_NUMBER_KEY
 from ansiblelint.rules import AnsibleLintRule, RulesCollection
 from ansiblelint.text import has_jinja
+from ansiblelint.utils import load_plugin
 from ansiblelint.yaml_utils import clean_json
 
 if TYPE_CHECKING:
@@ -66,12 +65,6 @@ workarounds_inject_map = {
 }
 
 
-@lru_cache
-def load_module(module_name: str) -> PluginLoadContext:
-    """Load plugin from module name and cache it."""
-    return module_loader.find_plugin_with_context(module_name)
-
-
 class ValidationPassedError(Exception):
     """Exception to be raised when validation passes."""
 
@@ -111,7 +104,7 @@ class ArgsRule(AnsibleLintRule):
         if module_name in self.module_aliases:
             return []
 
-        loaded_module = load_module(module_name)
+        loaded_module = load_plugin(module_name)
 
         # https://github.com/ansible/ansible-lint/issues/3200
         # since "ps1" modules cannot be executed on POSIX platforms, we will

--- a/src/ansiblelint/schemas/__store__.json
+++ b/src/ansiblelint/schemas/__store__.json
@@ -24,7 +24,7 @@
     "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/inventory.json"
   },
   "meta": {
-    "etag": "9eb5c611e25cc9e0a180119904f8dfe39c59409b37da972f66a6c60f040a3a08",
+    "etag": "097a20155bc7936b6eae292a556bb38202d34a0a333ff5cbaaa1b4d3a4cc7bf5",
     "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/meta.json"
   },
   "meta-runtime": {
@@ -36,7 +36,7 @@
     "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/molecule.json"
   },
   "playbook": {
-    "etag": "48d584b10235804c13de78177dcfeeba433bd4d196ef3872aac7fc26a26303f5",
+    "etag": "8ae42e48318ff6da41f6d383dc19b643221258ea6521886f834e31cb8d3a7322",
     "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/playbook.json"
   },
   "requirements": {
@@ -48,7 +48,7 @@
     "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/role-arg-spec.json"
   },
   "rulebook": {
-    "etag": "b8c4ddf5d8d276d7a27335f2042554b3528ad9a091f13f1ffe7241be08a9671b",
+    "etag": "8a421671574fa65a57fb0d08e45879bfa005f271aa8c0243982a84b49fb0fe54",
     "url": "https://raw.githubusercontent.com/ansible/ansible-rulebook/main/ansible_rulebook/schema/ruleset_schema.json"
   },
   "tasks": {

--- a/src/ansiblelint/schemas/rulebook.json
+++ b/src/ansiblelint/schemas/rulebook.json
@@ -157,6 +157,9 @@
                             "type": "string"
                         },
                         {
+                            "type": "boolean"
+                        },
+                        {
                             "$ref": "#/$defs/all-condition"
                         },
                         {

--- a/test/test_task_includes.py
+++ b/test/test_task_includes.py
@@ -1,4 +1,6 @@
 """Tests related to task inclusions."""
+import sys
+
 import pytest
 
 from ansiblelint.file_utils import Lintable
@@ -9,7 +11,14 @@ from ansiblelint.runner import Runner
 @pytest.mark.parametrize(
     ("filename", "file_count", "match_count"),
     (
-        pytest.param("examples/playbooks/blockincludes.yml", 4, 3, id="blockincludes"),
+        pytest.param(
+            "examples/playbooks/blockincludes.yml",
+            4,
+            3
+            if sys.version_info >= (3, 10, 0)
+            else 4,  # 3 with py310/ansible2.16, or 4 with py39/ansible2.15,
+            id="blockincludes",
+        ),
         pytest.param(
             "examples/playbooks/blockincludes2.yml",
             4,


### PR DESCRIPTION
- move module loading code in utils module
- mimic core behavior and fallback on legacy modules

Fixes: #3696
