### PR TITLE
Skip altered path warning for `ansible-lint` installed by `pipx`

### DIFF
--- a/src/ansiblelint/__main__.py
+++ b/src/ansiblelint/__main__.py
@@ -353,6 +353,7 @@ def path_inject() -> None:
     if (
         str(userbase_bin_path) not in paths
         and (userbase_bin_path / "bin" / "ansible").exists()
+        and not "pipx" in str(userbase_bin_path)
     ):
         inject_paths.append(str(userbase_bin_path))
 


### PR DESCRIPTION
Refs pypa/pipx#1053