### PR TITLE
Add /bin/bash executable to example correct code for pipefail rule

### DIFF
--- a/src/ansiblelint/rules/risky_shell_pipe.md
+++ b/src/ansiblelint/rules/risky_shell_pipe.md
@@ -30,10 +30,14 @@ As this requirement does not apply to PowerShell, for shell commands that have
   become: false
   tasks:
     - name: Pipeline with pipefail
-      ansible.builtin.shell: set -o pipefail && false | cat
+      ansible.builtin.shell:
+        cmd: set -o pipefail && false | cat
+        executable: /bin/bash
 
     - name: Pipeline with pipefail, multi-line
-      ansible.builtin.shell: |
-        set -o pipefail # <-- adding this will prevent surprises
-        false | cat
+      ansible.builtin.shell:
+        cmd: |
+          set -o pipefail # <-- adding this will prevent surprises
+          false | cat
+        executable: /bin/bash
 ```


### PR DESCRIPTION
##### Summary

The [documentation for pipefail](https://ansible.readthedocs.io/projects/lint/rules/risky-shell-pipe/#correct-code) suggests adding a `set -o pipefail` line when using a shell command containing a pipe. However, this option is a bash option, and afaik doesn't work on all `sh` versions (for instance, it fails on Debian Buster). sh is used by default by ansible when using the ansible.builtin.shell module. As a consequence, the example code leads to the following error:

```
/bin/sh: 1: set: Illegal option -o pipefail
```

The solution is to use another executable (e.g. `executable: /bin/bash`). That should be in the example code, which, in its current state, doesn't always work.