### PR TITLE
Rename --write option to --fix

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -76,7 +76,7 @@ warn_list:
   # - yaml[document-start]  # you can also use sub-rule matches
 
 # Some rules can transform files to fix (or make it easier to fix) identified
-# errors. `ansible-lint --write` will reformat YAML files and run these transforms.
+# errors. `ansible-lint --fix` will reformat YAML files and run these transforms.
 # By default it will run all transforms (effectively `write_list: ["all"]`).
 # You can disable running transforms by setting `write_list: ["none"]`.
 # Or only enable a subset of rule transforms by listing rules/tags here.

--- a/src/ansiblelint/__main__.py
+++ b/src/ansiblelint/__main__.py
@@ -274,7 +274,7 @@ def main(argv: list[str] | None = None) -> int:
 
         if Version(ruamel_safe_version) > Version(ruamel_yaml_version_str):
             _logger.warning(
-                "We detected use of `--write` feature with a buggy ruamel-yaml %s library instead of >=%s, upgrade it before reporting any bugs like dropped comments.",
+                "We detected use of `--fix` feature with a buggy ruamel-yaml %s library instead of >=%s, upgrade it before reporting any bugs like dropped comments.",
                 ruamel_yaml_version_str,
                 ruamel_safe_version,
             )

--- a/src/ansiblelint/app.py
+++ b/src/ansiblelint/app.py
@@ -223,7 +223,7 @@ class App:
 
         if self.options.write_list and "yaml" in self.options.skip_list:
             _logger.warning(
-                "You specified '--write', but no files can be modified "
+                "You specified '--fix', but no files can be modified "
                 "because 'yaml' is in 'skip_list'.",
             )
 

--- a/src/ansiblelint/rules/__init__.py
+++ b/src/ansiblelint/rules/__init__.py
@@ -254,7 +254,7 @@ class AnsibleLintRule(BaseRule):
 class TransformMixin:
     """A mixin for AnsibleLintRule to enable transforming files.
 
-    If ansible-lint is started with the ``--write`` option, then the ``Transformer``
+    If ansible-lint is started with the ``--fix`` option, then the ``Transformer``
     will call the ``transform()`` method for every MatchError identified if the rule
     that identified it subclasses this ``TransformMixin``. Only the rule that identified
     a MatchError can do transforms to fix that match.

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -68,34 +68,34 @@ def test_ensure_config_are_equal(
 @pytest.mark.parametrize(
     ("with_base", "args", "config"),
     (
-        (True, ["--write"], "test/fixtures/config-with-write-all.yml"),
-        (True, ["--write=all"], "test/fixtures/config-with-write-all.yml"),
-        (True, ["--write", "all"], "test/fixtures/config-with-write-all.yml"),
-        (True, ["--write=none"], "test/fixtures/config-with-write-none.yml"),
-        (True, ["--write", "none"], "test/fixtures/config-with-write-none.yml"),
+        (True, ["--fix"], "test/fixtures/config-with-write-all.yml"),
+        (True, ["--fix=all"], "test/fixtures/config-with-write-all.yml"),
+        (True, ["--fix", "all"], "test/fixtures/config-with-write-all.yml"),
+        (True, ["--fix=none"], "test/fixtures/config-with-write-none.yml"),
+        (True, ["--fix", "none"], "test/fixtures/config-with-write-none.yml"),
         (
             True,
-            ["--write=rule-tag,rule-id"],
+            ["--fix=rule-tag,rule-id"],
             "test/fixtures/config-with-write-subset.yml",
         ),
         (
             True,
-            ["--write", "rule-tag,rule-id"],
+            ["--fix", "rule-tag,rule-id"],
             "test/fixtures/config-with-write-subset.yml",
         ),
         (
             True,
-            ["--write", "rule-tag", "--write", "rule-id"],
+            ["--fix", "rule-tag", "--fix", "rule-id"],
             "test/fixtures/config-with-write-subset.yml",
         ),
         (
             False,
-            ["--write", "examples/playbooks/example.yml"],
+            ["--fix", "examples/playbooks/example.yml"],
             "test/fixtures/config-with-write-all.yml",
         ),
         (
             False,
-            ["--write", "examples/playbooks/example.yml", "non-existent.yml"],
+            ["--fix", "examples/playbooks/example.yml", "non-existent.yml"],
             "test/fixtures/config-with-write-all.yml",
         ),
     ),
@@ -106,7 +106,7 @@ def test_ensure_write_cli_does_not_consume_lintables(
     args: list[str],
     config: str,
 ) -> None:
-    """Check equality of the CLI --write options to config files."""
+    """Check equality of the CLI --fix options to config files."""
     cli_parser = cli.get_cli_parser()
 
     command = base_arguments + args if with_base else args
@@ -115,7 +115,7 @@ def test_ensure_write_cli_does_not_consume_lintables(
 
     file_value = file_config.get("write_list")
     orig_cli_value = options.write_list
-    cli_value = cli.WriteArgAction.merge_write_list_config(
+    cli_value = cli.WriteArgAction.merge_fix_list_config(
         from_file=[],
         from_cli=orig_cli_value,
     )


### PR DESCRIPTION
This change will make ansible-lint auto-fixing feature in line with other tools that can perform similar transformations (ruff, black, ...).

For compatibility, we automatically convert old option into new one and display a warning.

Fixes: #3742
