### PR TITLE
Expose rules that have autofix capability in docs

### DIFF
--- a/docs/autofix.md
+++ b/docs/autofix.md
@@ -1,0 +1,20 @@
+# Autofix
+
+Ansible-lint autofix can fix or simplify fixing issues identified by that rule. `ansible-lint --fix` will reformat YAML files and run transform for the given
+rules. You can limit the effective rule transforms (the 'write_list') by passing
+a keywords 'all' or 'none' or a comma separated list of rule ids or rule tags.
+By default it will run all transforms (effectively `write_list: ["all"]`).
+You can disable running transforms by setting `write_list: ["none"]`. Or only enable a subset of rule transforms by listing rules/tags here.
+
+Following is the list of supported rules covered under autofix functionality.
+
+- [command-instead-of-shell](rules/command-instead-of-shell.md#auto-fixing-capability)
+- [deprecated-local-action](rules/deprecated-local-action.md)
+- [fqcn](rules/fqcn.md)
+- [jinja](rules/jinja.md)
+- [key-order](rules/key-order.md)
+- [name](rules/name.md)
+- [no-free-form](rules/no-free-form.md)
+- [no-jinja-when](rules/no-jinja-when.md)
+- [no-log-password](rules/no-log-password.md)
+- [partial-become](rules/partial-become.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,7 @@ nav:
       - usage.md
       - configuring.md
       - profiles.md
+      - autofix.md
   - Rules:
       - index: rules/index.md
       - rules/args.md

--- a/src/ansiblelint/rules/command_instead_of_shell.md
+++ b/src/ansiblelint/rules/command_instead_of_shell.md
@@ -28,3 +28,65 @@ environment variable expansion or chaining multiple commands using pipes.
       ansible.builtin.command: echo hello
       changed_when: false
 ```
+
+## Auto-fixing capability
+
+### Before autofix
+
+```yaml
+---
+- name: Fixture
+  hosts: localhost
+  tasks:
+    - name: Shell no pipe
+      ansible.builtin.shell:
+        cmd: echo hello
+      changed_when: false
+
+    - name: Shell with jinja filter
+      ansible.builtin.shell:
+        cmd: echo {{ "hello" | upper }}
+      changed_when: false
+
+    - name: Shell with jinja filter (fqcn)
+      ansible.builtin.shell:
+        cmd: echo {{ "hello" | upper }}
+      changed_when: false
+
+    - name: Command with executable parameter
+      ansible.builtin.shell:
+        cmd: clear
+      args:
+        executable: /bin/bash
+      changed_when: false
+```
+
+### After autofix
+
+```yaml
+---
+- name: Fixture
+  hosts: localhost
+  tasks:
+    - name: Shell no pipe
+      ansible.builtin.command:
+        cmd: echo hello
+      changed_when: false
+
+    - name: Shell with jinja filter
+      ansible.builtin.command:
+        cmd: echo {{ "hello" | upper }}
+      changed_when: false
+
+    - name: Shell with jinja filter (fqcn)
+      ansible.builtin.command:
+        cmd: echo {{ "hello" | upper }}
+      changed_when: false
+
+    - name: Command with executable parameter
+      ansible.builtin.shell:
+        cmd: clear
+      args:
+        executable: /bin/bash
+      changed_when: false
+```


### PR DESCRIPTION
Related: https://github.com/ansible/ansible-lint/issues/3624, https://github.com/ansible/ansible-lint/issues/3634

Adds a new section as `autofix` in RTD docs.
Documents autofix behavior for `command-instead-of-shell` rule.