### PR TITLE
Add pipeline for testing with prereleased dependencies

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -18,8 +18,8 @@ env:
   PY_COLORS: 1
 
 jobs:
-  pre:
-    name: pre
+  prepare:
+    name: prepare
     runs-on: ubuntu-22.04
     outputs:
       matrix: ${{ steps.generate_matrix.outputs.matrix }}
@@ -37,6 +37,7 @@ jobs:
             docs
             schemas
             eco
+            pre
             py310-devel
           platforms: linux,macos
   test-action:
@@ -52,14 +53,14 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os || 'ubuntu-22.04' }}
     needs:
-      - pre
+      - prepare
       - test-action
     defaults:
       run:
         shell: ${{ matrix.shell || 'bash'}}
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.pre.outputs.matrix) }}
+      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
       # max-parallel: 5
       # The matrix testing goal is to cover the *most likely* environments
       # which are expected to be used by users in production. Avoid adding a

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ envlist =
   schemas
   py
   py-devel
+  pre
   eco
 isolated_build = true
 skip_missing_interpreters = True
@@ -20,6 +21,7 @@ requires =
 description =
   Run the tests under {basepython} and
   devel: ansible devel branch
+  pre: Enables --pre when installing dependencies, testing prereleases
 deps =
   devel: ansible-core @ git+https://github.com/ansible/ansible.git  # GPLv3+
   devel: ansible-compat @ git+https://github.com/ansible/ansible-compat.git  # GPLv3+
@@ -29,6 +31,7 @@ commands_pre =
   sh -c "rm -f .tox/.coverage.* 2>/dev/null || true"
   bash ./tools/install-reqs.sh
 commands =
+  ansible --version
   # safety measure to assure we do not accidentally run tests with broken dependencies
   {envpython} -m pip check
   coverage run -m pytest {posargs:\
@@ -63,10 +66,11 @@ setenv =
   COVERAGE_FILE = {env:COVERAGE_FILE:{toxworkdir}/.coverage.{envname}}
   COVERAGE_PROCESS_START={toxinidir}/pyproject.toml
   PIP_CONSTRAINT = {toxinidir}/.config/requirements.txt
-  devel,pkg: PIP_CONSTRAINT = /dev/null
+  devel,pkg,pre: PIP_CONSTRAINT = /dev/null
   PIP_DISABLE_PIP_VERSION_CHECK = 1
   PRE_COMMIT_COLOR = always
   FORCE_COLOR = 1
+  pre: PIP_PRE = 1
 allowlist_externals =
   bash
   find


### PR DESCRIPTION
In addition to 'devel' which installs ansible devel branch, this will instead test with latest pre-release of ansible and also other python dependencies as well.

This should sort of known issue, the fact that once ansible main branch is branching, we stop testing with it and instead we test with 'devel'.
