### PR TITLE
Add documentation for autofixing `deprecated-local-action` rule

### DIFF
--- a/docs/autofix.md
+++ b/docs/autofix.md
@@ -9,7 +9,7 @@ You can disable running transforms by setting `write_list: ["none"]`. Or only en
 Following is the list of supported rules covered under autofix functionality.
 
 - [command-instead-of-shell](rules/command-instead-of-shell.md#auto-fixing-capability)
-- [deprecated-local-action](rules/deprecated-local-action.md)
+- [deprecated-local-action](rules/deprecated-local-action.md#auto-fixing-capability)
 - [fqcn](rules/fqcn.md)
 - [jinja](rules/jinja.md)
 - [key-order](rules/key-order.md)

--- a/src/ansiblelint/rules/deprecated_local_action.md
+++ b/src/ansiblelint/rules/deprecated_local_action.md
@@ -19,3 +19,29 @@ This rule recommends using `delegate_to: localhost` instead of the
     ansible.builtin.debug:
   delegate_to: localhost # <-- recommended way to run on localhost
 ```
+
+## Auto-fixing capability
+
+### Before autofix
+
+```yaml
+---
+- name: Fixture for deprecated-local-action
+  hosts: localhost
+  tasks:
+    - name: Task example
+      local_action:
+        module: ansible.builtin.debug
+```
+
+### After autofix
+
+```yaml
+---
+- name: Fixture for deprecated-local-action
+  hosts: localhost
+  tasks:
+    - name: Task example
+      ansible.builtin.debug:
+      delegate_to: localhost
+```


### PR DESCRIPTION
Related: https://github.com/ansible/ansible-lint/issues/3624