### PR TITLE
Use checkout action in install docs

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -95,6 +95,7 @@ jobs:
     name: Ansible Lint # Naming the build is important to use it as a status check
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - name: Run ansible-lint
         uses: ansible/ansible-lint@v6
 ```


### PR DESCRIPTION
Prior to version 6.20.2, the ansible-lint action automatically included the checkout action. It was removed in 55b8b66 and discussed in #3801.

The ansible-lint action depends on the presence of a `.git` directory, into which it downloads the `requirements-lock.txt` file. If the directory isn't present, the action fails.

This commit updates the example YAML to work around this problem.

I suspect the best course of action might be to re-add the `uses: actions/checkout@v4` that was removed in 55b8b66 (in which case you can just close this PR), but if it was the preferred direction, I thought this was worth contributing…