### PR TITLE
Remove bump-homebrew-formula configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,7 @@ jobs:
     environment: release
     runs-on: ubuntu-22.04
     needs: pypi
+    if: github.event_name == 'release'
 
     env:
       FORCE_COLOR: 1
@@ -67,16 +68,18 @@ jobs:
       TOXENV: pkg
 
     steps:
-      - name: Check out src from Git
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # needed by setuptools-scm
-          submodules: true
+      - name: Extract version
+        id: extract-version
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          echo "version=${TAG_NAME#v}" >> $GITHUB_OUTPUT
 
       - name: Bump homebrew formula
         uses: mislav/bump-homebrew-formula-action@v3.1
         with:
           # A PR will be sent to github.com/Homebrew/homebrew-core to update this formula:
           formula-name: ansible-lint
+          download-url: https://pypi.org/packages/source/a/ansible-lint/ansible-lint-${{ steps.extract-version.outputs.version }}.tar.gz
         env:
           COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,4 @@
 ---
-# cspell:ignore mislav
 name: release
 
 "on":
@@ -54,32 +53,3 @@ jobs:
         if: >- # "create" workflows run separately from "push" & "pull_request"
           github.event_name == 'release'
         uses: pypa/gh-action-pypi-publish@release/v1
-
-  homebrew:
-    name: Bump homebrew formula
-    environment: release
-    runs-on: ubuntu-22.04
-    needs: pypi
-    if: github.event_name == 'release'
-
-    env:
-      FORCE_COLOR: 1
-      PY_COLORS: 1
-      TOXENV: pkg
-
-    steps:
-      - name: Extract version
-        id: extract-version
-        env:
-          TAG_NAME: ${{ github.event.release.tag_name }}
-        run: |
-          echo "version=${TAG_NAME#v}" >> $GITHUB_OUTPUT
-
-      - name: Bump homebrew formula
-        uses: mislav/bump-homebrew-formula-action@v3.1
-        with:
-          # A PR will be sent to github.com/Homebrew/homebrew-core to update this formula:
-          formula-name: ansible-lint
-          download-url: https://pypi.org/packages/source/a/ansible-lint/ansible-lint-${{ steps.extract-version.outputs.version }}.tar.gz
-        env:
-          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}


### PR DESCRIPTION
Moving the conversation from https://github.com/Homebrew/homebrew-core/pull/149334#issuecomment-1746766176 /cc @ssbarnea 

This updates the `download-url` input to the `bump-homebrew-formula-action` to be a URL in the format of `https://pypi.org/packages/source/a/ansible-lint/ansible-lint-<VERSION>.tar.gz`.

That resource ultimately resolves to `https://files.pythonhosted.org/packages/*/*/*/ansible-lint-<VERSION>.tar.gz`, which is the URL format currently present in the homebrew-core formula. I find the latter form unwieldy, and I think that the `pypi.org`-hosted resource looks much nicer and should be the same trustworthiness. I'm _not_ familiar with python-hosted anything, so you should decide which canonical form works best for you (and for the homebrew-core team).

Followup to https://github.com/ansible/ansible-lint/pull/2982
Ref. https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=published#release
Ref. https://github.com/marketplace/actions/bump-homebrew-formula#action-inputs
Ref. https://github.com/Homebrew/homebrew-core/pull/128963#issuecomment-1519423319