### PR TITLE
Support complex requirements in argument_specs.yml

### DIFF
--- a/src/ansiblelint/schemas/role-arg-spec.json
+++ b/src/ansiblelint/schemas/role-arg-spec.json
@@ -198,6 +198,70 @@
           "default": false,
           "type": "boolean"
         },
+        "mutually_exclusive": {
+          "type": "array",
+          "items": {
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required_together": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required_one_of": {
+          "type": "array",
+          "items": {
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required_if": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "prefixItems": [
+              {
+                "type": "string"
+              },
+              {},
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              {
+                "type": "boolean"
+              }
+            ],
+            "minItems": 3,
+            "maxItems": 4
+          }
+        },
+        "required_by": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          }
+        },
         "type": {
           "$ref": "#/$defs/datatype",
           "markdownDescription": "See [argument-spec](https://docs.ansible.com/ansible/latest/dev_guide/developing_program_flow_modules.html#argument-spec"

--- a/test/schemas/test/roles/foo/meta/argument_specs.yml
+++ b/test/schemas/test/roles/foo/meta/argument_specs.yml
@@ -40,6 +40,35 @@ argument_specs:
               - 3
               - 123
 
+      complex_required_options:
+        type: dict
+        description: Contains sub-options with interacting requirements
+        options:
+          foo:
+            type: str
+          bar:
+            type: str
+          baz:
+            type: str
+
+        mutually_exclusive:
+          - ["foo", "bar"]
+
+        required_together:
+          - ["bar", "baz"]
+
+        required_one_of:
+          - ["foo", "bar", "baz"]
+
+        required_if:
+          - ["foo", "must_have_bar_and_baz_default", ["bar", "baz"]]
+          - ["foo", "must_have_bar_and_baz_explicit", ["bar", "baz"], false]
+          - ["foo", "must_have_one_of_bar_or_baz", ["bar", "baz"], true]
+
+        required_by:
+          foo: "bar"
+          bar: ["foo", "baz"]
+
     seealso:
       - module: community.foo.bar
       - module: community.foo.baz


### PR DESCRIPTION
Extend schema to support the more advanced requirements specifications for arguments.

Fixes: #3822