### PR TITLE
Fix SARIF-formatter severity levels

### DIFF
--- a/src/ansiblelint/formatters/__init__.py
+++ b/src/ansiblelint/formatters/__init__.py
@@ -314,15 +314,13 @@ class SarifFormatter(BaseFormatter[Any]):
 
     @staticmethod
     def _get_sarif_rule_severity_level(rule: BaseRule) -> str:
-        """
-        General SARIF severity level for a rule.
-        (Can differ from an actual result/match severity.)
+        """General SARIF severity level for a rule.
+        (Can differ from an actual result/match severity.).
 
         Possible values: "none", "note", "warning", "error"
 
         see: https://github.com/oasis-tcs/sarif-spec/blob/123e95847b13fbdd4cbe2120fa5e33355d4a042b/Schemata/sarif-schema-2.1.0.json#L1934-L1939
         """
-
         if rule.severity in ["VERY_HIGH", "HIGH"]:
             return "error"
 
@@ -336,14 +334,12 @@ class SarifFormatter(BaseFormatter[Any]):
 
     @staticmethod
     def _get_sarif_result_severity_level(match: MatchError) -> str:
-        """
-        SARIF severity level for an actual result/match.
+        """SARIF severity level for an actual result/match.
 
         Possible values: "none", "note", "warning", "error"
 
         see: https://github.com/oasis-tcs/sarif-spec/blob/123e95847b13fbdd4cbe2120fa5e33355d4a042b/Schemata/sarif-schema-2.1.0.json#L2066-L2071
         """
-
         if not match.level:
             return "none"
 

--- a/src/ansiblelint/formatters/__init__.py
+++ b/src/ansiblelint/formatters/__init__.py
@@ -265,7 +265,7 @@ class SarifFormatter(BaseFormatter[Any]):
                 "text": str(match.message),
             },
             "defaultConfiguration": {
-                "level": self._get_sarif_rule_severity_level(match.rule),
+                "level": self.get_sarif_rule_severity_level(match.rule),
             },
             "help": {
                 "text": str(match.rule.description),
@@ -286,7 +286,7 @@ class SarifFormatter(BaseFormatter[Any]):
 
         result: dict[str, Any] = {
             "ruleId": match.tag,
-            "level": self._get_sarif_result_severity_level(match),
+            "level": self.get_sarif_result_severity_level(match),
             "message": {
                 "text": str(match.details)
                 if str(match.details)
@@ -313,10 +313,10 @@ class SarifFormatter(BaseFormatter[Any]):
         return result
 
     @staticmethod
-    def _get_sarif_rule_severity_level(rule: BaseRule) -> str:
+    def get_sarif_rule_severity_level(rule: BaseRule) -> str:
         """General SARIF severity level for a rule.
-        (Can differ from an actual result/match severity.).
 
+        Note: Can differ from an actual result/match severity.
         Possible values: "none", "note", "warning", "error"
 
         see: https://github.com/oasis-tcs/sarif-spec/blob/123e95847b13fbdd4cbe2120fa5e33355d4a042b/Schemata/sarif-schema-2.1.0.json#L1934-L1939
@@ -333,7 +333,7 @@ class SarifFormatter(BaseFormatter[Any]):
         return "none"
 
     @staticmethod
-    def _get_sarif_result_severity_level(match: MatchError) -> str:
+    def get_sarif_result_severity_level(match: MatchError) -> str:
         """SARIF severity level for an actual result/match.
 
         Possible values: "none", "note", "warning", "error"

--- a/src/ansiblelint/formatters/__init__.py
+++ b/src/ansiblelint/formatters/__init__.py
@@ -14,6 +14,7 @@ from ansiblelint.version import __version__
 
 if TYPE_CHECKING:
     from ansiblelint.errors import MatchError
+    from ansiblelint.rules import BaseRule
 
 T = TypeVar("T", bound="BaseFormatter")  # type: ignore[type-arg]
 
@@ -264,7 +265,7 @@ class SarifFormatter(BaseFormatter[Any]):
                 "text": str(match.message),
             },
             "defaultConfiguration": {
-                "level": self._to_sarif_level(match),
+                "level": self._get_sarif_rule_severity_level(match.rule),
             },
             "help": {
                 "text": str(match.rule.description),
@@ -285,7 +286,7 @@ class SarifFormatter(BaseFormatter[Any]):
 
         result: dict[str, Any] = {
             "ruleId": match.tag,
-            "level": match.level,
+            "level": self._get_sarif_result_severity_level(match),
             "message": {
                 "text": str(match.details)
                 if str(match.details)
@@ -312,6 +313,44 @@ class SarifFormatter(BaseFormatter[Any]):
         return result
 
     @staticmethod
-    def _to_sarif_level(match: MatchError) -> str:
-        # sarif accepts only 4 levels: error, warning, note, none
-        return match.level
+    def _get_sarif_rule_severity_level(rule: BaseRule) -> str:
+        """
+        General SARIF severity level for a rule.
+        (Can differ from an actual result/match severity.)
+
+        Possible values: "none", "note", "warning", "error"
+
+        see: https://github.com/oasis-tcs/sarif-spec/blob/123e95847b13fbdd4cbe2120fa5e33355d4a042b/Schemata/sarif-schema-2.1.0.json#L1934-L1939
+        """
+
+        if rule.severity in ["VERY_HIGH", "HIGH"]:
+            return "error"
+
+        if rule.severity in ["MEDIUM", "LOW", "VERY_LOW"]:
+            return "warning"
+
+        if rule.severity == "INFO":
+            return "note"
+
+        return "none"
+
+    @staticmethod
+    def _get_sarif_result_severity_level(match: MatchError) -> str:
+        """
+        SARIF severity level for an actual result/match.
+
+        Possible values: "none", "note", "warning", "error"
+
+        see: https://github.com/oasis-tcs/sarif-spec/blob/123e95847b13fbdd4cbe2120fa5e33355d4a042b/Schemata/sarif-schema-2.1.0.json#L2066-L2071
+        """
+
+        if not match.level:
+            return "none"
+
+        if match.level == "error":
+            return "error"
+
+        if match.level == "warning":
+            return "warning"
+
+        return "note"

--- a/src/ansiblelint/formatters/__init__.py
+++ b/src/ansiblelint/formatters/__init__.py
@@ -14,7 +14,7 @@ from ansiblelint.version import __version__
 
 if TYPE_CHECKING:
     from ansiblelint.errors import MatchError
-    from ansiblelint.rules import BaseRule
+    from ansiblelint.rules import BaseRule  # type: ignore[attr-defined]
 
 T = TypeVar("T", bound="BaseFormatter")  # type: ignore[type-arg]
 

--- a/src/ansiblelint/formatters/__init__.py
+++ b/src/ansiblelint/formatters/__init__.py
@@ -343,10 +343,7 @@ class SarifFormatter(BaseFormatter[Any]):
         if not match.level:
             return "none"
 
-        if match.level == "error":
-            return "error"
-
-        if match.level == "warning":
-            return "warning"
+        if match.level in ["warning", "error"]:
+            return match.level
 
         return "note"

--- a/test/test_formatter_sarif.py
+++ b/test/test_formatter_sarif.py
@@ -120,7 +120,7 @@ class TestSarifFormatter:
         assert rules[0]["shortDescription"]["text"] == self.matches[0].message
         assert rules[0]["defaultConfiguration"][
             "level"
-        ] == self.formatter._get_sarif_rule_severity_level(self.matches[0].rule)
+        ] == SarifFormatter.get_sarif_rule_severity_level(self.matches[0].rule)
         assert rules[0]["help"]["text"] == self.matches[0].rule.description
         assert rules[0]["properties"]["tags"] == self.matches[0].rule.tags
         assert rules[0]["helpUri"] == self.matches[0].rule.url
@@ -152,7 +152,7 @@ class TestSarifFormatter:
                     "startColumn"
                     not in result["locations"][0]["physicalLocation"]["region"]
                 )
-            assert result["level"] == self.formatter._get_sarif_result_severity_level(
+            assert result["level"] == SarifFormatter.get_sarif_result_severity_level(
                 self.matches[i]
             )
         assert sarif["runs"][0]["originalUriBaseIds"][SarifFormatter.BASE_URI_ID]["uri"]

--- a/test/test_formatter_sarif.py
+++ b/test/test_formatter_sarif.py
@@ -27,7 +27,6 @@ class TestSarifFormatter:
 
     def setup_class(self) -> None:
         """Set up few MatchError objects."""
-
         self.rule1.id = "TCF0001"
         self.rule1.severity = "VERY_HIGH"
         self.rule1.description = "This is the rule description."
@@ -39,37 +38,39 @@ class TestSarifFormatter:
         self.rule2.link = "https://rules/help#TCF0002"
         self.rule2.tags = ["tag3", "tag4"]
 
-        self.matches.extend([
-            MatchError(
-                message="message1",
-                lineno=1,
-                column=10,
-                details="details1",
-                lintable=Lintable("filename1.yml", content=""),
-                rule=self.rule1,
-                tag="yaml[test1]",
-                ignored=False
-            ),
-            MatchError(
-                message="message2",
-                lineno=2,
-                details="",
-                lintable=Lintable("filename2.yml", content=""),
-                rule=self.rule1,
-                tag="yaml[test2]",
-                ignored=True
-            ),
-            MatchError(
-                message="message3",
-                lineno=666,
-                column=667,
-                details="details3",
-                lintable=Lintable("filename3.yml", content=""),
-                rule=self.rule2,
-                tag="yaml[test3]",
-                ignored=False
-            ),
-        ])
+        self.matches.extend(
+            [
+                MatchError(
+                    message="message1",
+                    lineno=1,
+                    column=10,
+                    details="details1",
+                    lintable=Lintable("filename1.yml", content=""),
+                    rule=self.rule1,
+                    tag="yaml[test1]",
+                    ignored=False,
+                ),
+                MatchError(
+                    message="message2",
+                    lineno=2,
+                    details="",
+                    lintable=Lintable("filename2.yml", content=""),
+                    rule=self.rule1,
+                    tag="yaml[test2]",
+                    ignored=True,
+                ),
+                MatchError(
+                    message="message3",
+                    lineno=666,
+                    column=667,
+                    details="details3",
+                    lintable=Lintable("filename3.yml", content=""),
+                    rule=self.rule2,
+                    tag="yaml[test3]",
+                    ignored=False,
+                ),
+            ]
+        )
 
         self.formatter = SarifFormatter(pathlib.Path.cwd(), display_relative_path=True)
 
@@ -117,7 +118,9 @@ class TestSarifFormatter:
         assert rules[0]["id"] == self.matches[0].tag
         assert rules[0]["name"] == self.matches[0].tag
         assert rules[0]["shortDescription"]["text"] == self.matches[0].message
-        assert rules[0]["defaultConfiguration"]["level"] == self.formatter._get_sarif_rule_severity_level(self.matches[0].rule)
+        assert rules[0]["defaultConfiguration"][
+            "level"
+        ] == self.formatter._get_sarif_rule_severity_level(self.matches[0].rule)
         assert rules[0]["help"]["text"] == self.matches[0].rule.description
         assert rules[0]["properties"]["tags"] == self.matches[0].rule.tags
         assert rules[0]["helpUri"] == self.matches[0].rule.url
@@ -149,7 +152,9 @@ class TestSarifFormatter:
                     "startColumn"
                     not in result["locations"][0]["physicalLocation"]["region"]
                 )
-            assert result["level"] == self.formatter._get_sarif_result_severity_level(self.matches[i])
+            assert result["level"] == self.formatter._get_sarif_result_severity_level(
+                self.matches[i]
+            )
         assert sarif["runs"][0]["originalUriBaseIds"][SarifFormatter.BASE_URI_ID]["uri"]
         assert results[0]["message"]["text"] == self.matches[0].details
         assert results[1]["message"]["text"] == self.matches[1].message

--- a/test/test_formatter_sarif.py
+++ b/test/test_formatter_sarif.py
@@ -69,7 +69,7 @@ class TestSarifFormatter:
                     tag="yaml[test3]",
                     ignored=False,
                 ),
-            ]
+            ],
         )
 
         self.formatter = SarifFormatter(pathlib.Path.cwd(), display_relative_path=True)
@@ -153,7 +153,7 @@ class TestSarifFormatter:
                     not in result["locations"][0]["physicalLocation"]["region"]
                 )
             assert result["level"] == SarifFormatter.get_sarif_result_severity_level(
-                self.matches[i]
+                self.matches[i],
             )
         assert sarif["runs"][0]["originalUriBaseIds"][SarifFormatter.BASE_URI_ID]["uri"]
         assert results[0]["message"]["text"] == self.matches[0].details

--- a/test/test_formatter_sarif.py
+++ b/test/test_formatter_sarif.py
@@ -24,6 +24,8 @@ class TestSarifFormatter:
     matches: list[MatchError] = []
     formatter: SarifFormatter | None = None
     collection = RulesCollection()
+    collection.register(rule1)
+    collection.register(rule2)
 
     def setup_class(self) -> None:
         """Set up few MatchError objects."""


### PR DESCRIPTION
The SARIF formatter output contains information about "severity levels" in two different contexts (which should be handled differently).

* general "rule-based" severity levels
* "error-/match-based" severity levels within the result set
