### PR TITLE
Add some platforms to `meta.json`

### DIFF
--- a/src/ansiblelint/schemas/meta.json
+++ b/src/ansiblelint/schemas/meta.json
@@ -168,6 +168,7 @@
               "sid",
               "squeeze",
               "stretch",
+              "trixie",
               "wheezy",
               "all"
             ],

--- a/src/ansiblelint/schemas/meta.json
+++ b/src/ansiblelint/schemas/meta.json
@@ -1056,6 +1056,7 @@
               "impish",
               "jammy",
               "lucid",
+              "lunar",
               "maverick",
               "natty",
               "oneiric",

--- a/src/ansiblelint/schemas/meta.json
+++ b/src/ansiblelint/schemas/meta.json
@@ -1057,6 +1057,7 @@
               "jammy",
               "lucid",
               "lunar",
+              "mantic",
               "maverick",
               "natty",
               "oneiric",


### PR DESCRIPTION
Add the following platforms to the schema in `meta.json`:
- [Debian 13 (Trixie)](https://www.debian.org/releases/trixie/)
- [Ubuntu 23.04 (Lunar Lobster)](https://canonical.com/blog/canonical-releases-ubuntu-23-04-lunar-lobster)
- [Ubuntu 23.10 (Mantic Minotaur)](https://canonical.com/blog/canonical-releases-ubuntu-23-10-mantic-minotaur)