### PR TITLE
Update supported Ubuntu versions in `meta.json`

### DIFF
--- a/src/ansiblelint/schemas/meta.json
+++ b/src/ansiblelint/schemas/meta.json
@@ -1047,7 +1047,6 @@
               "artful",
               "bionic",
               "cosmic",
-              "cuttlefish",
               "disco",
               "eoan",
               "focal",

--- a/src/ansiblelint/schemas/meta.json
+++ b/src/ansiblelint/schemas/meta.json
@@ -1054,6 +1054,7 @@
               "hirsute",
               "impish",
               "jammy",
+              "kinetic",
               "lucid",
               "lunar",
               "mantic",


### PR DESCRIPTION
A followup from #3841.

- Remove `"cuttlefish"` as it is already (and correctly) covered by `"cosmic"` for Ubuntu 18.10 (Cosmic Cuttlefish).
- Add [Ubuntu 22.10 (Kinetic Kudu)](https://ubuntu.com/blog/canonical-releases-ubuntu-22-10-kinetic-kudu) for completeness.