### PR TITLE
Support `ruamel-yaml >= 0.18.2`

### DIFF
--- a/.config/requirements-lock.txt
+++ b/.config/requirements-lock.txt
@@ -34,7 +34,7 @@ referencing==0.30.2
 requests==2.31.0
 rich==13.5.3
 rpds-py==0.10.3
-ruamel-yaml==0.17.33
+ruamel-yaml==0.18.2
 subprocess-tee==0.4.1
 tomli==2.0.1
 typing-extensions==4.8.0

--- a/.config/requirements-test.txt
+++ b/.config/requirements-test.txt
@@ -11,7 +11,7 @@ pytest >= 7.2.2
 pytest-mock
 pytest-plus >= 0.6 # for PYTEST_REQPASS
 pytest-xdist >= 2.1.0
-ruamel.yaml>=0.17.31,<0.18 # only the latest is expected to pass our tests
+ruamel.yaml>=0.17.31
 ruamel-yaml-clib  # needed for mypy
 types-jsonschema # IDE support
 types-pyyaml # IDE support

--- a/.config/requirements.in
+++ b/.config/requirements.in
@@ -10,7 +10,7 @@ packaging>=21.3 # Apache-2.0,BSD-2-Clause
 pathspec>=0.10.3 # Mozilla Public License 2.0 (MPL 2.0)
 pyyaml>=5.4.1 # MIT (centos 9 has 5.3.1)
 rich>=12.0.0 # MIT
-ruamel.yaml>=0.17.0,<0.18,!=0.17.29,!=0.17.30 # MIT, next version is planned to have breaking changes
+ruamel.yaml>=0.17.0,!=0.17.29,!=0.17.30 # MIT
 requests>=2.31.0 # Apache-2.0 (indirect, but we want newer version for security reasons)
 subprocess-tee>=0.4.1 # MIT, used by ansible-compat
 yamllint >= 1.30.0 # GPLv3

--- a/.config/requirements.txt
+++ b/.config/requirements.txt
@@ -92,7 +92,7 @@ regex==2023.8.8
 requests==2.31.0
 rich==13.5.3
 rpds-py==0.10.3
-ruamel-yaml==0.17.33
+ruamel-yaml==0.18.2
 six==1.16.0
 soupsieve==2.5
 subprocess-tee==0.4.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -157,7 +157,7 @@ repos:
           - pytest>=7.2.2
           - rich>=13.2.0
           - ruamel-yaml-clib>=0.2.7
-          - ruamel-yaml>=0.17.31
+          - ruamel-yaml>=0.18.2
           - subprocess-tee
           - types-PyYAML
           - types-jsonschema>=4.4.2
@@ -188,7 +188,7 @@ repos:
           - pyyaml
           - rich>=13.2.0
           - ruamel-yaml-clib>=0.2.7
-          - ruamel-yaml>=0.17.31
+          - ruamel-yaml>=0.18.2
           - typing_extensions
           - wcmatch
           - yamllint


### PR DESCRIPTION
https://pypi.org/project/ruamel.yaml/0.18.0 was released on 2023-10-23.