### PR TITLE
Fix setuptools-scm versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ name: release
 jobs:
   # https://github.com/marketplace/actions/actions-tagger
   actions-tagger:
+    needs: pypi # do not move the mobile tag until we publish
     runs-on: windows-latest
     permissions:
       # Give the default GITHUB_TOKEN write permission.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -288,4 +288,15 @@ dependencies = { file = [".config/requirements.in"] }
 
 [tool.setuptools_scm]
 local_scheme = "no-local-version"
+tag_regex = "^(?P<prefix>v)?(?P<version>[0-9.]+)(?P<suffix>.*)?$"
 write_to = "src/ansiblelint/_version.py"
+# To prevent accidental pick of mobile version tags such 'v6'
+git_describe_command = [
+  "git",
+  "describe",
+  "--dirty",
+  "--tags",
+  "--long",
+  "--match",
+  "v*.*",
+]


### PR DESCRIPTION
This change reconfigures setuptools-scm to ignore mobile tags such `v6` and stick to more detailed ones. This issue caused the failure to publish on pypi on last release.

Related: https://github.com/ansible/ansible-lint/issues/3884