### PR TITLE
Log ignored exception details to debug log

### DIFF
--- a/src/ansiblelint/_internal/rules.py
+++ b/src/ansiblelint/_internal/rules.py
@@ -99,6 +99,7 @@ class BaseRule:
                         str(file),
                         exc,
                     )
+                    _logger.debug("Ignored exception details", exc_info=True)
         else:
             matches.extend(self.matchdir(file))
         return matches


### PR DESCRIPTION
This allows the user to see the exception stack trace by running in verbose mode.

Example:

```
DEBUG    Running rule yaml
DEBUG    Running rule args
WARNING  Ignored exception from ArgsRule.<bound method AnsibleLintRule.matchtasks of args: Validating module arguments.> while processing roles/alertmanager/tasks/main.yml (tasks): No module named 'distutils'
DEBUG    Ignored exception details
Traceback (most recent call last):
  File "/home/bluecmd/work/sonix-ansible/ansible/lib64/python3.12/site-packages/ansiblelint/_internal/rules.py", line 93, in getmatches
    matches.extend(method(file))
                   ^^^^^^^^^^^^
  File "/home/bluecmd/work/sonix-ansible/ansible/lib64/python3.12/site-packages/ansiblelint/rules/__init__.py", line 177, in matchtasks
    result = self.matchtask(task, file=file)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bluecmd/work/sonix-ansible/ansible/lib64/python3.12/site-packages/ansiblelint/rules/args.py", line 159, in matchtask
    spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 994, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/home/bluecmd/.ansible/collections/ansible_collections/ansible/posix/plugins/modules/firewalld.py", line 216, in <module>
    from ansible_collections.ansible.posix.plugins.module_utils.firewalld import FirewallTransaction, fw_offline
  File "/home/bluecmd/work/sonix-ansible/ansible/lib64/python3.12/site-packages/ansible/utils/collection_loader/_collection_finder.py", line 594, in exec_module
    exec(code_obj, module.__dict__)
  File "/home/bluecmd/.ansible/collections/ansible_collections/ansible/posix/plugins/module_utils/firewalld.py", line 11, in <module>
    from distutils.version import LooseVersion
ModuleNotFoundError: No module named 'distutils'
DEBUG    Running rule avoid-implicit
DEBUG    Running rule command-instead-of-module
```