### PR TITLE
Allow to set `max_fail_percentage` as templated integer

### DIFF
--- a/src/ansiblelint/schemas/ansible.json
+++ b/src/ansiblelint/schemas/ansible.json
@@ -527,7 +527,7 @@
         },
         "max_fail_percentage": {
           "title": "Max Fail Percentage",
-          "type": "number"
+          "$ref": "#/$defs/templated-integer"
         },
         "module_defaults": {
           "title": "Module Defaults"

--- a/src/ansiblelint/schemas/playbook.json
+++ b/src/ansiblelint/schemas/playbook.json
@@ -541,8 +541,8 @@
           "type": "boolean"
         },
         "max_fail_percentage": {
-          "title": "Max Fail Percentage",
-          "type": "number"
+          "$ref": "#/$defs/templated-integer",
+          "title": "Max Fail Percentage"
         },
         "module_defaults": {
           "title": "Module Defaults"


### PR DESCRIPTION
Recently in a [PR](https://github.com/openstack-k8s-operators/edpm-ansible/pull/494), one of my colleagues modified a playbook in this way:

```
  hosts: all
  strategy: linear
  become: true
  any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
  max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
<cut>
```

but the linter failed with error:

```
schema[playbook]: $[0].max_fail_percentage '{{ edpm_max_fail_percentage | default(0) }}' is not of type 'number'
```

Hopefully this should solve the issue.