### PR TITLE
GitHub Action: properly respect the `working_directory` argument

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,16 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Process inputs
+      id: inputs
+      shell: bash
+      run: |
+        if [[ -n "${{ inputs.working_directory }}" ]]; then
+          echo "working_directory=${{ inputs.working_directory }}" >> $GITHUB_OUTPUT
+        else
+          echo "working_directory=${{ github.workspace }}" >> $GITHUB_OUTPUT
+        fi
+
     # Due to GHA limitation, caching works only for files within GITHUB_WORKSPACE
     # folder, so we are forced to stick this temporary file inside .git, so it
     # will not affect the linted repository.
@@ -49,16 +59,6 @@ runs:
         cd $GITHUB_ACTION_PATH
         pip install "ansible-lint[lock] @ git+https://github.com/ansible/ansible-lint@${{ github.action_ref || 'main' }}"
         ansible-lint --version
-
-    - name: Process inputs
-      id: inputs
-      shell: bash
-      run: |
-        if [[ -n "${{ inputs.working_directory }}" ]]; then
-          echo "working_directory=${{ inputs.working_directory }}" >> $GITHUB_OUTPUT
-        else
-          echo "working_directory=${{ github.workspace }}" >> $GITHUB_OUTPUT
-        fi
 
     - name: Run ansible-lint
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,7 @@ runs:
     # https://github.com/actions/setup-python/issues/361
     - name: Generate .git/ansible-lint-requirements.txt
       shell: bash
+      working-directory: ${{ steps.inputs.outputs.working_directory }}
       run: |
         wget --output-document=.git/ansible-lint-requirements.txt https://raw.githubusercontent.com/ansible/ansible-lint/${{ github.action_ref || 'main' }}/.config/requirements-lock.txt
 
@@ -46,7 +47,7 @@ runs:
       uses: actions/setup-python@v4
       with:
         cache: pip
-        cache-dependency-path: .git/ansible-lint-requirements.txt
+        cache-dependency-path: ${{ steps.inputs.outputs.working_directory }}/.git/ansible-lint-requirements.txt
         python-version: "3.11"
 
     - name: Install ansible-lint


### PR DESCRIPTION
PR #3798 introduced a `working_directory` argument to switch the base directory in which `ansible-lint` runs; while it seems a good idea, in practice it does not work properly.
When specifying a different working directory than `github.workspace`, the steps before the `ansible-lint` run are not run in that different directory, leading to `wget` and `pip` to fail because of `.git` not found.

Hence:
- process the arguments earlier
- use the working directory in all the steps that need it