### PR TITLE
Avoid jinja[invalid] with ansible.builtin.mandatory filter

### DIFF
--- a/examples/playbooks/rule-jinja-pass.yml
+++ b/examples/playbooks/rule-jinja-pass.yml
@@ -84,3 +84,7 @@
     - name: "Bug https://github.com/ansible/ansible-lint/issues/3155"
       ansible.builtin.debug:
         msg: "Is changed:{{ date_cmd is changed }}"
+
+    - name: Bug https://github.com/ansible/ansible-lint/issues/3908
+      ansible.builtin.debug:
+        msg: "{{ foo | ansible.builtin.mandatory(msg='My message') }}"

--- a/src/ansiblelint/rules/jinja.py
+++ b/src/ansiblelint/rules/jinja.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any, NamedTuple
 
 import black
 import jinja2
-from ansible.errors import AnsibleError, AnsibleParserError
+from ansible.errors import AnsibleError, AnsibleFilterError, AnsibleParserError
 from ansible.parsing.yaml.objects import AnsibleUnicode
 from jinja2.exceptions import TemplateSyntaxError
 
@@ -132,6 +132,8 @@ class JinjaRule(AnsibleLintRule, TransformMixin):
                             variables=deannotate(task.get("vars", {})),
                             fail_on_error=True,  # we later decide which ones to ignore or not
                         )
+                    except AnsibleFilterError:
+                        bypass = True
                     # ValueError RepresenterError
                     except AnsibleError as exc:
                         bypass = False


### PR DESCRIPTION
Fixes: #3908
