### PR TITLE
Fix backward compatibility

### DIFF
--- a/.config/requirements-lock.txt
+++ b/.config/requirements-lock.txt
@@ -1,0 +1,1 @@
+lock-requirements.txt


### PR DESCRIPTION
Any versions before this PR https://github.com/ansible/ansible-lint/pull/3762 (`v6.22.1`) use the `main` branch for `requirements-lock.txt`. (full url `https://raw.githubusercontent.com/ansible/ansible-lint/main/.config/requirements-lock.txt`)
It still uses the main branch even if you specify a particular version. 
For example, this config
```yaml
name: ansible-lint
on: [pull_request]

jobs:
  build:
    name: Ansible Lint # Naming the build is important to use it as a status check
    runs-on: ubuntu-latest
    steps:
      - name: Checkout Code
        uses: actions/checkout@v2
      - name: Run ansible-lint
        uses: ansible/ansible-lint@v6.20.0
```
will try to download the main branch:
```sh
Run wget --output-file=.git/ansible-lint-requirements.txt https://raw.githubusercontent.com/ansible/ansible-lint/main/.config/requirements-lock.txt
  wget --output-file=.git/ansible-lint-requirements.txt https://raw.githubusercontent.com/ansible/ansible-lint/main/.config/requirements-lock.txt
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
Error: Process completed with exit code 8.
```
The PR that broke backward compatibility is this one https://github.com/ansible/ansible-lint/pull/3925

Fixes issue: https://github.com/ansible/ansible-lint/issues/3928

https://github.com/ansible/ansible-lint/commit/7fa5f76e0333a97476b5204487f183efb5e3d467