### PR TITLE
Ignore set-property for systemd command

### DIFF
--- a/src/ansiblelint/rules/command_instead_of_module.py
+++ b/src/ansiblelint/rules/command_instead_of_module.py
@@ -69,7 +69,14 @@ class CommandsInsteadOfModulesRule(AnsibleLintRule):
 
     _executable_options = {
         "git": ["branch", "log", "lfs", "rev-parse"],
-        "systemctl": ["--version", "kill", "set-default", "show-environment", "status"],
+        "systemctl": [
+            "--version",
+            "kill",
+            "set-default",
+            "set-property",
+            "show-environment",
+            "status",
+        ],
         "yum": ["clean"],
         "rpm": ["--nodeps"],
     }


### PR DESCRIPTION
For example:

`systemctl set-property systemd-nspawn@CONTAINER.service MemoryMax=1g`

is not supported by the systemd ansible command.