### PR TITLE
gha: disable latest tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,8 @@ jobs:
       - uses: Actions-R-Us/actions-tagger@latest
         with:
           token: "${{ github.token }}"
-          publish_latest_tag: true
+          # Do not activate latest tag because it seems to affect RTD builds
+          # publish_latest_tag: true
   pypi:
     name: Publish to PyPI registry
     environment: release


### PR DESCRIPTION
This will ensure that merged documentation changes are published immediately.

Related: https://github.com/readthedocs/readthedocs.org/issues/6415