### PR TITLE
Allow dashes in legacy role namespaces

### DIFF
--- a/src/ansiblelint/schemas/meta.json
+++ b/src/ansiblelint/schemas/meta.json
@@ -512,7 +512,7 @@
         "namespace": {
           "markdownDescription": "Used by molecule and ansible-lint to compute FQRN for roles outside collections",
           "minLength": 2,
-          "pattern": "^[a-z][a-z0-9_]+$",
+          "pattern": "^[a-z][a-z0-9_-]+$",
           "title": "Namespace Name",
           "type": "string"
         },

--- a/test/schemas/negative_test/roles/meta_invalid_role_namespace/meta/main.yml.md
+++ b/test/schemas/negative_test/roles/meta_invalid_role_namespace/meta/main.yml.md
@@ -19,15 +19,6 @@
       "failingKeyword": "then"
     },
     "schemaPath": "#/allOf/0/if"
-  },
-  {
-    "instancePath": "/galaxy_info/namespace",
-    "keyword": "pattern",
-    "message": "must match pattern \"^[a-z][a-z0-9_]+$\"",
-    "params": {
-      "pattern": "^[a-z][a-z0-9_]+$"
-    },
-    "schemaPath": "#/properties/namespace/pattern"
   }
 ]
 ```
@@ -45,12 +36,6 @@ stdout:
       "filename": "negative_test/roles/meta_invalid_role_namespace/meta/main.yml",
       "path": "$.galaxy_info",
       "message": "'author' is a required property",
-      "has_sub_errors": false
-    },
-    {
-      "filename": "negative_test/roles/meta_invalid_role_namespace/meta/main.yml",
-      "path": "$.galaxy_info.namespace",
-      "message": "'foo-bar' does not match '^[a-z][a-z0-9_]+$'",
       "has_sub_errors": false
     }
   ],


### PR DESCRIPTION
Fixes: #3961 