### PR TITLE
Make File Permissions Mode a String

### DIFF
--- a/src/ansiblelint/rules/risky_file_permissions.md
+++ b/src/ansiblelint/rules/risky_file_permissions.md
@@ -50,7 +50,7 @@ Modules that are checked:
 - name: Safe example of using ini_file (2nd solution)
   community.general.ini_file:
     path: foo
-    mode: 0600  # explicitly sets the desired permissions, to make the results predictable
+    mode: "0600"  # explicitly sets the desired permissions, to make the results predictable
 
 - name: Safe example of using copy (3rd solution)
   ansible.builtin.copy:


### PR DESCRIPTION
The example was a number with a leading zero, which is interpreted as an octal number. This is unexpected and undesired behavior, and was caught by another ansiblelint rule ("Forbidden implicit octal value", `yaml[octal-values]`).

This change makes the value in the example a string, which means the fix to the file permissions rule violation will not cause another rule violation.