### PR TITLE
Support notes and requirements in role entrypoint argument specs

### DIFF
--- a/src/ansiblelint/schemas/role-arg-spec.json
+++ b/src/ansiblelint/schemas/role-arg-spec.json
@@ -141,11 +141,37 @@
         "examples": {
           "type": "string"
         },
+        "notes": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ]
+        },
         "options": {
           "additionalProperties": {
             "$ref": "#/$defs/option"
           },
           "type": "object"
+        },
+        "requirements": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ]
         },
         "seealso": {
           "items": {

--- a/test/schemas/test/roles/foo/meta/argument_specs.yml
+++ b/test/schemas/test/roles/foo/meta/argument_specs.yml
@@ -6,6 +6,9 @@ argument_specs:
     description: "a longer description"
     version_added: 1.2.3
     author: Foobar Baz
+    notes:
+      - This is a note.
+      - This is another note.
     options:
       my_app_int:
         type: "int"
@@ -69,6 +72,10 @@ argument_specs:
           foo: "bar"
           bar: ["foo", "baz"]
 
+    requirements:
+      - Requirement 1
+      - Requirement 2
+
     seealso:
       - module: community.foo.bar
       - module: community.foo.baz
@@ -120,4 +127,6 @@ argument_specs:
     description:
       - First paragraph.
       - Second paragraph.
+    notes: A note.
     options: {}
+    requirements: A requirement


### PR DESCRIPTION
See https://github.com/ansible/ansible/issues/81735 and https://github.com/ansible/ansible/pull/81796.

`seealso` and `version_added` is already supported, so there's nothing to do.