### PR TITLE
Add attributes for role argument specs

### DIFF
--- a/src/ansiblelint/schemas/role-arg-spec.json
+++ b/src/ansiblelint/schemas/role-arg-spec.json
@@ -31,6 +31,32 @@
             }
           ]
         },
+        "membership": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "platform": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ]
+        },
         "support": {
           "enum": ["full", "partial", "none", "N/A"],
           "type": "string"

--- a/src/ansiblelint/schemas/role-arg-spec.json
+++ b/src/ansiblelint/schemas/role-arg-spec.json
@@ -1,5 +1,52 @@
 {
   "$defs": {
+    "attribute": {
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "description": "Detailed explanation of what this attribute does. It should be written in full sentences.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "details": {
+          "description": "Detailed explanation of what this attribute does. It should be written in full sentences.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "support": {
+          "enum": [
+            "full",
+            "partial",
+            "none",
+            "N/A"
+          ],
+          "type": "string"
+        },
+        "version_added": {
+          "type": "string"
+        }
+      },
+      "required": ["description", "support"],
+      "title": "Attribute"
+    },
     "datatype": {
       "enum": [
         "str",
@@ -38,6 +85,12 @@
     "entry_point": {
       "additionalProperties": false,
       "properties": {
+        "attributes": {
+          "additionalProperties": {
+            "$ref": "#/$defs/attribute"
+          },
+          "type": "object"
+        },
         "author": {
           "oneOf": [
             {

--- a/src/ansiblelint/schemas/role-arg-spec.json
+++ b/src/ansiblelint/schemas/role-arg-spec.json
@@ -32,12 +32,7 @@
           ]
         },
         "support": {
-          "enum": [
-            "full",
-            "partial",
-            "none",
-            "N/A"
-          ],
+          "enum": ["full", "partial", "none", "N/A"],
           "type": "string"
         },
         "version_added": {

--- a/test/schemas/test/roles/foo/meta/argument_specs.yml
+++ b/test/schemas/test/roles/foo/meta/argument_specs.yml
@@ -89,6 +89,17 @@ argument_specs:
     author:
       - Foobar Baz
       - Bert Foo
+    attributes:
+      idempotent:
+        description: Whether the role is idempotent.
+        support: full
+      check_mode:
+        description:
+          - Whether the role supports check mode.
+        support: partial
+        details:
+          - Does not work if O(my_app_int=5).
+        version_added: 1.2.0
     options:
       my_app_int:
         type: "int"

--- a/test/schemas/test/roles/foo/meta/argument_specs.yml
+++ b/test/schemas/test/roles/foo/meta/argument_specs.yml
@@ -100,6 +100,11 @@ argument_specs:
         details:
           - Does not work if O(my_app_int=5).
         version_added: 1.2.0
+      action_group:
+        description:
+          - Use C(group/foo.bar.baz) in C(module_defaults) to set authentication options for the C(foo.bar) modules used by this role.
+        support: full
+        membership: foo.bar.baz
     options:
       my_app_int:
         type: "int"


### PR DESCRIPTION
These are supported by ansible-core 2.14, 2.15, and 2.16, and by antsibull-docs.

(Core wants to no longer show them for ansible-core 2.17 (https://github.com/ansible/ansible/issues/82639), but I think that's a really bad idea and should not stop anyone from using them.)