### PR TITLE
[role-name] Handle string role dependencies

### DIFF
--- a/examples/roles/role_with_deps_paths/meta/main.yml
+++ b/examples/roles/role_with_deps_paths/meta/main.yml
@@ -7,3 +7,4 @@ dependencies:
     vars:
       param: baz
   - role: subfolder/2nd_role
+  - subfolder/3rd_role

--- a/src/ansiblelint/rules/role_name.py
+++ b/src/ansiblelint/rules/role_name.py
@@ -102,7 +102,8 @@ class RoleNames(AnsibleLintRule):
                 elif isinstance(role, str):
                     role_name = role
                 else:
-                    raise ValueError("role dependency has unexpected type")
+                    msg = "Role dependency has unexpected type."
+                    raise RuntimeError(msg)
                 if "/" in role_name:
                     result.append(
                         self.create_matcherror(

--- a/src/ansiblelint/rules/role_name.py
+++ b/src/ansiblelint/rules/role_name.py
@@ -97,13 +97,18 @@ class RoleNames(AnsibleLintRule):
 
         if file.kind == "meta":
             for role in file.data.get("dependencies", []):
-                role_name = role["role"]
+                if isinstance(role, dict):
+                    role_name = role["role"]
+                elif isinstance(role, str):
+                    role_name = role
+                else:
+                    raise ValueError("role dependency has unexpected type")
                 if "/" in role_name:
                     result.append(
                         self.create_matcherror(
                             f"Avoid using paths when importing roles. ({role_name})",
                             filename=file,
-                            lineno=role["__line__"],
+                            lineno=role_name.ansible_pos[1],
                             tag=f"{self.id}[path]",
                         ),
                     )
@@ -187,7 +192,7 @@ if "pytest" in sys.modules:
 
     @pytest.mark.parametrize(
         ("test_file", "failure"),
-        (pytest.param("examples/roles/role_with_deps_paths", 2, id="fail"),),
+        (pytest.param("examples/roles/role_with_deps_paths", 3, id="fail"),),
     )
     def test_role_deps_path_names(
         default_rules_collection: RulesCollection,
@@ -202,7 +207,9 @@ if "pytest" in sys.modules:
         expected_errors = (
             ("role-name[path]", 3),
             ("role-name[path]", 9),
+            ("role-name[path]", 10),
         )
+        assert len(expected_errors) == failure
         for idx, result in enumerate(results):
             assert result.tag == expected_errors[idx][0]
             assert result.lineno == expected_errors[idx][1]

--- a/src/ansiblelint/schemas/meta.json
+++ b/src/ansiblelint/schemas/meta.json
@@ -1518,7 +1518,14 @@
     },
     "dependencies": {
       "items": {
-        "$ref": "#/$defs/DependencyModel"
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "$ref": "#/$defs/DependencyModel"
+          }
+        ]
       },
       "title": "Dependencies",
       "type": "array"

--- a/test/schemas/negative_test/roles/role_with_bad_deps_in_meta/meta/main.yml
+++ b/test/schemas/negative_test/roles/role_with_bad_deps_in_meta/meta/main.yml
@@ -11,3 +11,4 @@ galaxy_info:
 
 dependencies:
   - version: foo # invalid, should have at least name, role or src properties
+  - 1234 # invalid, needs to be a string

--- a/test/schemas/negative_test/roles/role_with_bad_deps_in_meta/meta/main.yml.md
+++ b/test/schemas/negative_test/roles/role_with_bad_deps_in_meta/meta/main.yml.md
@@ -4,6 +4,15 @@
 [
   {
     "instancePath": "/dependencies/0",
+    "keyword": "type",
+    "message": "must be string",
+    "params": {
+      "type": "string"
+    },
+    "schemaPath": "#/properties/dependencies/items/anyOf/0/type"
+  },
+  {
+    "instancePath": "/dependencies/0",
     "keyword": "required",
     "message": "must have required property 'role'",
     "params": {
@@ -35,6 +44,13 @@
     "message": "must match a schema in anyOf",
     "params": {},
     "schemaPath": "#/anyOf"
+  },
+  {
+    "instancePath": "/dependencies/0",
+    "keyword": "anyOf",
+    "message": "must match a schema in anyOf",
+    "params": {},
+    "schemaPath": "#/properties/dependencies/items/anyOf"
   },
   {
     "instancePath": "/galaxy_info",
@@ -73,14 +89,22 @@ stdout:
       "has_sub_errors": true,
       "best_match": {
         "path": "$.dependencies[0]",
-        "message": "'role' is a required property"
+        "message": "{'version': 'foo'} is not of type 'string'"
       },
       "best_deep_match": {
         "path": "$.dependencies[0]",
-        "message": "'role' is a required property"
+        "message": "{'version': 'foo'} is not of type 'string'"
       },
-      "num_sub_errors": 2,
+      "num_sub_errors": 4,
       "sub_errors": [
+        {
+          "path": "$.dependencies[0]",
+          "message": "{'version': 'foo'} is not of type 'string'"
+        },
+        {
+          "path": "$.dependencies[0]",
+          "message": "{'version': 'foo'} is not valid under any of the given schemas"
+        },
         {
           "path": "$.dependencies[0]",
           "message": "'role' is a required property"

--- a/test/schemas/negative_test/roles/role_with_bad_deps_in_meta/meta/main.yml.md
+++ b/test/schemas/negative_test/roles/role_with_bad_deps_in_meta/meta/main.yml.md
@@ -53,6 +53,31 @@
     "schemaPath": "#/properties/dependencies/items/anyOf"
   },
   {
+    "instancePath": "/dependencies/1",
+    "keyword": "type",
+    "message": "must be string",
+    "params": {
+      "type": "string"
+    },
+    "schemaPath": "#/properties/dependencies/items/anyOf/0/type"
+  },
+  {
+    "instancePath": "/dependencies/1",
+    "keyword": "type",
+    "message": "must be object",
+    "params": {
+      "type": "object"
+    },
+    "schemaPath": "#/type"
+  },
+  {
+    "instancePath": "/dependencies/1",
+    "keyword": "anyOf",
+    "message": "must match a schema in anyOf",
+    "params": {},
+    "schemaPath": "#/properties/dependencies/items/anyOf"
+  },
+  {
     "instancePath": "/galaxy_info",
     "keyword": "required",
     "message": "must have required property 'author'",
@@ -116,6 +141,31 @@ stdout:
         {
           "path": "$.dependencies[0]",
           "message": "'name' is a required property"
+        }
+      ]
+    },
+    {
+      "filename": "negative_test/roles/role_with_bad_deps_in_meta/meta/main.yml",
+      "path": "$.dependencies[1]",
+      "message": "1234 is not valid under any of the given schemas",
+      "has_sub_errors": true,
+      "best_match": {
+        "path": "$.dependencies[1]",
+        "message": "1234 is not of type 'string'"
+      },
+      "best_deep_match": {
+        "path": "$.dependencies[1]",
+        "message": "1234 is not of type 'string'"
+      },
+      "num_sub_errors": 1,
+      "sub_errors": [
+        {
+          "path": "$.dependencies[1]",
+          "message": "1234 is not of type 'string'"
+        },
+        {
+          "path": "$.dependencies[1]",
+          "message": "1234 is not of type 'object'"
         }
       ]
     },

--- a/test/schemas/test/roles/foo/meta/main.yml
+++ b/test/schemas/test/roles/foo/meta/main.yml
@@ -5,6 +5,7 @@ dependencies:
     version: "1.0"
   - name: ansible-role-bar
     version: "1.0"
+  - ansible-role-baz
   # from Bitbucket
   - src: git+http://bitbucket.org/willthames/git-ansible-galaxy
     version: v1.4


### PR DESCRIPTION
The dependencies in a roles `meta/main.yml` can be simple strings. This currently results in a warning, as reported in #4000. The problem was supposedly fixed with #3993, that however only fixed the same error in a different part of the code. This PR actually makes the `role_name` rule handle this case properly.

Fixes #4000