### PR TITLE
Set global `cache_dir_lock`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -248,7 +248,8 @@ ignore = [
   "RUF012", # Mutable class attributes should be annotated with `typing.ClassVar`
   "TRY",
   "PERF203",
-  "PD011" # We are not using pandas, any .values attributes are unrelated
+  "PD011", # We are not using pandas, any .values attributes are unrelated
+  "PLW0603" # global lock file in cache dir
 ]
 select = ["ALL"]
 target-version = "py310"

--- a/src/ansiblelint/__main__.py
+++ b/src/ansiblelint/__main__.py
@@ -79,6 +79,7 @@ if TYPE_CHECKING:
 
 
 _logger = logging.getLogger(__name__)
+# cache_dir_lock could be set in `initialize_options`
 cache_dir_lock: None | FileLock = None
 
 
@@ -144,8 +145,9 @@ def initialize_options(arguments: list[str] | None = None) -> None:
     if options.cache_dir:
         options.cache_dir.mkdir(parents=True, exist_ok=True)
 
+    global cache_dir_lock  # pylint: disable=global-statement
     if not options.offline:  # pragma: no cover
-        cache_dir_lock = FileLock(  # pylint: disable=redefined-outer-name
+        cache_dir_lock = FileLock(
             f"{options.cache_dir}/.lock",
         )
         try:

--- a/src/ansiblelint/__main__.py
+++ b/src/ansiblelint/__main__.py
@@ -79,8 +79,6 @@ if TYPE_CHECKING:
 
 
 _logger = logging.getLogger(__name__)
-# cache_dir_lock could be set in `initialize_options`
-cache_dir_lock: None | FileLock = None
 
 
 class LintLogHandler(logging.Handler):
@@ -121,8 +119,9 @@ def initialize_logger(level: int = 0) -> None:
     _logger.debug("Logging initialized to level %s", logging_level)
 
 
-def initialize_options(arguments: list[str] | None = None) -> None:
+def initialize_options(arguments: list[str] | None = None) -> None | FileLock:
     """Load config options and store them inside options module."""
+    cache_dir_lock = None
     new_options = cli.get_config(arguments or [])
     new_options.cwd = pathlib.Path.cwd()
 
@@ -145,7 +144,6 @@ def initialize_options(arguments: list[str] | None = None) -> None:
     if options.cache_dir:
         options.cache_dir.mkdir(parents=True, exist_ok=True)
 
-    global cache_dir_lock  # pylint: disable=global-statement
     if not options.offline:  # pragma: no cover
         cache_dir_lock = FileLock(
             f"{options.cache_dir}/.lock",
@@ -161,6 +159,8 @@ def initialize_options(arguments: list[str] | None = None) -> None:
     # Avoid extra output noise from Ansible about using devel versions
     if "ANSIBLE_DEVEL_WARNING" not in os.environ:  # pragma: no branch
         os.environ["ANSIBLE_DEVEL_WARNING"] = "false"
+
+    return cache_dir_lock
 
 
 def _do_list(rules: RulesCollection) -> int:
@@ -287,7 +287,7 @@ def main(argv: list[str] | None = None) -> int:
 
     if argv is None:  # pragma: no cover
         argv = sys.argv
-    initialize_options(argv[1:])
+    cache_dir_lock = initialize_options(argv[1:])
 
     console_options["force_terminal"] = options.colored
     reconfigure(console_options)

--- a/src/ansiblelint/schemas/__store__.json
+++ b/src/ansiblelint/schemas/__store__.json
@@ -24,7 +24,7 @@
     "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/inventory.json"
   },
   "meta": {
-    "etag": "fb58deb0f5f2a3b77ba298764f74bc6e3bd38a761f368a50bb285042f6260354",
+    "etag": "e04a9e9c210c666c744dfe9ebf1ca1f4e95e71bd16995514b9c3a56186e66c98",
     "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/meta.json"
   },
   "meta-runtime": {


### PR DESCRIPTION
* in `initialize_options`, we need to update the globally-scoped
  `cache_dir_lock` so that later on, `main` can release the lock and
  cleanup the lockfile.

Fixes #4030