### PR TITLE
Fix typo'd docs link to make docs build correctly

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -42,10 +42,10 @@ repositories.
 
 ## Gradual adoption
 
-For an easier gradual adoption, adopters should consider [ignore
-file][configuring.md#ignoring-rules-for-entire-files] feature. This allows the
-quick introduction of a linter pipeline for preventing addition of new
-violations, while known violations are ignored. Some people can work on
+For an easier gradual adoption, adopters should consider
+[ignore file](configuring.md#ignoring-rules-for-entire-files) feature. This
+allows the quick introduction of a linter pipeline for preventing addition of
+new violations, while known violations are ignored. Some people can work on
 addressing these historical violations while others may continue to work on
 other maintenance tasks.
 


### PR DESCRIPTION
* fixes up typo'd `[]` in link (should be `()`)
* building docs should no longer complain about `Could not find
  cross-reference target '[configuring.md#ignoring-rules-for-entire-files]'`

before: https://ansible.readthedocs.io/projects/lint/usage/#gradual-adoption
after: https://ansible--4056.org.readthedocs.build/projects/lint/usage/#gradual-adoption

* `ignore file` is hyperlinked properly now
* CI for building docs should no longer error