### PR TITLE
Adding EDA tag to the required galaxy.yml tags

### DIFF
--- a/src/ansiblelint/rules/galaxy.py
+++ b/src/ansiblelint/rules/galaxy.py
@@ -41,6 +41,7 @@ class GalaxyRule(AnsibleLintRule):
             "application",
             "cloud",
             "database",
+            "eda",
             "infrastructure",
             "linux",
             "monitoring",


### PR DESCRIPTION
Adding the EDA tag to the list of required certification tags, to match the [tag list defined in galaxy-importer.](https://github.com/alisonlhart/galaxy-importer/blob/master/galaxy_importer/schema.py#L44-L56) 