### PR TITLE
Fix #3938: don't assume working_directory is github.workspace

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,7 @@ runs:
         GH_ACTION_REF: ${{ github.action_ref || 'main' }}
       working-directory: ${{ steps.inputs.outputs.working_directory }}
       run: |
-        wget --output-document=.git/ansible-lint-requirements.txt https://raw.githubusercontent.com/ansible/ansible-lint/$GH_ACTION_REF/.config/requirements-lock.txt
+        wget --output-document=${{ github.workspace}}/.git/ansible-lint-requirements.txt https://raw.githubusercontent.com/ansible/ansible-lint/$GH_ACTION_REF/.config/requirements-lock.txt
 
     - name: Set up Python
       if: inputs.setup_python == 'true'


### PR DESCRIPTION
Setting `working_directory` for ansible-lint action would fail due to hard-coded `.git`, introduced in commit 6f728e0c, when fetching `.config/requirements-lock.txt`, introduced in

This fix replaces `.git` with `${{ github.workspace }}/.git` to make `working_directory` argument work again.