### PR TITLE
Fix #3938: don't assume working_directory is github.workspace

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,14 +42,14 @@ runs:
         GH_ACTION_REF: ${{ github.action_ref || 'main' }}
       working-directory: ${{ steps.inputs.outputs.working_directory }}
       run: |
-        wget --output-document=.git/ansible-lint-requirements.txt https://raw.githubusercontent.com/ansible/ansible-lint/$GH_ACTION_REF/.config/requirements-lock.txt
+        wget --output-document=${{ github.workspace}}/.git/ansible-lint-requirements.txt https://raw.githubusercontent.com/ansible/ansible-lint/$GH_ACTION_REF/.config/requirements-lock.txt
 
     - name: Set up Python
       if: inputs.setup_python == 'true'
       uses: actions/setup-python@v5
       with:
         cache: pip
-        cache-dependency-path: ${{ steps.inputs.outputs.working_directory }}/.git/ansible-lint-requirements.txt
+        cache-dependency-path: ${{ github.workspace }}/.git/ansible-lint-requirements.txt
         python-version: "3.11"
 
     - name: Install ansible-lint


### PR DESCRIPTION
Setting `working_directory` for ansible-lint action would fail due to hard-coded `.git`, introduced in commit 6f728e0c, when fetching `.config/requirements-lock.txt`.

This fix replaces `.git` with `${{ github.workspace }}/.git` to make `working_directory` argument work again.

Tested that this does fix my github action, i.e.:

```
name: ansible-lint
on:
  pull_request:
    branches: ["main", "release/v*"]
jobs:
  build:
    name: Ansible Lint
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4

      - name: Run ansible-lint
        uses: ajfabbri/ansible-lint@main
        # this is broken :-( https://github.com/ansible/ansible-lint/issues/3938
        with:
          working_directory: iac
```
Fixes #3938 