### PR TITLE
Avoid running get_app more than once

### DIFF
--- a/src/ansiblelint/app.py
+++ b/src/ansiblelint/app.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
 
 
 _logger = logging.getLogger(__package__)
+_CACHED_APP = None
 
 
 class App:
@@ -386,8 +387,19 @@ def _sanitize_list_options(tag_list: list[str]) -> list[str]:
 
 
 @lru_cache
-def get_app(*, offline: bool | None = None) -> App:
+def get_app(*, offline: bool | None = None, cached: bool = False) -> App:
     """Return the application instance, caching the return value."""
+    # Avoids ever running the app initialization twice if cached argument
+    # is mentioned.
+    if cached:
+        if offline is not None:
+            msg = (
+                "get_app should never be called with other arguments when cached=True."
+            )
+            raise RuntimeError(msg)
+        if cached and _CACHED_APP is not None:
+            return _CACHED_APP
+
     if offline is None:
         offline = default_options.offline
 

--- a/src/ansiblelint/rules/__init__.py
+++ b/src/ansiblelint/rules/__init__.py
@@ -396,7 +396,7 @@ class RulesCollection:
         else:
             self.options = options
         self.profile = []
-        self.app = app or get_app(offline=True)
+        self.app = app or get_app(cached=True)
 
         if profile_name:
             self.profile = PROFILES[profile_name]

--- a/src/ansiblelint/rules/jinja.py
+++ b/src/ansiblelint/rules/jinja.py
@@ -389,6 +389,7 @@ class JinjaRule(AnsibleLintRule, TransformMixin):
 
         except jinja2.exceptions.TemplateSyntaxError as exc:
             return "", str(exc.message), "invalid"
+        # pylint: disable=c-extension-no-member
         except (NotImplementedError, black.parsing.InvalidInput) as exc:
             # black is not able to recognize all valid jinja2 templates, so we
             # just ignore InvalidInput errors.

--- a/src/ansiblelint/runner.py
+++ b/src/ansiblelint/runner.py
@@ -232,7 +232,7 @@ class Runner:
 
         # -- phase 1 : syntax check in parallel --
         if not self.skip_ansible_syntax_check:
-            app = get_app(offline=True)
+            app = get_app(cached=True)
 
             def worker(lintable: Lintable) -> list[MatchError]:
                 return self._get_ansible_syntax_check_matches(

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -490,7 +490,7 @@ def _rolepath(basedir: str, role: str) -> str | None:
         path_dwim(basedir, os.path.join("..", role)),
     ]
 
-    for loc in get_app(offline=True).runtime.config.default_roles_path:
+    for loc in get_app(cached=True).runtime.config.default_roles_path:
         loc = os.path.expanduser(loc)
         possible_paths.append(path_dwim(loc, role))
 


### PR DESCRIPTION
This fixes a misleading message about use of offline mode that
originates from ansible-compat when get_app was called multiple
times, even when the linter was not really running in offline mode.

Related: #4114
