### PR TITLE
Fix KeyError on `key-order` rule with blocks

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -71,7 +71,7 @@ jobs:
     env:
       # Number of expected test passes, safety measure for accidental skip of
       # tests. Update value if you add/remove tests.
-      PYTEST_REQPASS: 853
+      PYTEST_REQPASS: 854
     steps:
       - uses: actions/checkout@v4
         with:

--- a/examples/playbooks/transform-key-order-block.transformed.yml
+++ b/examples/playbooks/transform-key-order-block.transformed.yml
@@ -1,0 +1,20 @@
+---
+- name: Testing multiple plays in a playbook
+  hosts: localhost
+  tasks:
+    - name: First block
+      when: true
+      block:
+        - name: Display a message
+          ansible.builtin.debug:
+            msg: Hello world!
+
+- name: A second play
+  hosts: localhost
+  tasks:
+    - name: Second block
+      when: true # <-- name key should be the second one
+      block:
+        - name: Display a message
+          ansible.builtin.debug:
+            msg: Hello world!

--- a/examples/playbooks/transform-key-order-block.yml
+++ b/examples/playbooks/transform-key-order-block.yml
@@ -1,0 +1,20 @@
+---
+- name: Testing multiple plays in a playbook
+  hosts: localhost
+  tasks:
+    - name: First block
+      when: true
+      block:
+        - name: Display a message
+          ansible.builtin.debug:
+            msg: Hello world!
+
+- name: A second play
+  hosts: localhost
+  tasks:
+    - name: Second block
+      block:
+        - name: Display a message
+          ansible.builtin.debug:
+            msg: Hello world!
+      when: true # <-- name key should be the second one

--- a/src/ansiblelint/yaml_utils.py
+++ b/src/ansiblelint/yaml_utils.py
@@ -305,6 +305,10 @@ def _get_path_to_task_in_playbook(
         else:
             next_play_line_index = None
 
+        # We clearly haven't found the right spot yet if a following play starts on an earlier line.
+        if next_play_line_index and lineno > next_play_line_index:
+            continue
+
         play_keys = list(play.keys())
         for tasks_keyword in PLAYBOOK_TASK_KEYWORDS:
             if not play.get(tasks_keyword):

--- a/test/test_transformer.py
+++ b/test/test_transformer.py
@@ -157,6 +157,13 @@ def fixture_runner_result(
             id="key_order_play_transform",
         ),
         pytest.param(
+            "examples/playbooks/transform-key-order-block.yml",
+            1,
+            True,
+            True,
+            id="key_order_block_transform",
+        ),
+        pytest.param(
             "examples/.github/workflows/sample.yml",
             0,
             False,


### PR DESCRIPTION
Fixes https://github.com/ansible/ansible-lint/issues/4091

`_get_path_to_task_in_nested_tasks_block()` seems to do the wrong thing under certain circumstances when lineno > next_task_line_index. It seems like we should never want that anyway, so just skip the whole thing until there is not a later play that is earlier than lineno.