### PR TITLE
Update supported versions of ansible to 2.15 - 2.17

### DIFF
--- a/examples/meta_runtime_version_checks/pass/meta/runtime.yml
+++ b/examples/meta_runtime_version_checks/pass/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.14.0,<2.15"
+requires_ansible: ">=2.15.0"

--- a/src/ansiblelint/rules/meta_runtime.py
+++ b/src/ansiblelint/rules/meta_runtime.py
@@ -32,7 +32,7 @@ class CheckRequiresAnsibleVersion(AnsibleLintRule):
 
     # Refer to https://access.redhat.com/support/policy/updates/ansible-automation-platform
     # Also add devel to this list
-    supported_ansible = ["2.14.", "2.15.", "2.16."]
+    supported_ansible = ["2.15." , "2.16." , "2.17."]
     supported_ansible_examples = [f">={x}0" for x in supported_ansible]
     _ids = {
         "meta-runtime[unsupported-version]": f"'requires_ansible' key must refer to a currently supported version such as: {', '.join(supported_ansible_examples)}",

--- a/src/ansiblelint/rules/meta_runtime.py
+++ b/src/ansiblelint/rules/meta_runtime.py
@@ -32,7 +32,7 @@ class CheckRequiresAnsibleVersion(AnsibleLintRule):
 
     # Refer to https://access.redhat.com/support/policy/updates/ansible-automation-platform
     # Also add devel to this list
-    supported_ansible = ["2.15." , "2.16." , "2.17."]
+    supported_ansible = ["2.15.", "2.16.", "2.17."]
     supported_ansible_examples = [f">={x}0" for x in supported_ansible]
     _ids = {
         "meta-runtime[unsupported-version]": f"'requires_ansible' key must refer to a currently supported version such as: {', '.join(supported_ansible_examples)}",


### PR DESCRIPTION
Remove "2.14." from this list and add "2.17.", since 2.14 support is being dropped and 2.17 is starting support: https://github.com/ansible/ansible-lint/blob/main/src/ansiblelint/rules/meta_runtime.py#L35

The passing test will need to be updated as well: https://github.com/ansible/ansible-lint/blob/main/examples/meta_runtime_version_checks/pass/meta/runtime.yml

This test will need the lower bound increased to at least 2.15.0 and the upper bound should be removed. 