### PR TITLE
Refactor codecov to perform a single upload and use oidc authentication

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -54,7 +54,6 @@ jobs:
           args: .ansible-lint
   build:
     name: ${{ matrix.name }}
-    environment: test
     runs-on: ${{ matrix.os || 'ubuntu-22.04' }}
     needs:
       - prepare
@@ -131,25 +130,14 @@ jobs:
       - name: tox -e ${{ matrix.passed_name }}
         run: python3 -m tox -e ${{ matrix.passed_name }}
 
-      - name: Combine coverage data
-        if: ${{ startsWith(matrix.passed_name, 'py') }}
-        # produce a single .coverage file at repo root
-        run: tox -e coverage
-
-      - name: Upload coverage data
-        if: ${{ startsWith(matrix.passed_name, 'py') }}
-        uses: codecov/codecov-action@v4
-        with:
-          name: ${{ matrix.passed_name }}
-          token: ${{ secrets.CODECOV_TOKEN }}
-          verbose: true # optional (default = false)
-          fail_ci_if_error: true
-
       - name: Archive logs
         uses: actions/upload-artifact@v4
         with:
           name: logs-${{ matrix.name }}.zip
-          path: .tox/**/log/
+          path: |
+            .tox/**/log/
+            .tox/**/.coverage*
+            .tox/**/coverage.xml
 
       - name: Report failure if git reports dirty status
         run: |
@@ -201,6 +189,8 @@ jobs:
   check: # This job does nothing and is only used for the branch protection
     if: always()
     permissions:
+      id-token: write
+      checks: read
       pull-requests: write # allow codenotify to comment on pull-request
 
     needs:
@@ -210,12 +200,41 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # checkout needed for codecov action which needs codecov.yml file
+      - uses: actions/checkout@v4
+
+      - name: Set up Python # likely needed for coverage
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - run: pip3 install 'coverage>=7.5.1'
+
       - name: Merge logs into a single archive
         uses: actions/upload-artifact/merge@v4
         with:
           name: logs.zip
           pattern: logs*.zip
+          # artifacts like py312.zip and py312-macos do have overlapping files
+          separate-directories: true
           delete-merged: true
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: logs.zip
+          path: .
+
+      - run: find . -name coverage.xml
+
+      - name: Upload coverage data
+        uses: codecov/codecov-action@v4
+        with:
+          name: ${{ matrix.passed_name }}
+          # token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true # optional (default = false)
+          fail_ci_if_error: true
+          use_oidc: true # cspell:ignore oidc
 
       - name: Check codecov.io status
         if: github.event_name == 'pull_request'

--- a/tox.ini
+++ b/tox.ini
@@ -29,14 +29,14 @@ deps =
 extras =
   test
 commands_pre =
-  sh -c "rm -f .tox/.coverage.* 2>/dev/null || true"
+  sh -c "rm -f {envdir}/.coverage.* 2>/dev/null || true"
   # safety measure to assure we do not accidentally run tests with broken dependencies
   {envpython} -m pip check
   {envpython} -m pip freeze
   bash ./tools/install-reqs.sh
   ansible --version
 commands =
-  {envpython} -m pip freeze
+  sh -c "{envpython} -m pip freeze > {envdir}/log/requirements.txt"
   coverage run -m pytest {posargs:\
     -n auto \
     -ra \
@@ -44,7 +44,7 @@ commands =
     --doctest-modules \
     --durations=10 \
     }
-  sh -c "coverage combine -a -q --data-file=.coverage .tox/.coverage.*"
+  {py,py310,py311,py312,py313}: sh -c "coverage combine -a -q --data-file={envdir}/.coverage {toxworkdir}/*/.coverage.* && coverage xml --data-file={envdir}/.coverage -o {envdir}/coverage.xml --fail-under=0"
 
 passenv =
   CURL_CA_BUNDLE  # https proxies, https://github.com/tox-dev/tox/issues/1437
@@ -66,7 +66,7 @@ passenv =
 setenv =
   # Avoid runtime warning that might affect our devel testing
   devel: ANSIBLE_DEVEL_WARNING = false
-  COVERAGE_FILE = {env:COVERAGE_FILE:{toxworkdir}/.coverage.{envname}}
+  COVERAGE_FILE = {env:COVERAGE_FILE:{envdir}/.coverage.{envname}}
   COVERAGE_PROCESS_START={toxinidir}/pyproject.toml
   PIP_CONSTRAINT = {toxinidir}/.config/constraints.txt
   devel,pkg,pre,py310: PIP_CONSTRAINT = /dev/null
@@ -229,9 +229,11 @@ commands =
 description = Remove temporary files
 skip_install = true
 deps =
+commands_pre =
+commands_post =
 commands =
-  find . -type f -name '*.py[co]' -delete -o -type d -name __pycache__ -name coverage.xml -name .coverage
-  rm -rf .mypy_cache
+  find . -type d \( -name __pycache__ -o -name .mypy_cache \) -delete
+  find . -type f \( -name '*.py[co]' -o -name ".coverage*" -o -name coverage.xml \) -delete
 
 [testenv:coverage]
 description = Combines and displays coverage results


### PR DESCRIPTION
- Archive coverage report from each job
- Combine coverage reports inside check job
- Make a single upload to codecov.io
- Replace use of CODECOV token with OIDC authentication
- Remove 'test' GHA environment as we no longer need it