### PR TITLE
Don't quote strings that start with 0 when running ansible-lint --fix.

### DIFF
--- a/test/fixtures/formatting-after/fmt-2.yml
+++ b/test/fixtures/formatting-after/fmt-2.yml
@@ -22,3 +22,10 @@
     - 10
     - 9999
   zero: 0 # Not an octal. See #2071
+
+- string:
+    - 0steps
+    - 9steps
+    - 0.0.0.0
+    - "0"
+    - "01234"

--- a/test/fixtures/formatting-before/fmt-2.yml
+++ b/test/fixtures/formatting-before/fmt-2.yml
@@ -22,3 +22,10 @@
     - 10
     - 9999
     zero: 0  # Not an octal. See #2071
+
+  - string:
+    - 0steps
+    - 9steps
+    - 0.0.0.0
+    - "0"
+    - "01234"

--- a/test/fixtures/formatting-prettier/fmt-2.yml
+++ b/test/fixtures/formatting-prettier/fmt-2.yml
@@ -22,3 +22,10 @@
     - 10
     - 9999
   zero: 0 # Not an octal. See #2071
+
+- string:
+    - 0steps
+    - 9steps
+    - 0.0.0.0
+    - "0"
+    - "01234"


### PR DESCRIPTION
In order to try to handle [the mess that are octals in YAML](https://github.com/ansible/ansible-lint/issues/2965), some [special-case code was added](https://github.com/ansible/ansible-lint/pull/3030) to handle leading-zeros. But it caught too much, and would quote strings like `00-header` and `0.0.0.0`, even when .yamllint doesn't require them:

```
quoted-strings:
    required: false
```

and it generates awkward lists, like

```diff
   loop:
     - "00-header"
     - 10-help-text
     - 50-landscape-sysinfo
     - 50-motd-news
     - 88-esm-announce
     - 97-overlayroot
```

Fixes https://github.com/ansible/ansible-lint/issues/4166