### PR TITLE
Fix false positive reports in is_handler function

### DIFF
--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -785,7 +785,8 @@ class Task(dict[str, Any]):
         if isinstance(self._normalized_task, dict):
             file_name = str(self._normalized_task["action"].get(FILENAME_KEY, None))
             if file_name:
-                is_handler_file = "handlers" in str(file_name)
+                paths = file_name.split("/")
+                is_handler_file = "handlers" in paths
         return is_handler_file if is_handler_file else ".handlers[" in self.position
 
     def __repr__(self) -> str:


### PR DESCRIPTION
Found in the process of writing and checking custom rules.

The "is_handler" function considers all tasks from the file to be handlers if the file name contains the substring "handlers".

Therefore, all tasks in the check_handlers_playbook.yaml playbook were accepted as handlers.

I'm not sure if it's worth relying on the filename or path at all. But if we do, then maybe it makes sense to look for the full string, not just a part of it.