### PR TITLE
Allow inventory to be used for playbook order key

### DIFF
--- a/src/ansiblelint/schemas/ansible.json
+++ b/src/ansiblelint/schemas/ansible.json
@@ -548,11 +548,11 @@
           "oneOf": [
             {
               "enum": [
-                "default",
-                "sorted",
-                "reverse_sorted",
+                "inventory",
                 "reverse_inventory",
-                "shuffle"
+                "reverse_sorted",
+                "shuffle",
+                "sorted"
               ],
               "type": "string"
             },
@@ -560,7 +560,8 @@
               "$ref": "#/$defs/full-jinja"
             }
           ],
-          "title": "Order"
+          "title": "Order",
+          "markdownDescription": "See https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_strategies.html#ordering-execution-based-on-inventory"
         },
         "port": {
           "$ref": "#/$defs/templated-integer",

--- a/src/ansiblelint/schemas/playbook.json
+++ b/src/ansiblelint/schemas/playbook.json
@@ -555,14 +555,15 @@
           "$ref": "#/$defs/templated-boolean"
         },
         "order": {
+          "markdownDescription": "See https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_strategies.html#ordering-execution-based-on-inventory",
           "oneOf": [
             {
               "enum": [
-                "default",
-                "sorted",
-                "reverse_sorted",
+                "inventory",
                 "reverse_inventory",
-                "shuffle"
+                "reverse_sorted",
+                "shuffle",
+                "sorted"
               ],
               "type": "string"
             },

--- a/test/schemas/test/playbooks/order.yml
+++ b/test/schemas/test/playbooks/order.yml
@@ -1,6 +1,6 @@
 ---
 - name: Test
-  hosts: all
+  hosts: localhost
   order: "{{ host_order | default('shuffle') }}"
   gather_facts: false
   serial: 1
@@ -8,3 +8,8 @@
     - name: ABC
       ansible.builtin.debug:
         msg: "hello"
+- name: Test 2
+  hosts: localhost
+  order: inventory
+  gather_facts: false
+  tasks: []


### PR DESCRIPTION
Fixes: #4163
