### PR TITLE
Respect yamllint 'document_start' rule when autofixing yaml

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -72,7 +72,7 @@ jobs:
     env:
       # Number of expected test passes, safety measure for accidental skip of
       # tests. Update value if you add/remove tests.
-      PYTEST_REQPASS: 875
+      PYTEST_REQPASS: 877
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Currently disabling document_start in the .yamllint config (see example below) file isn't applied correctly when autofixing yaml files since ansible specifies yaml version 1.1 which produces the following file header:
```
%YAML 1.1
---
```

While ansible-lint automatically removes the `%YAML 1.1` line, the document start indicators are leftover. 

### Example .yamllint
```
rules:
  document-start:
    present: false
```