### PR TITLE
Don't raise name[casing] on handlers with special role syntax

### DIFF
--- a/examples/playbooks/name_case_notify_fail.yml
+++ b/examples/playbooks/name_case_notify_fail.yml
@@ -16,6 +16,14 @@
         - my handler
         - my other handler
 
+    - name: Only one of these is invalid
+      ansible.builtin.debug:
+        msg: foo
+      changed_when: true
+      notify:
+        - "role_name : lowercase handler"
+        - "role_name : Uppercase handler"
+
   handlers:
     - name: My handler
       ansible.builtin.debug:


### PR DESCRIPTION
Fixes https://github.com/ansible/ansible-lint/issues/4169