### PR TITLE
Correctly recognize path with spaces with tokenize

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -72,7 +72,7 @@ jobs:
     env:
       # Number of expected test passes, safety measure for accidental skip of
       # tests. Update value if you add/remove tests.
-      PYTEST_REQPASS: 872
+      PYTEST_REQPASS: 873
     steps:
       - uses: actions/checkout@v4
         with:

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -220,6 +220,11 @@ BLOCK_NAME_TO_ACTION_TYPE_MAP = {
 
 def tokenize(value: str) -> tuple[list[str], dict[str, str]]:
     """Parse a string task invocation."""
+    # We do not try to tokenize something very simple because it would fail to
+    # work for a case like: task_include: path with space.yml
+    if value and "=" not in value:
+        return ([value], {})
+
     parts = split_args(value)
     args: list[str] = []
     kwargs: dict[str, str] = {}

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -74,6 +74,12 @@ runtime = Runtime(require_module=True)
             {},
             id="x",
         ),
+        pytest.param(
+            "foo bar.yml",
+            ["foo bar.yml"],
+            {},
+            id="path-with-spaces",
+        ),
     ),
 )
 def test_tokenize(


### PR DESCRIPTION
This mimics ansible-core behavior when processing inline arguments, performing tokenization only when an '=' is present inside the string.