### PR TITLE
Avoid using warn for command/shell actions

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -43,11 +43,11 @@ repositories.
 ## Gradual adoption
 
 For an easier gradual adoption, adopters should consider [ignore
-file][ignoring-rules-for-entire-files] feature. This allows the
-quick introduction of a linter pipeline for preventing the addition of new
-violations, while known violations are ignored. Some people can work on
-addressing these historical violations while others may continue to work on
-other maintenance tasks.
+file][ignoring-rules-for-entire-files] feature. This allows the quick
+introduction of a linter pipeline for preventing the addition of new violations,
+while known violations are ignored. Some people can work on addressing these
+historical violations while others may continue to work on other maintenance
+tasks.
 
 The deprecated `--progressive` mode was removed in v6.16.0 as it added code
 complexity and performance overhead. It also presented several corner cases
@@ -222,17 +222,11 @@ argument or add it to `skip_list` in your configuration.
 
 The least preferred method of skipping rules is to skip all task-based rules for
 a task, which does not skip line-based rules. You can use the
-`skip_ansible_lint` tag with all tasks or the `warn` parameter with the
-_command_ or _shell_ modules, for example:
+`skip_ansible_lint` tag with all tasks, for example:
 
 ```yaml
 - name: This would typically fire no-free-form
   command: warn=no chmod 644 X
-
-- name: This would typically fire command-instead-of-module
-  command: git pull --rebase
-  args:
-    warn: false
 
 - name: This would typically fire git-latest
   git: src=/path/to/git/repo dest=checkout

--- a/examples/playbooks/skiptasks.yml
+++ b/examples/playbooks/skiptasks.yml
@@ -37,20 +37,16 @@
 
     - name: Test latest[git] (don't warn)
       ansible.builtin.command: git log
-      args:
-        warn: false
       changed_when: false
 
     - name: Test latest[hg] (don't warn)
       ansible.builtin.command: chmod 644 A
       args:
-        warn: false
         creates: B
 
     - name: Test latest[hg] (warn)
       ansible.builtin.command: chmod 644 A
       args:
-        warn: true
         creates: B
 
     - name: Test latest[git] (don't warn single line)

--- a/src/ansiblelint/rules/command_instead_of_module.py
+++ b/src/ansiblelint/rules/command_instead_of_module.py
@@ -26,7 +26,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ansiblelint.rules import AnsibleLintRule
-from ansiblelint.utils import convert_to_boolean, get_first_cmd_arg, get_second_cmd_arg
+from ansiblelint.utils import get_first_cmd_arg, get_second_cmd_arg
 
 if TYPE_CHECKING:
     from ansiblelint.file_utils import Lintable
@@ -106,9 +106,7 @@ class CommandsInsteadOfModulesRule(AnsibleLintRule):
         ):
             return False
 
-        if executable in self._modules and convert_to_boolean(
-            task["action"].get("warn", True),
-        ):
+        if executable in self._modules:
             message = "{0} used in place of {1} module"
             return message.format(executable, self._modules[executable])
         return False

--- a/src/ansiblelint/rules/inline_env_var.py
+++ b/src/ansiblelint/rules/inline_env_var.py
@@ -49,7 +49,6 @@ class EnvVarsInCommandRule(AnsibleLintRule):
         "executable",
         "removes",
         "stdin",
-        "warn",
         "stdin_add_newline",
         "strip_empty_ends",
         "cmd",

--- a/test/rules/test_inline_env_var.py
+++ b/test/rules/test_inline_env_var.py
@@ -14,7 +14,7 @@ SUCCESS_PLAY_TASKS = """
       HELLO: hello
 
   - name: Use some key-value pairs
-    command: chdir=/tmp creates=/tmp/bobbins warn=no touch bobbins
+    command: chdir=/tmp creates=/tmp/bobbins touch bobbins
 
   - name: Commands can have flags
     command: abc --xyz=def blah
@@ -69,7 +69,7 @@ FAIL_PLAY_TASKS = """
     command: HELLO=hello echo $HELLO
 
   - name: Typo some stuff
-    command: crates=/tmp/blah warn=no touch /tmp/blah
+    command: crates=/tmp/blah touch /tmp/blah
 """
 
 


### PR DESCRIPTION
As ansible removed the warn argument for shell/command, we also remove its special meaning from the linter.

This change counts as a bugfix because presence of `warn:` will trigger a runtime error with newer versions of ansible.