### PR TITLE
Update Contributing docs and add tox as test optional-dependency

### DIFF
--- a/.config/constraints.txt
+++ b/.config/constraints.txt
@@ -13,10 +13,12 @@ beautifulsoup4==4.12.3
 black==24.4.2
 boolean-py==4.0
 bracex==2.4
+cachetools==5.3.3
 cairocffi==1.7.0
 cairosvg==2.7.1
 certifi==2024.6.2
 cffi==1.16.0
+chardet==5.2.0
 charset-normalizer==3.3.2
 click==8.1.7
 colorama==0.4.6
@@ -27,6 +29,7 @@ csscompressor==0.9.5
 cssselect2==0.7.0
 defusedxml==0.7.1
 dill==0.3.8
+distlib==0.3.8
 dnspython==2.6.1
 exceptiongroup==1.2.1
 execnet==2.1.1
@@ -82,6 +85,7 @@ pycparser==2.22
 pygments==2.18.0
 pylint==3.2.2
 pymdown-extensions==10.8.1
+pyproject-api==1.6.1
 pytest==8.2.1
 pytest-mock==3.14.0
 pytest-plus==0.7.0
@@ -104,10 +108,12 @@ text-unidecode==1.3
 tinycss2==1.3.0
 tomli==2.0.1
 tomlkit==0.12.5
+tox==4.15.0
 types-jsonschema==4.22.0.20240501
 types-pyyaml==6.0.12.20240311
 typing-extensions==4.12.1
 urllib3==2.2.1
+virtualenv==20.26.2
 watchdog==4.0.1
 webencodings==0.5.1
 yamllint==1.35.1

--- a/.config/requirements-test.in
+++ b/.config/requirements-test.in
@@ -13,5 +13,6 @@ pytest-plus >= 0.6 # for PYTEST_REQPASS
 pytest-xdist >= 2.1.0
 ruamel.yaml>=0.17.31
 ruamel-yaml-clib  # needed for mypy
+tox >= 4.0.0
 types-jsonschema # IDE support
 types-pyyaml # IDE support

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ __pycache__
 
 # Packages
 .Python
-env/
 build/
 develop-eggs/
 dist/
@@ -20,7 +19,6 @@ parts/
 pip-wheel-metadata
 sdist/
 var/
-venv/
 *.egg-info/
 .installed.cfg
 *.egg
@@ -36,6 +34,12 @@ pip-log.txt
 
 # pyenv
 .python-version
+
+# Environments
+.env
+.venv
+env/
+venv/
 
 # Coverage artifacts
 .coverage*

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -8,8 +8,13 @@ After [creating your fork on GitHub], you can do:
 ```shell-session
 $ git clone --recursive git@github.com:your-name/ansible-lint
 $ cd ansible-lint
+$ # Recommended: Initialize and activate a Python virtual environment
+$ pip install --upgrade pip
+$ pip install -e .[test]       # Install testing dependencies
+$ tox run -e lint,pkg,docs,py  # Ensure subset of tox tests work in clean checkout
 $ git checkout -b your-branch-name
 # DO SOME CODING HERE
+$ tox run -e lint,pkg,docs,py  # Ensure subset of tox tests work with your changes
 $ git add your new files
 $ git commit -v
 $ git push origin your-branch-name
@@ -30,8 +35,6 @@ released.
 
 Automated tests will be run against all PRs, to run checks locally before
 pushing commits, just use [tox](https://tox.wiki/en/latest/).
-
-% DO-NOT-REMOVE-deps-snippet-PLACEHOLDER
 
 ## Talk to us
 

--- a/src/ansiblelint/schemas/__store__.json
+++ b/src/ansiblelint/schemas/__store__.json
@@ -1,6 +1,6 @@
 {
   "ansible-lint-config": {
-    "etag": "616457d973f4b221d85910086ce1fab520d8a363b1e1e62a62e4d8b57a824976",
+    "etag": "a0bb8004fad70bab34fad94a45b2698125127142ec6b2c8900976aa2bd96a86c",
     "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/ansible-lint-config.json"
   },
   "ansible-navigator-config": {

--- a/tools/test-hook.sh
+++ b/tools/test-hook.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 rm -rf .tox/x
 mkdir -p .tox/x
 cd .tox/x
-git init
+git init --initial-branch=main
 # we add a file to the repo to avoid error due to no file to to lint
 touch foo.yml
 git add foo.yml

--- a/tox.ini
+++ b/tox.ini
@@ -20,9 +20,9 @@ requires =
 
 [testenv]
 description =
-  Run the tests under {basepython} and
-  devel: ansible devel branch
-  pre: Enables --pre when installing dependencies, testing prereleases
+  Run the tests under {basepython}
+  devel: and ansible devel branch
+  pre: and enable --pre when installing dependencies, testing prereleases
 deps =
   devel: ansible-core @ git+https://github.com/ansible/ansible.git  # GPLv3+
   devel: ansible-compat @ git+https://github.com/ansible/ansible-compat.git  # GPLv3+
@@ -172,7 +172,7 @@ description = Rebuild and test JSON Schemas
 deps =
   check-jsonschema>=0.26.3
 setenv =
-  # without his upgrade would likely not do anything
+  # without this upgrade would likely not do anything
   PIP_CONSTRAINT = /dev/null
 skip_install = true
 changedir = test/schemas


### PR DESCRIPTION
## DISCLAIMER

Long time ansible-lint user, first time contributor, and also first time working
directly with a Python project. I'm trying to do things "right" but might have
missed the mark. Feedback welcome so I can get better!

## Description

**_Problem_**: The contributing docs are a little lacking on how to get up and go and,
while they encourage running tox tests, tox is not included as a test dependency.

**_Solution_**: This PR
  1. Improves documentation aimed at first time Contributors
  2. Adds tox as an optional test dependency 
  3. Adds some common `venv` paths to .gitignore
  4. Cleans up some output for `tox list`
  5. Cleans up some output in `tox run -e hook`

## Testing

- [x] `tox` installed with `pip install -e .[test]`
    <details>
    
    BEFORE: 
    ![ansiblelint-install-tox-before](https://github.com/ansible/ansible-lint/assets/14808878/519ade95-731a-4e84-9954-1fd6cc028521)

    AFTER:
    ![ansiblelint-install-tox-after](https://github.com/ansible/ansible-lint/assets/14808878/74695df5-9f81-427d-a704-ebbd401ef5e6)
    ![ansiblelint-install-tox-after-2](https://github.com/ansible/ansible-lint/assets/14808878/7d239706-8511-4fe4-aac9-a8caddba41e4)
    </details>

- [x] git ignores `.venv`
    <details>
    
    BEFORE: 
    ![ansiblelint-ignore-venv-before](https://github.com/ansible/ansible-lint/assets/14808878/53a094f4-fd05-4b4b-b79a-9aac8a642849)

    AFTER:
    ![ansiblelint-ignore-venv-after](https://github.com/ansible/ansible-lint/assets/14808878/dd74a016-0cec-4a9f-b4d9-199ebbead3d4)
    </details>

- [x] `tox list` no longer has a dangling `and`
    <details>
    
    BEFORE: 
    ![ansiblelint-tox-and-before](https://github.com/ansible/ansible-lint/assets/14808878/ac86611b-ae58-42db-bfec-83b770a1e7a5)
    
    AFTER:
    ![ansiblelint-tox-and-after](https://github.com/ansible/ansible-lint/assets/14808878/2e6aa37c-95cc-4d62-afb2-ff5960a0869a)
    </details>

- [x] Add `--initial-branch=main` to test-hooks.sh to get rid of big warning.
    <details>
    
    BEFORE: 
    ![ansiblelint-tox-hook-before](https://github.com/ansible/ansible-lint/assets/14808878/9f1934ca-21d4-4239-a154-799107b08fcb)
    
    AFTER:
    ![ansiblelint-tox-hook-after](https://github.com/ansible/ansible-lint/assets/14808878/b70bc06d-6e0b-4b21-856b-a0defd2d280e)

    </details>

- [x] `tox run -e lint,pkg,docs,py`
    <details>

    ![ansiblelint-final-tox-run](https://github.com/ansible/ansible-lint/assets/14808878/fc6dc98b-45e9-45e5-b93b-ab5f47ce060d)

    </details>

    
## Outstanding questions / TODOs

If someone has the answers for these, I'm willing to update this PR to include it.

 1. If there was a test that should be updated / added for this PR, please point me to the desired
     location and I will do the needful.
 2.  Should the DCO file be removed since the --signoff requirement was removed in #719?
 3. I didn't update the docs to mention the need to have npm installed for the `tox run -e schemas`.
    I see the workflows are using setup-node and a cache-dependency-path but I didn't see a quick
    way to utilize this in a fresh local install. Thoughts?