### PR TITLE
Fix cmd args with no-free-form transformer

### DIFF
--- a/examples/playbooks/transform-no-free-form.transformed.yml
+++ b/examples/playbooks/transform-no-free-form.transformed.yml
@@ -8,6 +8,12 @@
         cmd: touch foo
       changed_when: false
 
+    - name: Create a placefolder file
+      ansible.builtin.command: # <-- command can also go first
+        chdir: /tmp
+        cmd: touch bar
+      changed_when: false
+
     - name: Use raw to echo
       ansible.builtin.raw: echo foo # <-- don't use executable=
       args:

--- a/examples/playbooks/transform-no-free-form.transformed.yml
+++ b/examples/playbooks/transform-no-free-form.transformed.yml
@@ -17,6 +17,7 @@
     - name: Example task with usage for '=' as module params
       ansible.builtin.debug:
         msg: "'Hello there world'"
+      changed_when: false
 
     - name: Task that has a non-debug string with spaces
       ansible.builtin.set_fact:

--- a/examples/playbooks/transform-no-free-form.transformed.yml
+++ b/examples/playbooks/transform-no-free-form.transformed.yml
@@ -17,3 +17,7 @@
     - name: Example task with usage for '=' as module params
       ansible.builtin.debug:
         msg: "'Hello there world'"
+
+    - name: Task that has a non-debug string with spaces
+      ansible.builtin.set_fact:
+        foo: '"String with spaces"'

--- a/examples/playbooks/transform-no-free-form.yml
+++ b/examples/playbooks/transform-no-free-form.yml
@@ -12,3 +12,6 @@
 
     - name: Example task with usage for '=' as module params
       ansible.builtin.debug: msg='Hello there world'
+
+    - name: Task that has a non-debug string with spaces
+      ansible.builtin.set_fact: foo="String with spaces"

--- a/examples/playbooks/transform-no-free-form.yml
+++ b/examples/playbooks/transform-no-free-form.yml
@@ -6,6 +6,10 @@
       ansible.builtin.command: chdir=/tmp touch foo # <-- don't use shorthand
       changed_when: false
 
+    - name: Create a placefolder file
+      ansible.builtin.command: touch bar chdir=/tmp # <-- command can also go first
+      changed_when: false
+
     - name: Use raw to echo
       ansible.builtin.raw: executable=/bin/bash echo foo # <-- don't use executable=
       changed_when: false

--- a/examples/playbooks/transform-no-free-form.yml
+++ b/examples/playbooks/transform-no-free-form.yml
@@ -12,6 +12,7 @@
 
     - name: Example task with usage for '=' as module params
       ansible.builtin.debug: msg='Hello there world'
+      changed_when: false
 
     - name: Task that has a non-debug string with spaces
       ansible.builtin.set_fact: foo="String with spaces"

--- a/src/ansiblelint/rules/no_free_form.py
+++ b/src/ansiblelint/rules/no_free_form.py
@@ -80,7 +80,7 @@ class NoFreeFormRule(AnsibleLintRule, TransformMixin):
                 "win_command",
                 "win_shell",
             ):
-                if self.cmd_shell_re.match(action_value):
+                if self.cmd_shell_re.search(action_value):
                     fail = True
             else:
                 fail = True

--- a/src/ansiblelint/rules/no_free_form.py
+++ b/src/ansiblelint/rules/no_free_form.py
@@ -107,14 +107,36 @@ class NoFreeFormRule(AnsibleLintRule, TransformMixin):
                 val: str,
                 filter_key: str,
                 filter_dict: dict[str, Any],
-            ) -> bool:
-                """Return True if module option is not present in the string."""
-                if filter_key not in val:
-                    return True
+            ) -> str:
+                """Pull out key=value pairs from a string and set them in filter_dict.
 
-                [k, v] = val.split(filter_key)
+                Returns unmatched strings.
+                """
+                if filter_key not in val:
+                    return val
+
+                extra = ""
+                [k, v] = val.split(filter_key, 1)
+                if " " in k:
+                    extra, k = k.rsplit(" ", 1)
+
+                if v[0] in "\"'":
+                    # Keep quoted strings together
+                    quote = v[0]
+                    _, v, remainder = v.split(quote, 2)
+                    v = f"{quote}{v}{quote}"
+                else:
+                    try:
+                        v, remainder = v.split(" ", 1)
+                    except ValueError:
+                        remainder = ""
+
                 filter_dict[k] = v
-                return False
+
+                extra = " ".join(
+                    (extra, filter_values(remainder, filter_key, filter_dict)),
+                )
+                return extra.strip()
 
             if match.tag == "no-free-form":
                 module_opts: dict[str, Any] = {}
@@ -122,18 +144,9 @@ class NoFreeFormRule(AnsibleLintRule, TransformMixin):
                     k, v = task.popitem(False)
                     # identify module as key and process its value
                     if len(k.split(".")) == 3 and isinstance(v, str):
-                        # if it is a message
-                        if "msg" in v:
-                            filter_values(v, "=", module_opts)
-                        else:
-                            # Filter the module options and command
-                            module_opts["cmd"] = " ".join(
-                                [
-                                    item
-                                    for item in v.split(" ")
-                                    if filter_values(item, "=", module_opts)
-                                ],
-                            )
+                        cmd = filter_values(v, "=", module_opts)
+                        if cmd:
+                            module_opts["cmd"] = cmd
 
                         sorted_module_opts = {}
                         for key in sorted(

--- a/test/test_transformer.py
+++ b/test/test_transformer.py
@@ -143,7 +143,7 @@ def fixture_runner_result(
         ),
         pytest.param(
             "examples/playbooks/transform-no-free-form.yml",
-            3,
+            4,
             True,
             True,
             id="no_free_form_transform",

--- a/test/test_transformer.py
+++ b/test/test_transformer.py
@@ -143,7 +143,7 @@ def fixture_runner_result(
         ),
         pytest.param(
             "examples/playbooks/transform-no-free-form.yml",
-            4,
+            5,
             True,
             True,
             id="no_free_form_transform",


### PR DESCRIPTION
There was a specific callout for using msg with debug, but all other inline module args would generate a cmd arg even if nothing went into it. This generalizes the approach (though it assumes that anything that doesn't fit should go into a cmd arg)

Fixes #4189