### PR TITLE
Fix relative imports in args rule

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -366,6 +366,7 @@ taskincludes
 taskshandlers
 templatevars
 templating
+testcollection
 testinfra
 testmon
 testns

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -72,7 +72,7 @@ jobs:
     env:
       # Number of expected test passes, safety measure for accidental skip of
       # tests. Update value if you add/remove tests.
-      PYTEST_REQPASS: 883
+      PYTEST_REQPASS: 884
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -72,8 +72,10 @@ src/ansiblelint/_version.py
 test/eco/CODENOTIFY.html
 test/eco
 test/schemas/node_modules
+test/local-content
 .envrc
-collections
+# collections
+# !/collections
 site
 _readthedocs
 *.tmp.*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -173,6 +173,7 @@ repos:
           - wcmatch
         exclude: >
           (?x)^(
+            collections/.*|
             test/local-content/.*|
             plugins/.*
           )$

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,2 +1,2 @@
 [defaults]
-collections_path = examples/playbooks/collections
+collections_path = collections:examples/playbooks/collections

--- a/collections/ansible_collections/local/testcollection/README.md
+++ b/collections/ansible_collections/local/testcollection/README.md
@@ -1,0 +1,3 @@
+# Ansible Collection - local.testcollection
+
+Documentation for the collection.

--- a/collections/ansible_collections/local/testcollection/galaxy.yml
+++ b/collections/ansible_collections/local/testcollection/galaxy.yml
@@ -1,0 +1,7 @@
+---
+namespace: local
+name: testcollection
+version: 1.0.0
+readme: README.md
+authors:
+  - your name <example@domain.com>

--- a/collections/ansible_collections/local/testcollection/plugins/module_utils/__init__.py
+++ b/collections/ansible_collections/local/testcollection/plugins/module_utils/__init__.py
@@ -1,0 +1,4 @@
+"""module_utils package."""
+
+# Some value that can be imported from a module
+MY_STRING: str = "foo"

--- a/collections/ansible_collections/local/testcollection/plugins/modules/__init__.py
+++ b/collections/ansible_collections/local/testcollection/plugins/modules/__init__.py
@@ -1,0 +1,1 @@
+"""modules package."""

--- a/collections/ansible_collections/local/testcollection/plugins/modules/module_with_relative_import.py
+++ b/collections/ansible_collections/local/testcollection/plugins/modules/module_with_relative_import.py
@@ -1,0 +1,25 @@
+"""module_with_relative_import module."""
+
+from ansible.module_utils.basic import AnsibleModule
+
+# pylint: disable=E0402
+from ..module_utils import MY_STRING  # noqa: TID252 # type: ignore[import-untyped]
+
+DOCUMENTATION = r"""
+options:
+  name:
+    required: True
+"""
+
+
+def main() -> AnsibleModule:
+    """The main function."""
+    return AnsibleModule(
+        argument_spec={
+            "name": {"required": True, "aliases": [MY_STRING]},
+        },
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/playbooks/module_relative_import.yml
+++ b/examples/playbooks/module_relative_import.yml
@@ -1,0 +1,6 @@
+---
+- name: Module relative import
+  hosts: localhost
+  tasks:
+    - name: Module with relative import
+      local.testcollection.module_with_relative_import: {}

--- a/src/ansiblelint/rules/args.py
+++ b/src/ansiblelint/rules/args.py
@@ -144,7 +144,7 @@ class ArgsRule(AnsibleLintRule):
             CustomAnsibleModule,
         ):
             spec = importlib.util.spec_from_file_location(
-                name=loaded_module.resolved_fqcn,
+                name=loaded_module.plugin_resolved_name,
                 location=loaded_module.plugin_resolved_path,
             )
             if not spec:

--- a/test/rules/test_args.py
+++ b/test/rules/test_args.py
@@ -1,0 +1,19 @@
+"""Tests for args rule."""
+
+from ansiblelint.file_utils import Lintable
+from ansiblelint.rules import RulesCollection
+from ansiblelint.runner import Runner
+
+
+def test_args_module_relative_import(default_rules_collection: RulesCollection) -> None:
+    """Validate args check of a module with a relative import."""
+    lintable = Lintable(
+        "examples/playbooks/module_relative_import.yml",
+        kind="playbook",
+    )
+    result = Runner(lintable, rules=default_rules_collection).run()
+    assert len(result) == 1, result
+    assert result[0].lineno == 5
+    assert result[0].filename == "examples/playbooks/module_relative_import.yml"
+    assert result[0].tag == "args[module]"
+    assert result[0].message == "missing required arguments: name"


### PR DESCRIPTION
The `args` rule loads modules used in/by tasks using pythons `importlib`. When doing so it uses the ansible full-qualified collection name (fqcn), which works fine if the module only uses absolute imports. But if the to-be-loaded module uses relative imports, it breaks because the fqcn is different from the python qualified name (`local.testcollection.module_with_relative_import` vs `ansible_collections.local.testcollection.plugins.modules.module_with_relative_import`). As importlib and python have no idea about ansible collections, it will look for the wrong packages/modules, which manifests on the user-side in warnings like this:

```
% ansible-lint -vv examples/playbooks/module_relative_import.yml
[...]
DEBUG    Running rule args
WARNING  Ignored exception from ArgsRule.matchtasks while processing examples/playbooks/module_relative_import.yml (playbook): No module named 'local'
DEBUG    Ignored exception details
Traceback (most recent call last):
  File "/tmp/ansible-lint/src/ansiblelint/_internal/rules.py", line 94, in getmatches
    matches.extend(method(file))
                   ^^^^^^^^^^^^
  File "/tmp/ansible-lint/src/ansiblelint/rules/__init__.py", line 178, in matchtasks
    result = self.matchtask(task, file=file)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/ansible-lint/src/ansiblelint/rules/args.py", line 161, in matchtask
    spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 995, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/tmp/ansible-lint/collections/ansible_collections/local/testcollection/plugins/modules/module_with_relative_import.py", line 3, in <module> 
    from ..module_utils import MY_STRING
ModuleNotFoundError: No module named 'local'
[...]
```

It is looking for a module (or rather package) named `local` because that is the parent-package in the fqcn, while the actual parent is `plugins`. #2813 isn't really clear on why the fqcn was used.

For testing, I added a whole local collection, which is a first in the repo and may be a bit "too much". Any advice for a better solution is appreciated.

I initially ran into this issue with the [`containers.podman.podman_container` module](https://docs.ansible.com/ansible/latest/collections/containers/podman/podman_container_module.html), in case you want an actual example from the wild.

Fixes #4208 