### PR TITLE
Accept changlog.yml as a valid changelog

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -72,7 +72,7 @@ jobs:
     env:
       # Number of expected test passes, safety measure for accidental skip of
       # tests. Update value if you add/remove tests.
-      PYTEST_REQPASS: 882
+      PYTEST_REQPASS: 883
     steps:
       - uses: actions/checkout@v4
         with:

--- a/src/ansiblelint/config.py
+++ b/src/ansiblelint/config.py
@@ -68,7 +68,7 @@ DEFAULT_KINDS = [
     {"requirements": "**/requirements.{yaml,yml}"},  # v2 and v1
     {"playbook": "**/molecule/*/*.{yaml,yml}"},  # molecule playbooks
     {"yaml": "**/{.ansible-lint,.yamllint}"},
-    {"changelog": "**/changelogs/changelog.yaml"},
+    {"changelog": "**/changelogs/changelog.{yaml,yml}"},
     {"yaml": "**/*.{yaml,yml}"},
     {"yaml": "**/.*.{yaml,yml}"},
     {"sanity-ignore-file": "**/tests/sanity/ignore-*.txt"},

--- a/src/ansiblelint/rules/galaxy.md
+++ b/src/ansiblelint/rules/galaxy.md
@@ -62,12 +62,14 @@ description: "..."
 
 # Changelog Details
 
-This rule expects a `CHANGELOG.md` or `.rst` file in the collection root or a
-`changelogs/changelog.yaml` file.
+This rule expects a `CHANGELOG.md`, `CHANGELOG.rst`,
+`changelogs/changelog.yaml`, or `changelogs/changelog.yml` file in the
+collection root.
 
-If a `changelogs/changelog.yaml` file exists, the schema will be checked.
+If a `changelogs/changelog.yaml` or `changelogs/changelog.yml` file exists, the
+schema will be checked.
 
-## Minimum required changelog.yaml file
+## Minimum required changelog.yaml/changelog.yml file
 
 ```yaml
 # changelog.yaml

--- a/src/ansiblelint/rules/galaxy.py
+++ b/src/ansiblelint/rules/galaxy.py
@@ -58,6 +58,7 @@ class GalaxyRule(AnsibleLintRule):
         changelog_found = 0
         changelog_paths = [
             base_path / "changelogs" / "changelog.yaml",
+            base_path / "changelogs" / "changelog.yml",
             base_path / "CHANGELOG.rst",
             base_path / "CHANGELOG.md",
         ]

--- a/test/test_file_utils.py
+++ b/test/test_file_utils.py
@@ -264,6 +264,7 @@ def test_discover_lintables_umlaut(monkeypatch: MonkeyPatch) -> None:
             "plugin",
             id="44",
         ),
+        pytest.param("examples/meta/changelogs/changelog.yml", "changelog", id="45"),
     ),
 )
 def test_kinds(path: str, kind: FileType) -> None:


### PR DESCRIPTION
Fixes #4105.

I'd like to mention that when looking over #2832 again, I see that `changelog.yaml` was preferred over `changelog.yml` because the latter wasn't documented. While this isn't true anymore, `changelog.yml` appears to be sparsely mentioned (only reference I found in the offical docs was [here](https://docs.ansible.com/ansible/latest/community/collection_contributors/collection_release_with_branches.html#creating-the-changelogs)). This is to say, I wonder if this _should_ be fixed.