### PR TITLE
Ignore var-naming[pattern] to foreign role vars

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -72,7 +72,7 @@ jobs:
     env:
       # Number of expected test passes, safety measure for accidental skip of
       # tests. Update value if you add/remove tests.
-      PYTEST_REQPASS: 884
+      PYTEST_REQPASS: 886
     steps:
       - uses: actions/checkout@v4
         with:

--- a/examples/playbooks/bug-4095.yml
+++ b/examples/playbooks/bug-4095.yml
@@ -1,0 +1,10 @@
+---
+- name: Test task
+  hosts: localhost
+  connection: local
+  tasks:
+    - name: Reproduce bug related bug 4095
+      ansible.builtin.include_role:
+        name: local.testcollection.bug4095
+      vars:
+        var1: val1

--- a/src/ansiblelint/text.py
+++ b/src/ansiblelint/text.py
@@ -55,3 +55,10 @@ def has_glob(value: str) -> bool:
 def is_fqcn_or_name(value: str) -> bool:
     """Return true if a string seems to be a module/filter old name or a fully qualified one."""
     return bool(isinstance(value, str) and RE_IS_FQCN_OR_NAME.search(value))
+
+
+@cache
+def is_fqcn(value: str) -> bool:
+    """Return true if a string seems to be a fully qualified collection name."""
+    match = RE_IS_FQCN_OR_NAME.search(value)
+    return bool(isinstance(value, str) and match and match.group(1))

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -76,7 +76,7 @@ from ansiblelint.constants import (
 from ansiblelint.errors import MatchError
 from ansiblelint.file_utils import Lintable, discover_lintables
 from ansiblelint.skip_utils import is_nested_task
-from ansiblelint.text import has_jinja, removeprefix
+from ansiblelint.text import has_jinja, is_fqcn, removeprefix
 
 if TYPE_CHECKING:
     from ansiblelint.rules import RulesCollection
@@ -505,21 +505,40 @@ def _get_task_handler_children_for_tasks_or_playbooks(
 
 def _rolepath(basedir: str, role: str) -> str | None:
     role_path = None
+    namespace_name, collection_name, role_name = (
+        role.split(".") if is_fqcn(role) else ("", "", role)
+    )
 
     possible_paths = [
         # if included from a playbook
-        path_dwim(basedir, os.path.join("roles", role)),
-        path_dwim(basedir, role),
+        path_dwim(basedir, os.path.join("roles", role_name)),
+        path_dwim(basedir, role_name),
         # if included from roles/[role]/meta/main.yml
-        path_dwim(basedir, os.path.join("..", "..", "..", "roles", role)),
-        path_dwim(basedir, os.path.join("..", "..", role)),
+        path_dwim(basedir, os.path.join("..", "..", "..", "roles", role_name)),
+        path_dwim(basedir, os.path.join("..", "..", role_name)),
         # if checking a role in the current directory
-        path_dwim(basedir, os.path.join("..", role)),
+        path_dwim(basedir, os.path.join("..", role_name)),
     ]
 
     for loc in get_app(cached=True).runtime.config.default_roles_path:
         loc = os.path.expanduser(loc)
-        possible_paths.append(path_dwim(loc, role))
+        possible_paths.append(path_dwim(loc, role_name))
+
+    if namespace_name and collection_name:
+        for loc in get_app(cached=True).runtime.config.collections_paths:
+            loc = os.path.expanduser(loc)
+            possible_paths.append(
+                path_dwim(
+                    loc,
+                    os.path.join(
+                        "ansible_collections",
+                        namespace_name,
+                        collection_name,
+                        "roles",
+                        role_name,
+                    ),
+                ),
+            )
 
     possible_paths.append(path_dwim(basedir, ""))
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -480,3 +480,13 @@ def test_find_children_in_module(default_rules_collection: RulesCollection) -> N
     # Child correctly looks like a YAML file
     assert child.base_kind == "text/yaml"
     assert child.content.startswith("---")
+
+
+def test_find_children_in_playbook(default_rules_collection: RulesCollection) -> None:
+    """Verify correct function of find_children() in playbooks."""
+    lintable = Lintable("examples/playbooks/bug-4095.yml")
+    children = Runner(
+        rules=default_rules_collection,
+    ).find_children(lintable)
+    assert len(children) == 1
+    assert children[0].role == "bug4095"


### PR DESCRIPTION
Fixes #4095.

When working on this issue, I ran into another bug when writing a test case to test my solution to the issue. The bug I ran into was when running a test case that would lint a playbook from `./examples/playbooks` that contained a `include_role`/`import_role` task with a FQCN role as its argument. I noticed that the test case would pick up violations from other lintables that I didn't specify as an argument to my `runner` instance. I suspect this is because `_rolepath` currently doesn't handle FQCNs, which results in the `basedir` being returned and can cause `_look_for_role_files` to return additional unexpected files. This can be seen when running `pytest test/test_utils.py::test_find_children_in_playbook` from another fork branch I made to showcase this https://github.com/cavcrosby/ansible-lint/tree/ignore-foreign-role-vars-revert-utils. The changes to fix said bug are consolidated into `utils.py`.

To add, said bug probably won't affect an end user unless they purposefully contain violations in their Ansible yaml like in the case of `ansible-lint`. That said, I would think we would want to address this for development purposes.