### PR TITLE
GitHub Action: avoid extra working directory prefix for wget

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,7 @@ runs:
         GH_ACTION_REF: ${{ github.action_ref || 'main' }}
       working-directory: ${{ steps.inputs.outputs.working_directory }}
       run: |
-        wget --output-document=${{ steps.inputs.outputs.working_directory }}/.git/ansible-lint-requirements.txt https://raw.githubusercontent.com/ansible/ansible-lint/$GH_ACTION_REF/.config/requirements-lock.txt
+        wget --output-document=.git/ansible-lint-requirements.txt https://raw.githubusercontent.com/ansible/ansible-lint/$GH_ACTION_REF/.config/requirements-lock.txt
 
     - name: Set up Python
       if: inputs.setup_python == 'true'


### PR DESCRIPTION
The whole shell step for wget is run with the working directory for the action; hence, drop the extra prefix to the --output-document parameter of the wget command.