### PR TITLE
Make the documentation not use a very old version of ansible-lint by default

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -115,7 +115,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run ansible-lint
-        uses: ansible/ansible-lint@v6
+        uses: ansible/ansible-lint@main
 ```
 
 Due to limitations on how GitHub Actions are processing arguments, we do not


### PR DESCRIPTION
Make the documentation not use a very old version of ansible-lint by default