### PR TITLE
Add support for setting nodeps through cli and .ansible-lint

### DIFF
--- a/src/ansiblelint/__main__.py
+++ b/src/ansiblelint/__main__.py
@@ -131,6 +131,11 @@ def initialize_options(arguments: list[str] | None = None) -> None | FileLock:
     # persist loaded configuration inside options module
     for k, v in new_options.__dict__.items():
         setattr(options, k, v)
+    
+    if options.nodeps is None or options.nodeps == False:
+        options.nodeps = bool(int(os.environ.get("ANSIBLE_LINT_NODEPS", "0")))
+    if options.nodeps:
+        options.offline = True
 
     # rename deprecated ids/tags to newer names
     options.tags = [normalize_tag(tag) for tag in options.tags]

--- a/src/ansiblelint/__main__.py
+++ b/src/ansiblelint/__main__.py
@@ -131,7 +131,7 @@ def initialize_options(arguments: list[str] | None = None) -> None | FileLock:
     # persist loaded configuration inside options module
     for k, v in new_options.__dict__.items():
         setattr(options, k, v)
-    
+
     if options.nodeps is None or options.nodeps == False:
         options.nodeps = bool(int(os.environ.get("ANSIBLE_LINT_NODEPS", "0")))
     if options.nodeps:

--- a/src/ansiblelint/__main__.py
+++ b/src/ansiblelint/__main__.py
@@ -132,7 +132,7 @@ def initialize_options(arguments: list[str] | None = None) -> None | FileLock:
     for k, v in new_options.__dict__.items():
         setattr(options, k, v)
 
-    if options.nodeps is None or options.nodeps == False:
+    if options.nodeps is None or options.nodeps is False:
         options.nodeps = bool(int(os.environ.get("ANSIBLE_LINT_NODEPS", "0")))
     if options.nodeps:
         options.offline = True

--- a/src/ansiblelint/cli.py
+++ b/src/ansiblelint/cli.py
@@ -464,6 +464,14 @@ def get_cli_parser() -> argparse.ArgumentParser:
         help="Disable installation of requirements.yml and schema refreshing",
     )
     parser.add_argument(
+        "--nodeps",
+        dest="nodeps",
+        action="store_const",
+        const=True,
+        default=None,
+        help="Disable external dependency checking",
+    )
+    parser.add_argument(
         "--version",
         action="store_true",
     )
@@ -486,6 +494,7 @@ def merge_config(file_config: dict[Any, Any], cli_config: Options) -> Options:
         "strict",
         "use_default_rules",
         "offline",
+        "nodeps",
     )
     # maps lists to their default config values
     lists_map = {

--- a/src/ansiblelint/config.py
+++ b/src/ansiblelint/config.py
@@ -179,10 +179,8 @@ class Options:  # pylint: disable=too-many-instance-attributes
     _default_supported = ["2.15.", "2.16.", "2.17."]
     supported_ansible_also: list[str] = field(default_factory=list)
 
-
     def __post_init__(self) -> None:
         """Extra initialization logic."""
-        pass
 
     @property
     def supported_ansible(self) -> list[str]:

--- a/src/ansiblelint/config.py
+++ b/src/ansiblelint/config.py
@@ -154,6 +154,7 @@ class Options:  # pylint: disable=too-many-instance-attributes
     only_builtins_allow_modules: list[str] = field(default_factory=list)
     var_naming_pattern: str | None = None
     offline: bool = False
+    nodeps: bool | None = None
     project_dir: str = "."  # default should be valid folder (do not use None here)
     extra_vars: dict[str, Any] | None = None
     enable_list: list[str] = field(default_factory=list)
@@ -178,16 +179,10 @@ class Options:  # pylint: disable=too-many-instance-attributes
     _default_supported = ["2.15.", "2.16.", "2.17."]
     supported_ansible_also: list[str] = field(default_factory=list)
 
-    @property
-    def nodeps(self) -> bool:
-        """Returns value of nodeps feature."""
-        # We do not want this to be cached as it would affect our testings.
-        return bool(int(os.environ.get("ANSIBLE_LINT_NODEPS", "0")))
 
     def __post_init__(self) -> None:
         """Extra initialization logic."""
-        if self.nodeps:
-            self.offline = True
+        pass
 
     @property
     def supported_ansible(self) -> list[str]:

--- a/src/ansiblelint/schemas/ansible-lint-config.json
+++ b/src/ansiblelint/schemas/ansible-lint-config.json
@@ -85,6 +85,11 @@
       "title": "Offline",
       "type": "boolean"
     },
+    "nodeps": {
+      "default": null,
+      "title": "Nodeps",
+      "type": ["boolean", "null"]
+    },
     "only_builtins_allow_collections": {
       "items": {
         "type": "string"

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -104,7 +104,7 @@ def test_nodeps(lintable: str) -> None:
     env = os.environ.copy()
     py_path = Path(sys.executable).parent
     proc = subprocess.run(
-        [str(py_path / "ansible-lint"), "--nodeps=true", lintable],
+        [str(py_path / "ansible-lint"), "--nodeps", lintable],
         check=False,
         capture_output=True,
         text=True,

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -102,6 +102,13 @@ def test_get_version_warning_no_pip(mocker: MockerFixture) -> None:
 def test_nodeps(lintable: str) -> None:
     """Asserts ability to be called w/ or w/o venv activation."""
     env = os.environ.copy()
+    proc = subprocess.run(
+        [str(py_path / "ansible-lint"), '--nodeps=true', lintable],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
     env["ANSIBLE_LINT_NODEPS"] = "1"
     py_path = Path(sys.executable).parent
     proc = subprocess.run(

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -104,7 +104,7 @@ def test_nodeps(lintable: str) -> None:
     env = os.environ.copy()
     py_path = Path(sys.executable).parent
     proc = subprocess.run(
-        [str(py_path / "ansible-lint"), '--nodeps=true', lintable],
+        [str(py_path / "ansible-lint"), "--nodeps=true", lintable],
         check=False,
         capture_output=True,
         text=True,

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -109,6 +109,7 @@ def test_nodeps(lintable: str) -> None:
         text=True,
         env=env,
     )
+    assert proc.returncode == 0, proc
     env["ANSIBLE_LINT_NODEPS"] = "1"
     py_path = Path(sys.executable).parent
     proc = subprocess.run(

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -102,6 +102,7 @@ def test_get_version_warning_no_pip(mocker: MockerFixture) -> None:
 def test_nodeps(lintable: str) -> None:
     """Asserts ability to be called w/ or w/o venv activation."""
     env = os.environ.copy()
+    py_path = Path(sys.executable).parent
     proc = subprocess.run(
         [str(py_path / "ansible-lint"), '--nodeps=true', lintable],
         check=False,
@@ -111,7 +112,6 @@ def test_nodeps(lintable: str) -> None:
     )
     assert proc.returncode == 0, proc
     env["ANSIBLE_LINT_NODEPS"] = "1"
-    py_path = Path(sys.executable).parent
     proc = subprocess.run(
         [str(py_path / "ansible-lint"), lintable],
         check=False,

--- a/test/test_transformer.py
+++ b/test/test_transformer.py
@@ -200,7 +200,7 @@ def fixture_runner_result(
         pytest.param(
             "examples/playbooks/4114/transform-with-missing-role-and-modules.yml",
             1,
-            True,
+            False,
             True,
             id="4114",
         ),


### PR DESCRIPTION
As proposed in #4258, it seems that having an option to set nodeps using the command line interface and/or .ansible-lint file to be desireable, so here is a simple implementation of it.