### PR TITLE
Fix incorrect documentation of playbook and roles linting

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -63,7 +63,7 @@ because it helps those tools better distinguish between random YAML files and
 files managed by Ansible. When you call `ansible-lint` without arguments, it
 uses internal heuristics to determine file types.
 
-**Roles** and **playbooks** that you want to lint are added as arguments.
+Pass the **roles** and **playbooks** that you want to lint as arguments to the `ansible-lint` command.
 For example, to lint `examples/playbooks/play.yml` and
 `examples/roles/bobbins`, use the following command:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -63,12 +63,12 @@ because it helps those tools better distinguish between random YAML files and
 files managed by Ansible. When you call `ansible-lint` without arguments, it
 uses internal heuristics to determine file types.
 
-You can specify the list of **roles** or **playbooks** that you want to lint
-with the `-p` argument. For example, to lint `examples/playbooks/play.yml` and
+**Roles** and **playbooks** that you want to lint are added as arguments.
+For example, to lint `examples/playbooks/play.yml` and
 `examples/roles/bobbins`, use the following command:
 
 ```console exec="1" source="console" returncode="2"
-$ ansible-lint --offline -p examples/playbooks/play.yml examples/roles/bobbins
+$ ansible-lint examples/playbooks/play.yml examples/roles/bobbins
 ```
 
 [collection structure layout]:


### PR DESCRIPTION
Previously, the documentation stated that the `-p` flag was used to lint roles and playbooks. This is incorrect as the `-p` flag is used to specify the output format.

I've removed all unnecessary flags from the example to avoid confusion to the reader. This confusion is very likely what lead to the misdocumentation.

This documentation error was introduced in a documentation rewrite in #2682.