### PR TITLE
Fix list of non-strings in args rule

### DIFF
--- a/examples/playbooks/rule-args-module-pass.yml
+++ b/examples/playbooks/rule-args-module-pass.yml
@@ -95,3 +95,14 @@
           src: "args.json"
       action: ansible.builtin.copy
       args: "{{ copy_vars }}" # since, we're unable to analyze jinja, we skip this kind of checks
+
+    - name: Variable containing list of non-strings should pass (Bug 4229)
+      community.general.mas:
+        id: "{{ item }}"
+        state: present
+      loop: "{{ mas_app_ids }}"
+      vars:
+        mas_app_ids:
+          - 409183694
+          - 409203825
+          - 409201541

--- a/src/ansiblelint/rules/args.py
+++ b/src/ansiblelint/rules/args.py
@@ -225,7 +225,7 @@ class ArgsRule(AnsibleLintRule):
             error_message = failed_msg
 
         option_type_check_error = re.search(
-            r"argument '(?P<name>.*)' is of type",
+            r"(argument|option) '(?P<name>.*)' is of type",
             error_message,
         )
         if option_type_check_error:


### PR DESCRIPTION
Fixes #4229 where lists of non-strings passed to an argument as a variable will fail.