### PR TITLE
fix: Adding missing EE option skip_pip_install

### DIFF
--- a/src/ansiblelint/schemas/execution-environment.json
+++ b/src/ansiblelint/schemas/execution-environment.json
@@ -278,6 +278,10 @@
               "description": "Disables the check for Ansible/Runner in final image",
               "type": "boolean"
             },
+            "skip_pip_install": {
+              "description": "Disables the installation of pip in the base image",
+              "type": "boolean"
+            },
             "user": {
               "description": "Sets the username or UID",
               "type": "string"


### PR DESCRIPTION
Adding the missing option options.skip_pip_install, see https://ansible.readthedocs.io/projects/builder/en/latest/definition/#options