### PR TITLE
fix: Add reset-failed state in executable_options

### DIFF
--- a/examples/playbooks/rule-command-instead-of-module-pass.yml
+++ b/examples/playbooks/rule-command-instead-of-module-pass.yml
@@ -34,6 +34,10 @@
       ansible.builtin.command: systemctl kill --signal=SIGUSR1 sshd
       changed_when: false
 
+    - name: Reset a service with systemctl reset-failed
+      ansible.builtin.command: systemctl reset-failed sshd
+      changed_when: false
+
     - name: Clear yum cache
       ansible.builtin.command: yum clean all
       changed_when: false

--- a/src/ansiblelint/rules/command_instead_of_module.py
+++ b/src/ansiblelint/rules/command_instead_of_module.py
@@ -78,6 +78,7 @@ class CommandsInsteadOfModulesRule(AnsibleLintRule):
             "set-property",
             "show-environment",
             "status",
+            "reset-failed",
         ],
         "yum": ["clean", "history", "info"],
         "rpm": ["--nodeps"],


### PR DESCRIPTION
### Issue:
- Fixes [ansible-lint Issue #4255](https://github.com/ansible/ansible-lint/issues/4255)

### Description:
This PR introduces a fix that allows the `reset-failed` state to be correctly handled when using the `ansible.builtin.command` module. Previously, the rule validation incorrectly flagged tasks using `systemctl reset-failed` through the `ansible.builtin.command` module, suggesting the use of the `systemd` module instead, which does not natively support the `reset-failed` state.

### Changes:
- Added support for the `reset-failed` state in the executable options for the `ansible.builtin.command` module.