### PR TITLE
chore: Update ansible-compat version

### DIFF
--- a/.config/requirements.in
+++ b/.config/requirements.in
@@ -1,7 +1,7 @@
 # Special order section for helping pip:
 will-not-work-on-windows-try-from-wsl-instead; platform_system=='Windows'
 ansible-core>=2.13.0 # GPLv3
-ansible-compat>=24.5.0dev0 # GPLv3
+ansible-compat>=24.8.0 # GPLv3
 # alphabetically sorted:
 black>=24.3.0 # MIT (security)
 filelock>=3.3.0 # The Unlicense

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -153,7 +153,7 @@ repos:
         # empty args needed in order to match mypy cli behavior
         args: [--strict]
         additional_dependencies:
-          - ansible-compat>=24.5.1
+          - ansible-compat>=24.8.0
           - black>=22.10.0
           - cryptography>=39.0.1
           - filelock>=3.12.2
@@ -183,7 +183,7 @@ repos:
         args:
           - --output-format=colorized
         additional_dependencies:
-          - ansible-compat>=24.5.1
+          - ansible-compat>=24.8.0
           - ansible-core>=2.14.0
           - black>=22.10.0
           - docutils


### PR DESCRIPTION
### Description:
This PR updates the `ansible-compat` dependency version to the latest version.

### Changes:
- Updated `ansible-compat` to version `24.8.0` in the `.pre-commit-config.yaml` and `requirements.in` .