### PR TITLE
Fix missing MatchErrors due to hash collisions

### DIFF
--- a/examples/playbooks/vars/rule_var_naming_fails_files/bar.yml
+++ b/examples/playbooks/vars/rule_var_naming_fails_files/bar.yml
@@ -1,0 +1,3 @@
+---
+CamelCaseIsBad: bar
+ALL_CAPS_ARE_BAD_TOO: bar

--- a/examples/playbooks/vars/rule_var_naming_fails_files/foo.yml
+++ b/examples/playbooks/vars/rule_var_naming_fails_files/foo.yml
@@ -1,0 +1,3 @@
+---
+CamelCaseIsBad: foo
+ALL_CAPS_ARE_BAD_TOO: foo

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -358,6 +358,7 @@ class HandleChildren:
             raise MatchError(
                 message="A malformed block was encountered while loading a block.",
                 rule=RuntimeErrorRule(),
+                lintable=lintable,
             )
         for task_handler in v:
             # ignore empty tasks, `-`
@@ -408,23 +409,21 @@ class HandleChildren:
         """Verify that the task handler action is valid for role include."""
         module = th_action["__ansible_module__"]
 
+        lintable = Lintable(
+            self.rules.options.lintables[0] if self.rules.options.lintables else ".",
+        )
         if "name" not in th_action:
             raise MatchError(
                 message=f"Failed to find required 'name' key in {module!s}",
                 rule=self.rules.rules[0],
-                lintable=Lintable(
-                    (
-                        self.rules.options.lintables[0]
-                        if self.rules.options.lintables
-                        else "."
-                    ),
-                ),
+                lintable=lintable,
             )
 
         if not isinstance(th_action["name"], str):
             raise MatchError(
                 message=f"Value assigned to 'name' key on '{module!s}' is not a string.",
                 rule=self.rules.rules[1],
+                lintable=lintable,
             )
 
     def roles_children(

--- a/tox.ini
+++ b/tox.ini
@@ -74,7 +74,7 @@ setenv =
   PRE_COMMIT_COLOR = always
   # Number of expected test passes, safety measure for accidental skip of
   # tests. Update value if you add/remove tests. (tox-extra)
-  PYTEST_REQPASS = 893
+  PYTEST_REQPASS = 894
   FORCE_COLOR = 1
   pre: PIP_PRE = 1
 allowlist_externals =


### PR DESCRIPTION
Fixes #4297.

This fix follows what was done here, https://github.com/ansible/ansible-lint/pull/4202, for transitioning to passing a `lintable` argument for `MatchError` object construction instead of a `filename` argument. I also noticed a few places in `src/ansiblelint/utils.py` where this problem could be reproduced. Hence, I figured now would be a good time to address those spots as well.