### PR TITLE
Community comms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![PyPI version](https://img.shields.io/pypi/v/ansible-lint.svg)](https://pypi.org/project/ansible-lint)
 [![Ansible-lint rules explanation](https://img.shields.io/badge/Ansible--lint-rules-blue.svg)](https://ansible.readthedocs.io/projects/lint/rules/)
-[![Discussions](https://img.shields.io/badge/Discussions-gray.svg)](https://github.com/ansible/ansible-lint/discussions)
+[![Discussions](https://img.shields.io/badge/Discussions-gray.svg)](https://forum.ansible.com/tag/ansible-lint)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 
 # Ansible-lint

--- a/README.md
+++ b/README.md
@@ -34,9 +34,23 @@ jobs:
 
 For more details, see [ansible-lint-action].
 
+# Communication
+
+Refer to the
+[Talk to us](https://ansible.readthedocs.io/projects/lint/contributing/#talk-to-us)
+section of the Contributing guide to find out how to get in touch with us.
+
+You can also find more information in the
+[Ansible communication guide](https://docs.ansible.com/ansible/devel/community/communication.html).
+
 # Contributing
 
 Please read [Contribution guidelines] if you wish to contribute.
+
+# Code of Conduct
+
+Please see the official
+[Ansible Community Code of Conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html).
 
 # Licensing
 
@@ -53,7 +67,8 @@ ansible-lint was created by [Will Thames] and is now maintained as part of the
 [Ansible] by [Red Hat] project.
 
 [ansible]: https://ansible.com
-[contribution guidelines]: https://ansible.readthedocs.io/projects/lint/contributing
+[contribution guidelines]:
+  https://ansible.readthedocs.io/projects/lint/contributing
 [gplv3]: https://github.com/ansible/ansible-lint/blob/main/COPYING
 [mit]:
   https://github.com/ansible/ansible-lint/blob/main/docs/licenses/LICENSE.mit.txt

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Please read [Contribution guidelines] if you wish to contribute.
 
 # Code of Conduct
 
-Please see the official
+Please see the
 [Ansible Community Code of Conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html).
 
 # Licensing

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -38,13 +38,28 @@ pushing commits, just use [tox](https://tox.wiki/en/latest/).
 
 ## Talk to us
 
-Use Github [discussions] forum or for a live chat experience try
-`#ansible-devtools` IRC channel on libera.chat or Matrix room
+Connect with the Ansible community!
+
+Join the Ansible forum to ask questions, get help, and interact with the
+community.
+
+- [Get Help](https://forum.ansible.com/c/help/6): get help or help others.
+  Please add appropriate tags if you start new discussions, for example use the
+  `ansible-lint` or `devtools` tags.
+- [Social Spaces](https://forum.ansible.com/c/chat/4): meet and interact with
+  fellow enthusiasts.
+- [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide
+  announcements including social events.
+
+To get release announcements and important changes from the community, see the
+[Bullhorn newsletter](https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn).
+
+For a live chat experience try the `#ansible-devtools` IRC channel on
+libera.chat or Matrix room
 [#devtools:ansible.com](https://matrix.to/#/#devtools:ansible.com).
 
-For the full list of Ansible IRC and Mailing list, please see the [Ansible
-Communication] page. Release announcements will be made to the [Ansible
-Announce] list.
+You can find more information in the
+[Ansible communication guide](https://docs.ansible.com/ansible/devel/community/communication.html).
 
 Possible security bugs should be reported via email to
 <mailto:security@ansible.com>.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,9 +53,9 @@ extra:
     - icon: simple/matrix
       link: https://matrix.to/#/#devtools:ansible.com
       name: Matrix
-    - icon: fontawesome/solid/comments
-      link: https://github.com/ansible/ansible-lint/discussions
-      name: Discussions
+    - icon: fontawesome/brands/discourse
+      link: https://forum.ansible.com/c/project/7
+      name: Ansible forum
     - icon: fontawesome/brands/github-alt
       link: https://github.com/ansible/ansible-lint
       name: GitHub


### PR DESCRIPTION
As a part of the [Consolidating Ansible discussion platforms initiative](https://forum.ansible.com/t/proposal-consolidating-ansible-discussion-platforms/6812), this PR adds the communication section template defined by the community to the README and the docsite. Similar PRs are now being raised across all the Ansible ecosystem projects.

Thanks!