### PR TITLE
Handle bare exception case from nested jinja2 vars

### DIFF
--- a/examples/playbooks/jinja-nested-vars.yml
+++ b/examples/playbooks/jinja-nested-vars.yml
@@ -1,0 +1,11 @@
+---
+- name: Test
+  gather_facts: false
+  hosts:
+    - localhost
+  tasks:
+    - name: Test
+      ansible.builtin.debug:
+        msg: "{{ cron_hour_raw }}"
+      vars:
+        cron_hour_raw: "{{ 12 | random(seed=inventory_hostname) }}"

--- a/tox.ini
+++ b/tox.ini
@@ -74,7 +74,7 @@ setenv =
   PRE_COMMIT_COLOR = always
   # Number of expected test passes, safety measure for accidental skip of
   # tests. Update value if you add/remove tests. (tox-extra)
-  PYTEST_REQPASS = 892
+  PYTEST_REQPASS = 893
   FORCE_COLOR = 1
   pre: PIP_PRE = 1
 allowlist_externals =


### PR DESCRIPTION
Fixes #4298

I sometimes found that nested `jinja2` variables cause the base exception to be thrown from an instance of `AnsibleJ2Vars` (which is used within the `Templar.do_template` method). This can happen I believe from the call to `return self._templar.template(variable)` within `AnsibleJ2Vars`. Through testing, I found that Python version `3.10` doesn't reproduce this issue, but `3.11` and `3.12` do.