### PR TITLE
Update schema for missing `tags` property to builder v3 `options`

### DIFF
--- a/src/ansiblelint/schemas/execution-environment.json
+++ b/src/ansiblelint/schemas/execution-environment.json
@@ -289,6 +289,13 @@
             "workdir": {
               "description": "Default working directory, also often the homedir for ephemeral UIDs",
               "type": ["string", "null"]
+            },
+            "tags": {
+              "description": "A list of names to assign to the resulting image if build process completes successfully",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           },
           "type": "object"

--- a/test/schemas/test/execution-environment-v3.yml
+++ b/test/schemas/test/execution-environment-v3.yml
@@ -17,3 +17,8 @@ additional_build_steps:
   append_base:
     - RUN echo This is a post-install command!
     - RUN ls -la /etc
+
+options:
+  package_manager_path: /usr/bin/dnf
+  tags:
+    - automation-hub.my.company.com/ee-supported-rhel9_foo:latest


### PR DESCRIPTION
Fixes: https://github.com/ansible/ansible-lint/issues/4343
