### PR TITLE
Fix to avoid spamming  syslog with invoked messages

### DIFF
--- a/src/ansiblelint/rules/args.py
+++ b/src/ansiblelint/rules/args.py
@@ -73,8 +73,9 @@ class ValidationPassedError(Exception):
 class CustomAnsibleModule(basic.AnsibleModule):  # type: ignore[misc]
     """Mock AnsibleModule class."""
 
-    def __init__(self, *args: str, **kwargs: str) -> None:
+    def __init__(self, *args: str, **kwargs: Any) -> None:
         """Initialize AnsibleModule mock."""
+        kwargs["no_log"] = True
         super().__init__(*args, **kwargs)
         raise ValidationPassedError
 


### PR DESCRIPTION
## Fix issue #4317

# Description
This PR resolves the issue where `ansible-basic.py` was unnecessarily logging invoked messages to the local syslog, leading to excessive and irrelevant logging during playbook execution.

## Changes
- Modified `CustomAnsibleModule` in `args.py` to modify the initialization process.
-Preventing the unnecessary execution of `AnsibleModule`.
- This stops the spamming of syslog with messages such as "ansible-basic.py Invoked with...".

## Impact
- Significantly reduces irrelevant syslog entries.
- Verified by running `ansible-lint` and checking logs with `journalctl | grep ansible`.
