### PR TITLE
Pin codecov action to v4.5.0 and update dependabot.yml to ignore v4.6.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,6 @@ updates:
     labels:
       - "dependencies"
       - "skip-changelog"
+    ignore:
+      - dependency-name: "codecov/codecov-action"
+        versions: ["4.6.0"]

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -249,7 +249,7 @@ jobs:
           fi
 
       - name: Upload coverage data
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v4.5.0
         with:
           name: ${{ matrix.name }}
           # verbose: true # optional (default = false)


### PR DESCRIPTION
### Description
Pin `codecov-action` to v4.5.0 and update `dependabot.yml` to ignore v4.6.0

This PR makes the following changes to address issues with the `codecov/codecov-action`:

- **Pin `codecov/codecov-action` to v4.5.0**:
  - To fix the error: `Codecov: Failed to get OIDC token with url: https://codecov.io./ Error message: Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable`..
  - To prevent this, the `tox.yml` file has been updated to pin the action to version `v4.5.0`.

- **Update `dependabot.yml` to ignore `v4.6.0`**:
  - Added a configuration to `.github/dependabot.yml` to ignore `codecov/codecov-action v4.6.0`.
  - This ensures that Dependabot will not automatically upgrade to this version until the issue is resolved in future releases.
 
Related: https://github.com/codecov/codecov-action/issues/1594