### PR TITLE
Fix wonky writing to sarif_file

### DIFF
--- a/src/ansiblelint/app.py
+++ b/src/ansiblelint/app.py
@@ -125,7 +125,9 @@ class App:
         if self.options.sarif_file:
             sarif = formatters.SarifFormatter(self.options.cwd, True)
             json = sarif.format_result(matches)
-            self.options.sarif_file.write_text(
+            # Somehow, this gets set as an AnsibleUnicode under unclear circumstances. Force it to be a Path
+            sarif_file = Path(self.options.sarif_file)
+            sarif_file.write_text(
                 json,
                 encoding="utf-8",
             )

--- a/src/ansiblelint/app.py
+++ b/src/ansiblelint/app.py
@@ -125,12 +125,10 @@ class App:
         if self.options.sarif_file:
             sarif = formatters.SarifFormatter(self.options.cwd, True)
             json = sarif.format_result(matches)
-            with Path.open(
-                self.options.sarif_file,
-                "w",
+            self.options.sarif_file.write_text(
+                json,
                 encoding="utf-8",
-            ) as sarif_file:
-                sarif_file.write(json)
+            )
 
     def count_results(self, matches: list[MatchError]) -> SummarizedResults:
         """Count failures and warnings in matches."""


### PR DESCRIPTION
Fixes #4349

We're misusing `Path.open()` to look like we're using pathlib when we're effectively calling `open(sarif_file)` with more steps. The problem is that somewhere, sarif_file is getting picked up as `AnsibleUnicode`, which passes through `Path.open` when provided in place of the path object, but not in Python 3.10, where `Path.open()` is less straightforward in its implementation.

This fixes the issue, but does not solve the underlying problem, which is that `Options.sarif_file` is typed as a Path, but appears to take the value of a string. Either Options needs to be fixed to return this as a Path or the type should be fixed.

The change from `open() -> write()` to `write_text()` is not strictly related but looks a lot cleaner and forces the inconsistent usage to be an error.