### PR TITLE
fixes WARN on empty/template meta/main.yaml

### DIFF
--- a/src/ansiblelint/rules/role_name.py
+++ b/src/ansiblelint/rules/role_name.py
@@ -95,7 +95,7 @@ class RoleNames(AnsibleLintRule):
         if file.kind not in ("meta", "role", "playbook"):
             return result
 
-        if file.kind == "meta":
+        if file.kind == "meta" and file.data:
             for role in file.data.get("dependencies", []):
                 if isinstance(role, dict):
                     role_name = role["role"]


### PR DESCRIPTION
WARNING  Ignored exception from RoleNames.matchyaml while processing roles/xxx/meta/main.yaml (meta): 'NoneType' object has no attribute 'get'