### PR TITLE
Avoid ruamel.yaml 0.18.7-0.18.8 due to regression

### DIFF
--- a/.config/constraints.txt
+++ b/.config/constraints.txt
@@ -63,13 +63,13 @@ mkdocs-minify-plugin==0.8.0  # via mkdocs-ansible
 mkdocs-monorepo-plugin==1.1.0  # via mkdocs-ansible
 mkdocstrings==0.27.0      # via mkdocs-ansible, mkdocstrings-python
 mkdocstrings-python==1.13.0  # via mkdocs-ansible
-mypy==1.14.0              # via ansible-lint (pyproject.toml)
+mypy==1.14.1              # via ansible-lint (pyproject.toml)
 mypy-extensions==1.0.0    # via black, mypy
 netaddr==1.3.0            # via ansible-lint (pyproject.toml)
 packaging==24.2           # via ansible-compat, ansible-core, black, mkdocs, mkdocs-macros-plugin, pyproject-api, pytest, tox, ansible-lint (pyproject.toml)
 paginate==0.5.7           # via mkdocs-material
 pathspec==0.12.1          # via black, mkdocs, mkdocs-macros-plugin, yamllint, ansible-lint (pyproject.toml)
-pillow==11.0.0            # via cairosvg, mkdocs-ansible
+pillow==11.1.0            # via cairosvg, mkdocs-ansible
 platformdirs==4.3.6       # via black, mkdocs-get-deps, mkdocstrings, pylint, tox, virtualenv
 pluggy==1.5.0             # via pytest, tox
 psutil==6.1.1             # via pytest-xdist, ansible-lint (pyproject.toml)
@@ -105,9 +105,9 @@ tomli==2.2.1              # via black, coverage, mypy, pylint, pyproject-api, py
 tomlkit==0.13.2           # via pylint
 tox==4.23.2               # via ansible-lint (pyproject.toml)
 types-jsonschema==4.23.0.20241208  # via ansible-lint (pyproject.toml)
-types-pyyaml==6.0.12.20241221  # via ansible-lint (pyproject.toml)
+types-pyyaml==6.0.12.20241230  # via ansible-lint (pyproject.toml)
 urllib3==2.3.0            # via requests
-virtualenv==20.28.0       # via tox
+virtualenv==20.28.1       # via tox
 watchdog==6.0.0           # via mkdocs
 wcmatch==10.0             # via ansible-lint (pyproject.toml)
 webencodings==0.5.1       # via cssselect2, tinycss2

--- a/.config/requirements.in
+++ b/.config/requirements.in
@@ -10,7 +10,7 @@ jsonschema>=4.10.0 # MIT, version needed for improved errors
 packaging>=21.3 # Apache-2.0,BSD-2-Clause
 pathspec>=0.10.3 # Mozilla Public License 2.0 (MPL 2.0)
 pyyaml>=5.4.1 # MIT (centos 9 has 5.3.1)
-ruamel.yaml>=0.18.5 # MIT
+ruamel.yaml>=0.18.5,!=0.18.7,!=0.18.8 # MIT
 subprocess-tee>=0.4.1 # MIT, used by ansible-compat
 yamllint >= 1.30.0 # GPLv3
 wcmatch>=8.1.2; python_version < '3.12' # MIT

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
           - prettier-plugin-toml@2.0.1
           - prettier-plugin-sort-json@3.1.0
   - repo: https://github.com/streetsidesoftware/cspell-cli
-    rev: v8.16.0
+    rev: v8.17.0
     hooks:
       - id: cspell
         # entry: codespell --relative
@@ -134,7 +134,7 @@ repos:
     hooks:
       - id: toml-sort-fix
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.1
+    rev: v0.8.5
     hooks:
       - id: ruff
         args:
@@ -148,7 +148,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.13.0
+    rev: v1.14.1
     hooks:
       - id: mypy
         # empty args needed in order to match mypy cli behavior
@@ -179,7 +179,7 @@ repos:
             plugins/.*
           )$
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.389
+    rev: v1.1.391
     hooks:
       - id: pyright
         additional_dependencies:
@@ -203,7 +203,7 @@ repos:
           - wcmatch
           - yamllint
   - repo: https://github.com/pycqa/pylint
-    rev: v3.3.2
+    rev: v3.3.3
     hooks:
       - id: pylint
         args:
@@ -227,7 +227,7 @@ repos:
           - wcmatch
           - yamllint
   - repo: https://github.com/jendrikseipp/vulture
-    rev: v2.13
+    rev: v2.14
     hooks:
       - id: vulture
   - # keep at bottom as these are slower

--- a/src/ansiblelint/errors.py
+++ b/src/ansiblelint/errors.py
@@ -120,10 +120,10 @@ class MatchError(ValueError):
         formatstr = "[{0}] ({1}) matched {2}:{3} {4}"
         # note that `rule.id` can be int, str or even missing, as users
         # can defined their own custom rules.
-        _id = getattr(self.rule, "id", "000")
+        id_ = getattr(self.rule, "id", "000")
 
         return formatstr.format(
-            _id,
+            id_,
             self.message,
             self.filename,
             self.lineno,

--- a/src/ansiblelint/rules/args.py
+++ b/src/ansiblelint/rules/args.py
@@ -137,8 +137,7 @@ class ArgsRule(AnsibleLintRule):
             module_args.update(workarounds_inject_map[loaded_module.resolved_fqcn])
         if loaded_module.resolved_fqcn in workarounds_drop_map:
             for key in workarounds_drop_map[loaded_module.resolved_fqcn]:
-                if key in module_args:
-                    del module_args[key]
+                module_args.pop(key, None)
 
         with mock.patch.object(
             mock_ansible_module,

--- a/src/ansiblelint/schemas/__store__.json
+++ b/src/ansiblelint/schemas/__store__.json
@@ -1,6 +1,6 @@
 {
   "ansible-lint-config": {
-    "etag": "8e626a1196cba4ac67956e6891090991a29aec6e8949e16a58f41773da055ca8",
+    "etag": "edfce2b56aae684bf1f0b9978dcfaaaa588dbc236f6e0ce29427277f6a327ddc",
     "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/ansible-lint-config.json"
   },
   "ansible-navigator-config": {

--- a/src/ansiblelint/schemas/main.py
+++ b/src/ansiblelint/schemas/main.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 import logging
 import re
-import typing
 from typing import TYPE_CHECKING, Any
 
 import yaml
@@ -18,6 +17,8 @@ from ansiblelint.schemas.__main__ import JSON_SCHEMAS, _schema_cache
 _logger = logging.getLogger(__package__)
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from ansiblelint.file_utils import Lintable
 
 
@@ -28,7 +29,7 @@ def find_best_deep_match(
 
     def iter_validation_error(
         err: ValidationError,
-    ) -> typing.Iterator[ValidationError]:
+    ) -> Iterator[ValidationError]:
         if err.context:
             for e in err.context:
                 yield e

--- a/src/ansiblelint/testing/__init__.py
+++ b/src/ansiblelint/testing/__init__.py
@@ -113,10 +113,10 @@ def run_ansible_lint(
         "VIRTUAL_ENV",
     ]
 
-    _env = {} if env is None else env
+    env_ = {} if env is None else env
     for v in safe_list:
-        if v in os.environ and v not in _env:
-            _env[v] = os.environ[v]
+        if v in os.environ and v not in env_:
+            env_[v] = os.environ[v]
 
     return subprocess.run(
         args,
@@ -124,7 +124,7 @@ def run_ansible_lint(
         shell=False,  # needed when command is a list
         check=False,
         cwd=cwd,
-        env=_env,
+        env=env_,
         text=True,
         encoding="utf-8",
     )

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -735,12 +735,12 @@ def task_to_str(task: dict[str, Any]) -> str:
         ]
     ]
 
-    _raw_params = action.get("_raw_params", [])
-    if isinstance(_raw_params, list):
-        for item in _raw_params:
+    raw_params = action.get("_raw_params", [])
+    if isinstance(raw_params, list):
+        for item in raw_params:
             args.extend(str(item))
     else:
-        args.append(_raw_params)
+        args.append(raw_params)
 
     return f"{action['__ansible_module__']} {' '.join(args)}"
 
@@ -934,18 +934,18 @@ def task_in_list(  # type: ignore[no-any-unimported]
         for entry_index, entry in enumerate(data):
             if not entry:
                 continue
-            _pos = f"{position}[{entry_index}]"
+            pos_ = f"{position}[{entry_index}]"
             if isinstance(entry, dict):
                 yield Task(
                     entry,
-                    position=_pos,
+                    position=pos_,
                 )
             for block in [k for k in entry if k in NESTED_TASK_KEYS]:
                 yield from task_in_list(
                     data=entry[block],
                     file=file,
                     kind="tasks",
-                    position=f"{_pos}.{block}",
+                    position=f"{pos_}.{block}",
                 )
 
     if not isinstance(data, list):

--- a/test/schemas/package-lock.json
+++ b/test/schemas/package-lock.json
@@ -16,7 +16,7 @@
         "@types/js-yaml": "^4.0.9",
         "@types/minimatch": "^5.1.2",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^22.10.1",
+        "@types/node": "^22.10.5",
         "chai": "^5.1.2",
         "minimatch": "^10.0.1",
         "mocha": "^11.0.1",
@@ -227,9 +227,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.10.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.1.tgz",
-      "integrity": "sha512-qKgsUwfHZV2WCWLAnVP1JqnpE6Im6h3Y0+fYgMTasNQ7V++CBX5OT1as0g0f+OyubbFqhf6XVNIsmN4IIhEgGQ==",
+      "version": "22.10.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
+      "integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.20.0"
@@ -1744,9 +1744,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "22.10.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.1.tgz",
-      "integrity": "sha512-qKgsUwfHZV2WCWLAnVP1JqnpE6Im6h3Y0+fYgMTasNQ7V++CBX5OT1as0g0f+OyubbFqhf6XVNIsmN4IIhEgGQ==",
+      "version": "22.10.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
+      "integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
       "requires": {
         "undici-types": "~6.20.0"
       }

--- a/test/schemas/package.json
+++ b/test/schemas/package.json
@@ -16,7 +16,7 @@
     "@types/js-yaml": "^4.0.9",
     "@types/minimatch": "^5.1.2",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^22.10.1",
+    "@types/node": "^22.10.5",
     "chai": "^5.1.2",
     "minimatch": "^10.0.1",
     "mocha": "^11.0.1",

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -234,7 +234,7 @@ def test_path_from_config_do_not_depend_on_cwd(
 )
 def test_config_failure(base_arguments: list[str], config_file: str) -> None:
     """Ensures specific config files produce error code 3."""
-    with pytest.raises(SystemExit, match="^3$"):
+    with pytest.raises(SystemExit, match=r"^3$"):
         cli.get_config([*base_arguments, "-c", config_file])
 
 

--- a/test/test_transformer.py
+++ b/test/test_transformer.py
@@ -508,7 +508,7 @@ def test_transform_na(
     result = test_result[0]
     options = test_result[1]
 
-    _isinstance = builtins.isinstance
+    isinstance_ = builtins.isinstance
     called = False
 
     def mp_isinstance(t_object: Any, classinfo: type) -> bool:
@@ -516,7 +516,7 @@ def test_transform_na(
             nonlocal called
             called = True
             return False
-        return _isinstance(t_object, classinfo)
+        return isinstance_(t_object, classinfo)
 
     monkeypatch.setattr(builtins, "isinstance", mp_isinstance)
 


### PR DESCRIPTION
Update dependencies and avoid use of newer ruamel.yaml versions due to formatting regression from https://sourceforge.net/p/ruamel-yaml/tickets/534/
