### PR TITLE
Add EL 10 as a platform in the metadata schema

### DIFF
--- a/src/ansiblelint/schemas/meta.json
+++ b/src/ansiblelint/schemas/meta.json
@@ -332,7 +332,7 @@
         "versions": {
           "default": "all",
           "items": {
-            "enum": ["5", "6", "7", "8", "9", "all"],
+            "enum": ["5", "6", "7", "8", "9", "10", "all"],
             "type": "string"
           },
           "type": "array"


### PR DESCRIPTION
CentOS Stream 10 was released on 2024-12-12: https://blog.centos.org/2024/12/introducing-centos-stream-10/
RHEL 10 Beta was released on 2024-12-11: https://www.redhat.com/en/blog/red-hat-enterprise-linux-10-beta-now-available