### PR TITLE
Require ansible-core>=2.16

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -126,4 +126,4 @@ task_name_prefix: "{stem} | "
 
 # Also recognize these versions of Ansible as supported:
 # supported_ansible_also:
-#   - "2.14"
+#   - "2.18"

--- a/.config/requirements.in
+++ b/.config/requirements.in
@@ -1,6 +1,6 @@
 # Special order section for helping pip:
 will-not-work-on-windows-try-from-wsl-instead; platform_system=='Windows'
-ansible-core>=2.13.0 # GPLv3
+ansible-core>=2.16.0 # GPLv3
 ansible-compat>=24.10.0 # GPLv3
 # alphabetically sorted:
 black>=24.3.0 # MIT (security)

--- a/.github/lower-constraints.txt
+++ b/.github/lower-constraints.txt
@@ -1,8 +1,8 @@
 # This file is kept in a different directory than .config in order to not be
 # automatically updated by dependabot. This should be kept in sync with
 # minimal requirements configured inside .config/requirements.in
-ansible-core==2.13.0
-ansible-compat==24.5.1 # GPLv3
+ansible-core==2.16.0
+ansible-compat==24.10.0 # GPLv3
 black==24.3.0 # MIT (security)
 filelock==3.3.0 # The Unlicense
 jsonschema==4.10.0 # MIT, version needed for improved errors

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -179,7 +179,7 @@ repos:
             plugins/.*
           )$
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.391
+    rev: v1.1.392
     hooks:
       - id: pyright
         additional_dependencies:
@@ -210,7 +210,7 @@ repos:
           - --output-format=colorized
         additional_dependencies:
           - ansible-compat>=24.8.0
-          - ansible-core>=2.14.0
+          - ansible-core>=2.16.0
           - black>=24.10.0
           - docutils
           - filelock>=3.12.2


### PR DESCRIPTION
Due to a testing bug that is fixed by #4478 we did not test with minimal requirements for
a while and ansible-core 2.16 was the oldest version that passed our testing. This fixes
the minimal requirements.