### PR TITLE
Remove dependency hack that prevents installation on Windows

### DIFF
--- a/.config/requirements.in
+++ b/.config/requirements.in
@@ -1,5 +1,4 @@
 # Special order section for helping pip:
-will-not-work-on-windows-try-from-wsl-instead; platform_system=='Windows'
 ansible-core>=2.16.0 # GPLv3
 ansible-compat>=24.10.0 # GPLv3
 # alphabetically sorted:


### PR DESCRIPTION
We are removing this because it proved to cause compatibility issues with tools such uv, pdm and poetry.

Fixes: #4466
Fixes: #2998