### PR TITLE
Improve path injection logic to resolve symlinked directories

### DIFF
--- a/src/ansiblelint/__main__.py
+++ b/src/ansiblelint/__main__.py
@@ -446,16 +446,16 @@ def path_inject(own_location: str = "") -> None:
         str(userbase_bin_path) not in paths
         and (userbase_bin_path / "bin" / "ansible").exists()
     ):
-        inject_paths.append(str(userbase_bin_path))
+        inject_paths.append(userbase_bin_path.resolve().as_posix())
 
-    py_path = Path(sys.executable).parent
+    py_path = Path(sys.executable).parent.resolve()
     pipx_path = os.environ.get("PIPX_HOME", "pipx")
     if (
         str(py_path) not in paths
         and (py_path / "ansible").exists()
         and pipx_path not in str(py_path)
     ):
-        inject_paths.append(str(py_path))
+        inject_paths.append(py_path.as_posix())
 
     # last option, if nothing else is found, just look next to ourselves...
     if own_location:

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -59,7 +59,6 @@ def test_call_from_outside_venv(in_path: bool) -> None:
     assert warning_found is in_path
 
 
-
 @pytest.mark.parametrize(
     ("ver_diff", "found", "check", "outlen"),
     (


### PR DESCRIPTION
This bug caused some testing failures in a very limited use scenarios.
Related: https://github.com/ansible/ansible-compat/pull/447
