### PR TITLE
Add git clean to allowed executable options

### DIFF
--- a/examples/playbooks/rule-command-instead-of-module-pass.yml
+++ b/examples/playbooks/rule-command-instead-of-module-pass.yml
@@ -14,6 +14,10 @@
       ansible.builtin.command: git lfs install
       changed_when: false
 
+    - name: Clean git repo (dry run)
+      ansible.builtin.command: git clean -n -d
+      changed_when: false
+
     - name: Show systemctl service status
       ansible.builtin.command: systemctl status systemd-timesyncd
       changed_when: false

--- a/src/ansiblelint/rules/command_instead_of_module.py
+++ b/src/ansiblelint/rules/command_instead_of_module.py
@@ -69,7 +69,7 @@ class CommandsInsteadOfModulesRule(AnsibleLintRule):
     }
 
     _executable_options = {
-        "git": ["branch", "log", "lfs", "rev-parse"],
+        "git": ["branch", "log", "lfs", "rev-parse", "clean"],
         "systemctl": [
             "--version",
             "get-default",


### PR DESCRIPTION
A `git clean` command task causes `command-instead-of-module: git used in place of git module`, but this feature has been rejected from `git` module in favor of a command task in https://github.com/ansible/ansible/pull/39776#issuecomment-1137765667.