### PR TITLE
Fix failing `ansible-lint` CI job

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -5,7 +5,7 @@ actions:
   create-archive:
     # packit.dev service does have these module pre-installed:
     - python3 -m build --sdist --outdir dist
-    - sh -c "ls dist/ansible-lint-*.tar.gz"
+    - sh -c "ls dist/ansible_lint-*.tar.gz"
   get-current-version:
     - ./tools/get-version.sh
   post-upstream-clone:


### PR DESCRIPTION
The "Packit-as-a-Service" CI jobs have been failing since commit 34eb179[^1] from 2024-04-04. From the log[^2] of a recent failed build[^3], I saw the following output:

```log
2025-01-23 17:15:27.261 commands.py       DEBUG  Command: python3 -m build --sdist --outdir dist
...
2025-01-23 17:15:30.617 logging.py        INFO   Successfully built ansible_lint-25.1.1.dev1.tar.gz
2025-01-23 17:15:30.634 commands.py       DEBUG  Command: sh -c ls dist/ansible-lint-*.tar.gz
2025-01-23 17:15:30.636 logging.py        INFO   ls: cannot access 'dist/ansible-lint-*.tar.gz': No such file or directory
2025-01-23 17:15:30.636 commands.py       ERROR  Command 'sh -c ls dist/ansible-lint-*.tar.gz' failed.
```

The problem is therefore that line 8 of `.packit.yaml`[^4] expects a file of the form `ansible-lint-*` when the file is _actually_ named `ansible_lint-*`. Changing the line should fix the build, or at the very least, this single error.

[^1]: https://github.com/ansible/ansible-lint/commit/34eb1794a1e2e69b51bde4d953e463f756fe70f5
[^2]: https://download.copr.fedorainfracloud.org/results/packit/ansible-ansible-lint-main/srpm-builds/08563847/builder-live.log.gz
[^3]: https://copr.fedorainfracloud.org/coprs/packit/ansible-ansible-lint-main/build/8563847/
[^4]: https://github.com/ansible/ansible-lint/blob/395b674bbc78bc4d9da641c38a7e959b4993d9a4/.packit.yaml#L8

---

I'm unfortunately not sure how to test this change without making a PR and running CI. I hope it works!