### PR TITLE
Isolate ansible internal types to submodule

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -298,6 +298,7 @@ pyright
 pytest
 pyupgrade
 pyyaml
+redef
 redirections
 reexec
 reformatter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ fail_under = 92
 # During development we might remove code (files) with coverage data, and we dont want to fail:
 ignore_errors = true
 omit = ["test/*"]
+partial_branches = ["pragma: no cover", "if TYPE_CHECKING:"]
 show_missing = true
 skip_covered = true
 skip_empty = true

--- a/src/ansiblelint/runner.py
+++ b/src/ansiblelint/runner.py
@@ -21,7 +21,6 @@ from typing import TYPE_CHECKING, Any
 
 from ansible.errors import AnsibleError
 from ansible.parsing.splitter import split_args
-from ansible.parsing.yaml.constructor import AnsibleMapping
 from ansible.plugins.loader import add_all_plugin_dirs
 from ansible_compat.runtime import AnsibleWarning
 
@@ -38,6 +37,7 @@ from ansiblelint.file_utils import (
 from ansiblelint.logger import timed_info
 from ansiblelint.rules.syntax_check import OUTPUT_PATTERNS
 from ansiblelint.text import strip_ansi_escape
+from ansiblelint.types import AnsibleMapping
 from ansiblelint.utils import (
     PLAYBOOK_DIR,
     HandleChildren,

--- a/src/ansiblelint/skip_utils.py
+++ b/src/ansiblelint/skip_utils.py
@@ -49,9 +49,8 @@ from ansiblelint.errors import LintWarning, WarnSource
 if TYPE_CHECKING:
     from collections.abc import Generator
 
-    from ansible.parsing.yaml.objects import AnsibleBaseYAMLObject
-
     from ansiblelint.file_utils import Lintable
+    from ansiblelint.types import AnsibleBaseYAMLObject
 
 
 _logger = logging.getLogger(__name__)

--- a/src/ansiblelint/types.py
+++ b/src/ansiblelint/types.py
@@ -1,0 +1,37 @@
+"""Types helper."""
+
+from __future__ import annotations
+
+from typing import TypeAlias
+
+from ansible.parsing.yaml.objects import (  # pyright: ignore[reportMissingImports]
+    AnsibleMapping,
+    AnsibleSequence,
+    AnsibleUnicode,
+    AnsibleVaultEncryptedUnicode,
+)
+
+try:
+    from ansible.parsing.yaml.constructor import (  # pyright: ignore[reportMissingImports]
+        AnsibleConstructor,
+    )
+except ImportError:  # ansible-core 2.19+
+    from ansible._internal._yaml._constructor import (  # pyright: ignore[reportMissingImports]
+        AnsibleConstructor,
+    )
+try:
+    from ansible.parsing.yaml.objects import (  # pyright: ignore[reportMissingImports]
+        AnsibleBaseYAMLObject,  # pyright: ignore[reportRedeclaration]
+    )
+except ImportError:  # ansible-core 2.19+
+    AnsibleBaseYAMLObject: TypeAlias = AnsibleSequence | AnsibleUnicode | str | None  # type: ignore[no-redef] # pyright: ignore[reportRedeclaration]
+
+
+__all__ = [
+    "AnsibleBaseYAMLObject",
+    "AnsibleConstructor",
+    "AnsibleMapping",
+    "AnsibleSequence",
+    "AnsibleUnicode",
+    "AnsibleVaultEncryptedUnicode",
+]

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -46,9 +46,7 @@ from ansible.parsing.mod_args import ModuleArgsParser
 from ansible.parsing.plugin_docs import read_docstring
 from ansible.parsing.splitter import split_args
 from ansible.parsing.vault import PromptVaultSecret
-from ansible.parsing.yaml.constructor import AnsibleConstructor, AnsibleMapping
 from ansible.parsing.yaml.loader import AnsibleLoader
-from ansible.parsing.yaml.objects import AnsibleBaseYAMLObject, AnsibleSequence
 from ansible.plugins.loader import (
     PluginLoadContext,
     action_loader,
@@ -82,6 +80,12 @@ from ansiblelint.errors import MatchError
 from ansiblelint.file_utils import Lintable, discover_lintables
 from ansiblelint.skip_utils import is_nested_task
 from ansiblelint.text import has_jinja, is_fqcn, removeprefix
+from ansiblelint.types import (
+    AnsibleBaseYAMLObject,
+    AnsibleConstructor,
+    AnsibleMapping,
+    AnsibleSequence,
+)
 
 if TYPE_CHECKING:
     from ansiblelint.rules import RulesCollection

--- a/test/test_skiputils.py
+++ b/test/test_skiputils.py
@@ -17,10 +17,9 @@ from ansiblelint.skip_utils import (
 )
 
 if TYPE_CHECKING:
-    from ansible.parsing.yaml.objects import AnsibleBaseYAMLObject
-
     from ansiblelint.rules import RulesCollection
     from ansiblelint.testing import RunFromText
+    from ansiblelint.types import AnsibleBaseYAMLObject
 
 PLAYBOOK_WITH_NOQA = """\
 ---

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -28,7 +28,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import pytest
-from ansible.parsing.yaml.constructor import AnsibleMapping, AnsibleSequence
 from ansible.utils.sentinel import Sentinel
 from ansible_compat.runtime import Runtime
 
@@ -39,6 +38,7 @@ from ansiblelint.constants import RC
 from ansiblelint.file_utils import Lintable, cwd
 from ansiblelint.runner import Runner
 from ansiblelint.testing import run_ansible_lint
+from ansiblelint.types import AnsibleMapping, AnsibleSequence
 
 if TYPE_CHECKING:
     from collections.abc import Sequence


### PR DESCRIPTION
Preparatory change for upcoming ansible-core 2.19

Related: https://issues.redhat.com/browse/AAP-41586
