### PR TITLE
Improve pytest output via pytest-sugar

### DIFF
--- a/.config/constraints.txt
+++ b/.config/constraints.txt
@@ -66,11 +66,11 @@ mkdocs-material-extensions==1.3.1  # via mkdocs-ansible, mkdocs-material
 mkdocs-minify-plugin==0.8.0  # via mkdocs-ansible
 mkdocs-monorepo-plugin==1.1.0  # via mkdocs-ansible
 mkdocstrings==0.29.0      # via mkdocs-ansible, mkdocstrings-python
-mkdocstrings-python==1.16.7  # via mkdocs-ansible
+mkdocstrings-python==1.16.8  # via mkdocs-ansible
 mypy==1.15.0              # via ansible-lint (pyproject.toml)
 mypy-extensions==1.0.0    # via black, mypy
 netaddr==1.3.0            # via ansible-lint (pyproject.toml)
-packaging==24.2           # via ansible-compat, ansible-core, bindep, black, mkdocs, mkdocs-macros-plugin, pyproject-api, pytest, tox, tox-extra, tox-uv, ansible-lint (pyproject.toml)
+packaging==24.2           # via ansible-compat, ansible-core, bindep, black, mkdocs, mkdocs-macros-plugin, pyproject-api, pytest, pytest-sugar, tox, tox-extra, tox-uv, ansible-lint (pyproject.toml)
 paginate==0.5.7           # via mkdocs-material
 parsley==1.3              # via bindep
 pathspec==0.12.1          # via black, mkdocs, mkdocs-macros-plugin, yamllint, ansible-lint (pyproject.toml)
@@ -84,10 +84,11 @@ pygments==2.19.1          # via mkdocs-material
 pylint==3.3.6             # via ansible-lint (pyproject.toml)
 pymdown-extensions==10.14.3  # via markdown-exec, mkdocs-ansible, mkdocs-material, mkdocstrings
 pyproject-api==1.9.0      # via tox
-pytest==8.3.5             # via pytest-instafail, pytest-mock, pytest-plus, pytest-xdist, ansible-lint (pyproject.toml)
+pytest==8.3.5             # via pytest-instafail, pytest-mock, pytest-plus, pytest-sugar, pytest-xdist, ansible-lint (pyproject.toml)
 pytest-instafail==0.5.0   # via ansible-lint (pyproject.toml)
 pytest-mock==3.14.0       # via ansible-lint (pyproject.toml)
 pytest-plus==0.8.1        # via ansible-lint (pyproject.toml)
+pytest-sugar==1.0.0       # via ansible-lint (pyproject.toml)
 pytest-xdist==3.6.1       # via ansible-lint (pyproject.toml)
 python-dateutil==2.9.0.post0  # via ghp-import, mkdocs-macros-plugin
 python-slugify==8.0.4     # via mkdocs-monorepo-plugin
@@ -98,13 +99,13 @@ requests==2.32.3          # via linkchecker, mkdocs-htmlproofer-plugin, mkdocs-m
 rpds-py==0.23.1           # via jsonschema, referencing
 ruamel-yaml==0.18.10      # via ansible-lint (pyproject.toml)
 setproctitle==1.3.5       # via pytest-xdist
-setuptools==77.0.3        # via pbr
+setuptools==78.0.1        # via pbr
 six==1.17.0               # via python-dateutil
 smmap==5.0.2              # via gitdb
 soupsieve==2.6            # via beautifulsoup4
 subprocess-tee==0.4.2     # via ansible-compat, ansible-lint (pyproject.toml)
 super-collections==0.5.3  # via mkdocs-macros-plugin
-termcolor==2.5.0          # via mkdocs-macros-plugin
+termcolor==2.5.0          # via mkdocs-macros-plugin, pytest-sugar
 text-unidecode==1.3       # via python-slugify
 tinycss2==1.4.0           # via cairosvg, cssselect2
 tomlkit==0.13.2           # via pylint
@@ -118,7 +119,7 @@ virtualenv==20.29.3       # via tox
 watchdog==6.0.0           # via mkdocs
 wcmatch==10.0             # via ansible-lint (pyproject.toml)
 webencodings==0.5.1       # via cssselect2, tinycss2
-yamllint==1.36.2          # via ansible-lint (pyproject.toml)
+yamllint==1.37.0          # via ansible-lint (pyproject.toml)
 zipp==3.21.0              # via importlib-metadata
 
 # The following packages were excluded from the output:

--- a/.config/requirements-test.in
+++ b/.config/requirements-test.in
@@ -13,6 +13,7 @@ pytest-instafail >= 0.5.0 # only for local development, via PYTEST_ADDOPTS=-edit
 pytest-mock
 pytest-plus >= 0.6 # for PYTEST_REQPASS
 pytest-xdist[psutil,setproctitle] >= 2.1.0
+pytest-sugar  # shows failures immediately, even with xdist
 ruamel-yaml-clib  # needed for mypy
 ruamel.yaml>=0.17.31
 tox >= 4.0.0


### PR DESCRIPTION
Adds pytest-sugar which will display failures as soon they are found
even when pytest-xdist is used, making development easier.

Related: AAP-41586
