### PR TITLE
Add noqa skips in otherwise empty lines to the next non-empty line

### DIFF
--- a/examples/playbooks/vars/noqa_multiline.yml
+++ b/examples/playbooks/vars/noqa_multiline.yml
@@ -1,0 +1,28 @@
+---
+# noqa: jinja[spacing]
+foo_postgresql_grafana_password_encoded: >-
+  {% if '!' in foo_postgresql_grafana_password or '#' in foo_postgresql_grafana_password %}
+  {{- ('\"\"\"' + foo_postgresql_grafana_password + '\"\"\"') | b64encode -}}
+  {% else %}
+  {{- foo_postgresql_grafana_password | b64encode -}}
+  {% endif %}
+
+
+# noqa: jinja[spacing]
+
+foo_postgresql_grafana_password_encoded_2: >-
+  {% if '!' in foo_postgresql_grafana_password or '#' in foo_postgresql_grafana_password %}
+  {{- ('\"\"\"' + foo_postgresql_grafana_password + '\"\"\"') | b64encode -}}
+  {% else %}
+  {{- foo_postgresql_grafana_password | b64encode -}}
+  {% endif %}
+
+
+inner:
+    # noqa: jinja[spacing]
+    foo_postgresql_grafana_password_encoded: >-
+        {% if '!' in foo_postgresql_grafana_password or '#' in foo_postgresql_grafana_password %}
+        {{- ('\"\"\"' + foo_postgresql_grafana_password + '\"\"\"') | b64encode -}}
+        {% else %}
+        {{- foo_postgresql_grafana_password | b64encode -}}
+        {% endif %}

--- a/src/ansiblelint/skip_utils.py
+++ b/src/ansiblelint/skip_utils.py
@@ -270,7 +270,7 @@ def _continue_skip_next_lines(
         if _noqa_comment_line_re.fullmatch(line_content[line_no - 1]):
             # Find next non-empty line
             next_line_no = line_no
-            while line_content[next_line_no].strip() == "" and next_line_no >= len(line_content):
+            while next_line_no < len(line_content) and line_content[next_line_no].strip() == "":
                 next_line_no += 1
             if next_line_no >= len(line_content):
                 continue

--- a/src/ansiblelint/skip_utils.py
+++ b/src/ansiblelint/skip_utils.py
@@ -56,6 +56,7 @@ if TYPE_CHECKING:
 _logger = logging.getLogger(__name__)
 _found_deprecated_tags: set[str] = set()
 _noqa_comment_re = re.compile(r"^# noqa(\s|:)")
+_noqa_comment_line_re = re.compile(r"^\s*# noqa(\s|:).*$")
 
 # playbook: Sequence currently expects only instances of one of the two
 # classes below but we should consider avoiding this chimera.
@@ -257,6 +258,27 @@ def _get_tasks_from_blocks(task_blocks: Sequence[Any]) -> Generator[Any, None, N
         yield task
 
 
+def _continue_skip_next_lines(
+    lintable: Lintable,
+) -> None:
+    """
+    When a line only contains a noqa comment (and possibly indentation), add the skip also to the next non-empty line
+    """
+    # If line starts with _noqa_comment_line_re, add next non-empty line to same lintable.line_skips
+    line_content = lintable.content.splitlines()
+    for line_no in list(lintable.line_skips.keys()):
+        if _noqa_comment_line_re.fullmatch(line_content[line_no - 1]):
+            # Find next non-empty line
+            next_line_no = line_no
+            while line_content[next_line_no].strip() == "" and next_line_no >= len(line_content):
+                next_line_no += 1
+            if next_line_no >= len(line_content):
+                continue
+            lintable.line_skips[next_line_no + 1].update(
+                lintable.line_skips[line_no],
+            )
+
+
 def _get_rule_skips_from_yaml(
     yaml_input: Sequence[Any],
     lintable: Lintable,
@@ -269,6 +291,9 @@ def _get_rule_skips_from_yaml(
 
     def traverse_yaml(obj: Any) -> None:
         for entry in obj.ca.items.values():
+            # flatten all lists we might have in entries. Some arcane ruamel CommentedMap magic
+            entry = [item for sublist in entry if sublist is not None
+                     for item in (sublist if isinstance(sublist, list) else [sublist])]
             for v in entry:
                 if isinstance(v, CommentToken):
                     comment_str = v.value
@@ -298,6 +323,7 @@ def _get_rule_skips_from_yaml(
     for comment_obj_str in yaml_comment_obj_strings:
         for line in comment_obj_str.split(r"\n"):
             rule_id_list.extend(get_rule_skips_from_line(line, lintable=lintable))
+    _continue_skip_next_lines(lintable)
 
     return [normalize_tag(tag) for tag in rule_id_list]
 

--- a/src/ansiblelint/skip_utils.py
+++ b/src/ansiblelint/skip_utils.py
@@ -55,7 +55,7 @@ if TYPE_CHECKING:
 
 _logger = logging.getLogger(__name__)
 _found_deprecated_tags: set[str] = set()
-_noqa_comment_re = re.compile(r"^# noqa(\s|:)")
+_noqa_comment_re = re.compile(r"^\s*# noqa(\s|:)", flags=re.MULTILINE)
 _noqa_comment_line_re = re.compile(r"^\s*# noqa(\s|:).*$")
 
 # playbook: Sequence currently expects only instances of one of the two
@@ -290,7 +290,10 @@ def _get_rule_skips_from_yaml(
         return []
 
     def traverse_yaml(obj: Any) -> None:
-        for entry in obj.ca.items.values():
+        traversable = list(obj.ca.items.values())
+        if obj.ca.comment:
+            traversable.append(obj.ca.comment)
+        for entry in traversable:
             # flatten all lists we might have in entries. Some arcane ruamel CommentedMap magic
             entry = [item for sublist in entry if sublist is not None
                      for item in (sublist if isinstance(sublist, list) else [sublist])]

--- a/test/test_skiputils.py
+++ b/test/test_skiputils.py
@@ -64,6 +64,13 @@ def test_playbook_noqa2(default_text_runner: RunFromText) -> None:
     assert len(results) == 1
 
 
+def test_var_noqa(default_text_runner: RunFromText) -> None:
+    """Check that noqa is properly taken into account on vars and tasks."""
+    results = default_text_runner.run("examples/playbooks/vars/noqa_multiline.yml")
+    # Should raise no error at "SOME_VAR".
+    assert len(results) == 0
+
+
 @pytest.mark.parametrize(
     ("lintable", "yaml", "expected_form"),
     (


### PR DESCRIPTION
This addresses #3935

So what it does:
 - Some magic in `traverse_yaml` to flatten lists within there (these are required for a ruamel CommentMap, please don't ask any further, afaik these are entirely undocumented)
 - After collecting all `#noqa` and inserting them into the `lintable`, postprocessing is done on the `lintable`.
   - For each line where a skip is found, it is matched against a regex whether `# noqa` is the start of the line, minus some whitespace/indentation.
   - If there is only the `# noqa` on that line, the skip is added to the next non-empty line.

This is something required for me in order to suppress errors on yaml multiline strings, as reported by the issue referenced.


In general I think the solution is quite hacky, so this can also be seen as a proof of concept. The whole flattening thing and how ruamel works with comments is quite weird. As in the context of `_get_rule_skips_from_yaml` only a map of `{lineno: rule_to_skip}` is what we're interested in, it might be easier to just go over the content of a file, check each line for `_noqa_comment_re` match. The whole tree structure of `CommentMap` is annoying to traverse, a simple iterator over all comments would do it (don't know if that's in `pyyaml`?) and would be more accurate for comments not attached to objects in a line.