### PR TITLE
chore(schema): add missing ubuntu codenames

### DIFF
--- a/src/ansiblelint/schemas/meta.json
+++ b/src/ansiblelint/schemas/meta.json
@@ -1129,6 +1129,8 @@
               "maverick",
               "natty",
               "oneiric",
+              "oracular",
+              "plucky",
               "precise",
               "quantal",
               "raring",


### PR DESCRIPTION
This adds the two most recent ubuntu version codenames to the schema.