### PR TITLE
chore: Updated some of the docs and messages around setting pipefail.

### DIFF
--- a/src/ansiblelint/rules/risky_shell_pipe.md
+++ b/src/ansiblelint/rules/risky_shell_pipe.md
@@ -7,6 +7,9 @@ The return status of a pipeline is the exit status of the command. The
 `pipefail` option ensures that tasks fail as expected if the first command
 fails.
 
+This does not work in the standard (POSIX) shell. You will need to set the executable
+to a different shell, such as bash. See the example below.
+
 As this requirement does not apply to PowerShell, for shell commands that have
 `pwsh` inside `executable` attribute, this rule will not trigger.
 

--- a/src/ansiblelint/rules/risky_shell_pipe.py
+++ b/src/ansiblelint/rules/risky_shell_pipe.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 
 class ShellWithoutPipefail(AnsibleLintRule):
-    """Shells that use pipes should set the pipefail option."""
+    """Shells that use pipes should set the pipefail option. (This requires changing the shell, see the docs.)"""
 
     id = "risky-shell-pipe"
     description = (
@@ -24,7 +24,8 @@ class ShellWithoutPipefail(AnsibleLintRule):
         "any part of the pipeline other than the terminal command "
         "fails, the whole pipeline will still return 0, which may "
         "be considered a success by Ansible. "
-        "Pipefail is available in the bash shell."
+        "Pipefail is not available in the default (POSIX) shell, "
+        "consider bash."
     )
     severity = "MEDIUM"
     tags = ["command-shell"]


### PR DESCRIPTION
Setting pipefail necessitates other changes away from the default functioning of ansible, this is made more explicit to the user.