### PR TITLE
Enable junit.xml reporting to codecov.io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ pip-log.txt
 
 # Unit test / coverage reports
 .tox
+junit.xml
 
 # Needed for CLI tests
 .sandbox

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -411,11 +411,7 @@ filterwarnings = [
   # https://github.com/ansible/ansible/pull/80968
   "ignore:Attribute s is deprecated and will be removed in Python 3.14; use value instead:DeprecationWarning"
 ]
-junit_duration_report = "call"
-junit_family = "xunit1"
-# Our github annotation parser from .github/workflows/tox.yml requires xunit1 format. Ref:
-# https://github.com/shyim/junit-report-annotations-action/issues/3#issuecomment-663241378
-junit_suite_name = "ansible_lint_test_suite"
+junit_family = "legacy"
 minversion = "4.6.6"
 # https://code.visualstudio.com/docs/python/testing
 # coverage is re-enabled in `tox.ini`. That approach is safer than

--- a/tools/report-coverage
+++ b/tools/report-coverage
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euo pipefail
+coverage combine -q "--data-file=${TOX_ENV_DIR}/.coverage" "${TOX_ENV_DIR}"/.coverage.*
+coverage xml "--data-file=${TOX_ENV_DIR}/.coverage" -o "${TOX_ENV_DIR}/coverage.xml" --ignore-errors --fail-under=0
+COVERAGE_FILE="${TOX_ENV_DIR}/.coverage" coverage report --fail-under=0 --ignore-errors

--- a/tox.ini
+++ b/tox.ini
@@ -77,9 +77,12 @@ commands =
       --showlocals \
       --doctest-modules \
       --durations=10 \
+      --junitxml=./junit.xml \
       }
-    {py,py310,py311,py312,py313}: sh -c "coverage combine -a -q --data-file={env_dir}/.coverage {work_dir}/*/.coverage.* && coverage xml --data-file={env_dir}/.coverage -o {env_dir}/coverage.xml --fail-under=0 && coverage report --data-file={env_dir}/.coverage"
+commands_post =
+    {py,py310,py311,py312,py313}: ./tools/report-coverage
 allowlist_externals =
+    ./tools/report-coverage
     ./tools/test-hook.sh
     bash
     find


### PR DESCRIPTION
There is some existing junit config that I don't think we're using anymore?