### PR TITLE
Add vSphere/vCenter 8.0 to schema

### DIFF
--- a/src/ansiblelint/schemas/meta.json
+++ b/src/ansiblelint/schemas/meta.json
@@ -1508,7 +1508,7 @@
         "versions": {
           "default": "all",
           "items": {
-            "enum": ["5.5", "6.0", "6.5", "6.7", "7.0", "all"],
+            "enum": ["5.5", "6.0", "6.5", "6.7", "7.0", "8.0", "all"],
             "type": "string"
           },
           "type": "array"
@@ -1527,7 +1527,7 @@
         "versions": {
           "default": "all",
           "items": {
-            "enum": ["5.5", "6.0", "6.5", "6.7", "7.0", "all"],
+            "enum": ["5.5", "6.0", "6.5", "6.7", "7.0", "8.0", "all"],
             "type": "string"
           },
           "type": "array"


### PR DESCRIPTION
This adds vSphere/vCenter 8.0 to the platform schema. They're currently missing.