### PR TITLE
Remove patch report from codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,7 +2,5 @@
 comment: false
 coverage:
   status:
-    patch: true
-    project:
-      default:
-        threshold: 0.5%
+    patch: false
+    project: true


### PR DESCRIPTION
This should remove the false positives from coverage
as we would not allow the total coverage to go down.
