### PR TITLE
Address disable_lookups deprecation with ansible-core 2.19

### DIFF
--- a/.github/workflows/ack.yml
+++ b/.github/workflows/ack.yml
@@ -1,5 +1,5 @@
 ---
-# See https://github.com/ansible/devtools/blob/main/.github/workflows/ack.yml
+# See https://github.com/ansible/team-devtools/blob/main/.github/workflows/ack.yml
 name: ack
 on:
   merge_group:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,5 +1,5 @@
 ---
-# See https://github.com/ansible/devtools/blob/main/.github/workflows/push.yml
+# See https://github.com/ansible/team-devtools/blob/main/.github/workflows/push.yml
 name: push
 "on":
   push:

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -201,7 +201,6 @@ def ansible_template(
     re_valid_filter = re.compile(r"^\w+(\.\w+\.\w+)?$")
     templar = ansible_templar(basedir=basedir, templatevars=templatevars)
 
-    kwargs["disable_lookups"] = True
     for _i in range(10):
         try:
             if TrustedAsTemplate and not isinstance(varname, TrustedAsTemplate):


### PR DESCRIPTION
As we cannot use `disable_lookups` anymore, this change will make linter behavior consistent with all versions of ansible-core at the small risk of introducing possible lookup failures.

Fixes: AAP-48340
Fixes: #4592
Related: https://github.com/ansible/ansible-lint/discussions/4652