### PR TITLE
Skip lookups for ansible-core>=2.19

### DIFF
--- a/examples/playbooks/test_lookup.yml
+++ b/examples/playbooks/test_lookup.yml
@@ -1,0 +1,29 @@
+---
+- name: Test lookup playbook for template() function
+  hosts: localhost
+  gather_facts: false
+  vars:
+    # File lookup example
+    config_content: "{{ lookup('env', 'HOME') }}"
+
+    # Environment variable lookup
+    current_user: "{{ lookup('env', 'USER') }}"
+
+    # Lookup with default value
+    optional_port: "{{ lookup('env', 'TEST_PORT', default='8080') }}"
+
+  tasks:
+    - name: Display environment variable via lookup
+      ansible.builtin.debug:
+        msg: "Current user: {{ current_user }}"
+
+    - name: Use lookup in task
+      ansible.builtin.set_fact:
+        app_config:
+          port: "{{ lookup('env', 'APP_PORT', default='3000') }}"
+          home: "{{ lookup('env', 'HOME') }}"
+
+    - name: Conditional task with lookup
+      ansible.builtin.debug:
+        msg: "Debug mode enabled"
+      when: lookup('env', 'DEBUG', default='false') | bool

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -30,10 +30,12 @@ from typing import TYPE_CHECKING, Any
 import pytest
 from ansible.utils.sentinel import Sentinel
 from ansible_compat.runtime import Runtime
+from packaging.version import Version
 
 from ansiblelint import cli, constants, utils
 from ansiblelint.__main__ import initialize_logger
 from ansiblelint.cli import get_rules_dirs
+from ansiblelint.config import get_deps_versions
 from ansiblelint.constants import RC
 from ansiblelint.file_utils import Lintable, cwd
 from ansiblelint.runner import Runner
@@ -277,6 +279,47 @@ def test_template(template: str, output: str) -> None:
         fail_on_error=False,
     )
     assert result == output
+
+
+@pytest.mark.parametrize(
+    ("template", "has_lookup"),
+    (
+        pytest.param(
+            "{{ lookup('file', '/etc/hostname') }}",
+            True,
+            id="file_lookup",
+        ),
+        pytest.param(
+            "Welcome {{ lookup('env', 'USER', default='user') }}!",
+            True,
+            id="lookup_with_text",
+        ),
+    ),
+)
+def test_template_lookup_behavior(template: str, has_lookup: bool) -> None:
+    """Test template behavior for both ansible-core >= 2.19 and < 2.19."""
+    result = utils.template(
+        basedir=Path("/base/dir"),
+        value=template,
+        variables={"some_var": "test_value"},
+        fail_on_error=False,
+    )
+
+    # Get ansible-core version to determine expected behavior
+    deps = get_deps_versions()
+    ansible_version = deps.get("ansible-core")
+    is_new_ansible = ansible_version and ansible_version >= Version("2.19")
+
+    if has_lookup and is_new_ansible:
+        # For ansible-core >= 2.19: lookups should be skipped (returned unchanged)
+        assert result == template, (
+            f"Expected lookup to be skipped for ansible-core >= 2.19, but got: {result}"
+        )
+    elif not has_lookup:
+        # Normal templates should always be processed
+        assert result != template, (
+            f"Expected normal template to be processed, but got unchanged: {result}"
+        )
 
 
 def test_task_to_str_unicode() -> None:


### PR DESCRIPTION
Reverts #4683.

Adds a check for ansible-core 2.19 before setting `disable_lookups=True`. If ansible-core>=2.19 is used, return early and do not template. 

This is because we need to ensure lookups (and code execution) are not performed inside of ansible-lint for ansible-core `>=2.19`. 

See https://github.com/ansible/ansible-lint/discussions/4652 and https://github.com/ansible/ansible-lint/issues/4592

Jira issue for a later larger rework based on the outcome of [this discussion](https://github.com/ansible/ansible-lint/discussions/4652): [AAP-49998](https://issues.redhat.com/browse/AAP-49998)