### PR TITLE
Use 'x-ansible-lint' key for example paths in schema tests

### DIFF
--- a/src/ansiblelint/schemas/pattern.json
+++ b/src/ansiblelint/schemas/pattern.json
@@ -3,6 +3,7 @@
   "title": "Ansible Pattern Schema",
   "description": "A schema for validating Ansible pattern definitions",
   "examples": [],
+  "x-ansible-lint": ["extensions/patterns/*/meta/pattern.json"],
   "type": "object",
   "required": [
     "schema_version",
@@ -10,7 +11,6 @@
     "title",
     "description",
     "short_description",
-    "tags",
     "aap_resources"
   ],
   "properties": {
@@ -19,82 +19,81 @@
       "type": "string"
     },
     "name": {
-      "description": "Machine-readable name for the pattern. MUST match the pattern directory name, and be limited to lowercase letters, numbers, and underscores, with a maximum length of 64 characters",
+      "description": "Machine-readable name for the pattern. MUST match the pattern directory name, and be limited to lowercase letters, numbers, and underscores, with a maximum length of 64 character.",
       "minLength": 1,
       "maxLength": 64,
       "pattern": "^[a-z0-9_]+$",
       "type": "string"
     },
     "title": {
-      "description": "Human readable title for the pattern, may be used for pattern catalog and display purposes. It MUST be limited to 64 characters and should start with an action verb (e.g. Create an instance)",
+      "description": "Human readable title for the pattern, may be used for pattern catalog and display purposes. It should meaningfully convey what the pattern does. It MUST be limited to 64 characters and should start with an action verb (e.g. Create an AWS EC2 instance).",
       "maxLength": 64,
       "type": "string"
     },
     "description": {
-      "description": "A detailed explanation of what the pattern does. Use complete sentences to describe its functionality. This should provide more information than the short description",
+      "description": "A detailed explanation of what the pattern does. Use complete sentences with correct grammar to describe the functionality of the pattern and provide usage guidance. The description should provide context to the user so that they understand the purpose of the pattern and what they will gain by using it.",
       "type": "string"
     },
     "short_description": {
-      "description": "A brief summary of what the pattern does that can be used for display purposes",
+      "description": "A one-line description of the entry point. Ideally it is a phrase and not a sentence. The short description should always be a string and never a list, and should not end in a period.",
       "type": "string"
     },
     "tags": {
-      "description": "List of tags associated with the pattern",
+      "description": "List of tags associated with the pattern. Tags may be used to filter patterns in catalog UIs such as automation hub and Red Hat Developer Hub.",
       "type": "array",
       "items": {
         "type": "string"
       },
-      "minItems": 1,
       "uniqueItems": true
     },
     "aap_resources": {
-      "description": "Define the resources required in Ansible Automation Platform (AAP) to run the pattern automation",
+      "description": "Define the resources required in Ansible Automation Platform (AAP) to run the pattern automation.",
       "type": "object",
       "required": ["controller_project", "controller_job_templates"],
       "properties": {
         "controller_project": {
-          "description": "Information about the project to be created in automation controller. Every pattern MUST specify a controller project, which will be sourced from the pattern's parent collection published in private automation hub",
+          "description": "Information about the project to be created in automation controller. Every pattern MUST specify a controller project, which will be sourced from the pattern's parent collection published in private automation hub.",
           "type": "object",
           "required": ["name", "description"],
           "properties": {
             "name": {
-              "description": "Name for the project to be created in automation controller. The value MUST not exceed 200 characters",
+              "description": "Name for the project to be created in automation controller. The value MUST not exceed 200 characters.",
               "maxLength": 200,
               "type": "string"
             },
             "description": {
-              "description": "Description for the project to be created in automation controller",
+              "description": "Description of the project to be created in automation controller.",
               "type": "string"
             }
           }
         },
         "controller_execution_environment": {
-          "description": "Definition of the execution environment (EE) to be used by the pattern. An EE should be included if the pattern requires dependencies that are not available in the default controller EE. The EE image MUST be available in Private Automation Hub (PAH)",
+          "description": "Definition of the execution environment (EE) to be used by the pattern. An EE should be included if the pattern requires dependencies that are not available in the default controller EE. The EE image MUST be available in Private Automation Hub.",
           "type": "object",
           "required": ["name", "description", "image_name"],
           "properties": {
             "name": {
-              "description": "Name for the EE to be created in automation controller. The value MUST not exceed 200 characters",
+              "description": "Name for the EE to be created in automation controller. The value MUST not exceed 200 characters.",
               "maxLength": 200,
               "type": "string"
             },
             "description": {
-              "description": "Description for the EE to be created in automation controller",
+              "description": "Description for the EE to be created in automation controller.",
               "type": "string"
             },
             "image_name": {
-              "description": "Name of the execution environment (EE) image as published in Private Automation Hub (PAH). Use the format <namespace>/<image_name>, such as 'cloud/aws_ops_ee'. If the pattern is created before the image is published, the image MUST be uploaded to PAH with the name specified here. If the image is already in PAH, this value MUST exactly match the existing image name",
+              "description": "Name of the execution environment (EE) image as published in Private Automation Hub (PAH). Use the format <namespace>/<image_name>, such as 'cloud/aws_ops_ee'. If the pattern is created before the image is published, the image MUST be uploaded to PAH with the name specified here. If the image is already in PAH, this value MUST exactly match the existing image name.",
               "type": "string"
             },
             "pull": {
-              "description": "Whether to pull the EE image before running",
+              "description": "Whether to pull the EE image before running.",
               "type": "string",
               "enum": ["always", "missing", "never"]
             }
           }
         },
         "controller_labels": {
-          "description": "Labels to create for the pattern if not already present in automation controller",
+          "description": "Labels to create for the pattern if not already present in automation controller.",
           "type": "array",
           "items": {
             "type": "string"
@@ -103,7 +102,7 @@
           "uniqueItems": true
         },
         "controller_job_templates": {
-          "description": "A list of one or more job templates to be created in automation controller",
+          "description": "A list of one or more job templates to be created in automation controller.",
           "type": "array",
           "minItems": 1,
           "items": {
@@ -111,36 +110,40 @@
             "required": ["name", "description", "playbook"],
             "properties": {
               "name": {
-                "description": "Name for the job template to be created in automation controller. The value MUST not exceed 200 characters",
+                "description": "Name for the job template to be created in automation controller. The value MUST not exceed 200 characters.",
                 "maxLength": 200,
                 "type": "string"
               },
               "description": {
-                "description": "Description for the job template to be created in automation controller",
+                "description": "Description for the job template to be created in automation controller.",
                 "type": "string"
               },
               "execution_environment": {
-                "description": "Name of the execution environment to use for job template execution. MUST match the EE name defined in controller_execution_environment, IF defined",
+                "description": "Name of the execution environment to use for job template execution. MUST match the EE name defined in controller_execution_environment, IF defined.",
                 "type": "string"
               },
               "playbook": {
-                "description": "Name of the playbook file included in the pattern `automations` directory",
+                "description": "Name of the playbook file included in the pattern `automations` directory.",
                 "type": "string"
               },
+              "primary": {
+                "description": "Whether the playbook is the primary playbook for this job template. If there are multiple job templates included, one should be labeled as the primary job template.",
+                "type": "boolean"
+              },
               "ask_credential_on_launch": {
-                "description": "Whether the user must select a credential when launching the job template",
+                "description": "Whether the user must select a credential when launching the job template.",
                 "type": "boolean"
               },
               "ask_inventory_on_launch": {
-                "description": "Whether the user must select an inventory when launching the job template",
+                "description": "Whether the user must select an inventory when launching the job template.",
                 "type": "boolean"
               },
               "ask_verbosity_on_launch": {
-                "description": "Whether the user must choose a verbosity level when launching the job template",
+                "description": "Whether the user must choose a verbosity level when launching the job template.",
                 "type": "boolean"
               },
               "labels": {
-                "description": "List of labels to associate with this resource. Each label MUST either already exist in automation controller or be defined in the 'controller_labels' field of this pattern to be created during pattern loading",
+                "description": "List of labels to associate with this resource. Each label MUST either already exist in automation controller or be defined in the 'controller_labels' field of this pattern to be created during pattern loading.",
                 "type": "array",
                 "items": {
                   "type": "string"
@@ -149,21 +152,21 @@
                 "uniqueItems": true
               },
               "survey": {
-                "description": "A survey that captures required and optional variables from the user for configuring job templates",
+                "description": "A survey that captures required and optional variables from the user for configuring job templates.",
                 "type": "object",
                 "required": ["name", "description", "spec"],
                 "properties": {
                   "name": {
                     "type": "string",
-                    "description": "Name of the survey"
+                    "description": "Name of the survey."
                   },
                   "description": {
                     "type": "string",
-                    "description": "Description of the survey"
+                    "description": "Description of the survey."
                   },
                   "spec": {
                     "type": "array",
-                    "description": "List of survey questions",
+                    "description": "List of survey questions.",
                     "items": {
                       "type": "object",
                       "required": [
@@ -176,7 +179,7 @@
                       "properties": {
                         "type": {
                           "type": "string",
-                          "description": "Type of input field",
+                          "description": "Type of input field.",
                           "enum": [
                             "text",
                             "textarea",
@@ -189,30 +192,33 @@
                         },
                         "question_name": {
                           "type": "string",
-                          "description": "Human-readable question title"
+                          "description": "Human-readable question title."
                         },
                         "question_description": {
                           "type": "string",
-                          "description": "Description or help text for the question"
+                          "description": "A prompt that instructs the user to supply information or other input to the pattern. Use a complete sentence with correct grammar. Start with an imperative verb form and be specific and actionable. Address the user directly in a conversational and professional way."
                         },
                         "variable": {
                           "type": "string",
-                          "description": "Variable name used to store the answer"
+                          "minLength": 1,
+                          "maxLength": 64,
+                          "pattern": "^[a-z0-9_]+$",
+                          "description": "Variable name used to store the answer."
                         },
                         "required": {
                           "type": "boolean",
-                          "description": "Whether this question must be answered"
+                          "description": "Whether this question must be answered."
                         },
                         "choices": {
                           "type": "array",
-                          "description": "List of selectable values for multiple choice questions",
+                          "description": "List of selectable values for multiple choice questions.",
                           "items": {
                             "type": "string"
                           }
                         },
                         "default": {
                           "type": "string",
-                          "description": "Default value for the input field"
+                          "description": "Default value for the input field."
                         }
                       },
                       "allOf": [

--- a/test/schemas/src/schema.spec.ts
+++ b/test/schemas/src/schema.spec.ts
@@ -55,14 +55,19 @@ describe("schemas under f/", function () {
     const schema_json = JSON.parse(fs.readFileSync(`f/${schema_file}`, "utf8"));
     ajv.addSchema(schema_json);
     const validator = ajv.compile(schema_json);
-    if (schema_json.examples == undefined) {
+    if (
+      schema_json["examples"] == undefined &&
+      schema_json["x-ansible-lint"] == undefined
+    ) {
       console.error(
-        `Schema file ${schema_file} is missing an examples key that we need for documenting file matching patterns.`,
+        `Schema file ${schema_file} is missing an 'examples' or 'x-ansible-lint' key that we need for documenting file matching patterns.`,
       );
       return process.exit(1);
     }
     describe(schema_file, function () {
-      getTestFiles(schema_json.examples).forEach(
+      const file_path_key =
+        schema_json["x-ansible-lint"] || schema_json["examples"];
+      getTestFiles(file_path_key).forEach(
         ({ file: test_file, expect_fail }) => {
           it(`linting ${test_file} using ${schema_file}`, function () {
             var errors_md = "";


### PR DESCRIPTION
This PR expands schema tests to look for an `x-ansible-lint` key for file location examples. 

As part of the discussion on https://github.com/ansible/pattern-service/pull/17, we have decided to allow using the schema key `x-ansible-lint` to provide path examples for file types. 

For example, the patterns schema uses the value: 
```
  "x-ansible-lint": ["extensions/patterns/*/meta/pattern.json"],
```
This is because the correct usage of an `examples` key in JSON schemas is for JSON examples, not example file locations. 