### PR TITLE
Skip lookups with query and q (2.19)

### DIFF
--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -200,10 +200,11 @@ def ansible_template(
     re_filter_fqcn = re.compile(r"\w+\.\w+\.\w+")
     re_filter_in_err = re.compile(r"Could not load \"(\w+)\"")
     re_valid_filter = re.compile(r"^\w+(\.\w+\.\w+)?$")
+    re_lookup_functions = re.compile(r"\b(lookup|query|q)\s*\(")
     templar = ansible_templar(basedir=basedir, templatevars=templatevars)
 
     # Skip lookups for ansible-core >= 2.19; use disable_lookups for older versions
-    if "lookup" in varname:
+    if re_lookup_functions.search(str(varname)):
         deps = get_deps_versions()
         if deps["ansible-core"] and deps["ansible-core"] >= Version("2.19"):
             return varname

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -294,6 +294,22 @@ def test_template(template: str, output: str) -> None:
             True,
             id="lookup_with_text",
         ),
+        pytest.param(
+            "{{ query('env', 'HOME') }}",
+            True,
+            id="query_function_call",
+        ),
+        pytest.param(
+            "{{ q('file', 'config.txt') }}",
+            True,
+            id="q_function_call",
+        ),
+        # query() with whitespace - should still be detected, will throw spacing errors
+        pytest.param(
+            "{{ query  ('dict', my_var) }}",
+            True,
+            id="query_function_with_whitespace",
+        ),
     ),
 )
 def test_template_lookup_behavior(template: str, has_lookup: bool) -> None:


### PR DESCRIPTION
Fixes #4695.

Adds `query` and `q` to the check for skipping lookups with ansible-core 2.19. 