### PR TITLE
Lint failure in ansible.utils: src must be an absolute path fix

### DIFF
--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -1344,7 +1344,7 @@ def parse_examples_from_plugin(lintable: Lintable) -> tuple[int, str]:
                 offset = child.lineno - 1
                 break
 
-    docs = read_docstring(str(lintable.path.resolve(strict=False))) # type: ignore[no-untyped-call]
+    docs = read_docstring(str(lintable.path.resolve(strict=False)))  # type: ignore[no-untyped-call]
     examples = docs["plainexamples"]
 
     # Ignore the leading newline and lack of document start

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -1344,7 +1344,7 @@ def parse_examples_from_plugin(lintable: Lintable) -> tuple[int, str]:
                 offset = child.lineno - 1
                 break
 
-    docs = read_docstring(str(lintable.path))  # type: ignore[no-untyped-call]
+    docs = read_docstring(str(lintable.path.resolve(strict=False))) # type: ignore[no-untyped-call]
     examples = docs["plainexamples"]
 
     # Ignore the leading newline and lack of document start


### PR DESCRIPTION
**Related:** -https://issues.redhat.com/browse/AAP-50583

**Description**
A regression has been observed in the linting of the [ansible.utils](https://github.com/ansible-collections/ansible.utils/actions/runs/16610582350/job/46992716228) collection post-July 21. Though the linked [ansible-lint#4687](https://github.com/ansible/ansible-lint/pull/4687) PR appears unrelated, the failures suggest a breaking change in Ansible Lint behavior. This failures need to be addressed inorder to make the upstream CI green.
