### PR TITLE
make rule deprecated-local-action preserve module parameters

### DIFF
--- a/examples/playbooks/tasks/local_action.transformed.yml
+++ b/examples/playbooks/tasks/local_action.transformed.yml
@@ -1,4 +1,8 @@
 ---
-- name: Sample
-  ansible.builtin.command: echo 123
+- name: Sample 1
+  command: echo 123
+  delegate_to: localhost
+- name: Sample 2
+  command:
+    cmd: echo 456
   delegate_to: localhost

--- a/examples/playbooks/tasks/local_action.yml
+++ b/examples/playbooks/tasks/local_action.yml
@@ -1,3 +1,7 @@
 ---
-- name: Sample
+- name: Sample 1
   local_action: command echo 123
+- name: Sample 2
+  local_action:
+    module: command
+    cmd: echo 456

--- a/src/ansiblelint/rules/deprecated_local_action.py
+++ b/src/ansiblelint/rules/deprecated_local_action.py
@@ -61,7 +61,12 @@ class TaskNoLocalActionRule(AnsibleLintRule, TransformMixin):
                 if k == "local_action":
                     if isinstance(v, dict):
                         module_name = v["module"]
-                        target_task[module_name] = None
+                        target_task[module_name] = {}
+                        for param, val in v.items():
+                            if param != "module":
+                                target_task[module_name][param] = val
+                        if len(target_task[module_name]) == 0:
+                            target_task[module_name] = None
                         target_task["delegate_to"] = "localhost"
                     elif isinstance(v, str):
                         module_name, module_value = v.split(" ", 1)


### PR DESCRIPTION
Proposed fix for #4731

This is my first attempt at hacking something I want into ansible-lint, be gentle ;)

I was a bit surprised why all rule tests get a a full ruleset provided via `default_rules_collection` param as this makes the rules prone to breakage caused by other rules' auto-formating. I changed this and also made some assertions test if `decprecated-local-action` actually matched, not the number of expected matches which may change in the future.