### PR TITLE
Prevent false positive pattern detection in filenames containing "pattern.json"

### DIFF
--- a/src/ansiblelint/file_utils.py
+++ b/src/ansiblelint/file_utils.py
@@ -169,6 +169,10 @@ def kind_from_path(path: Path, *, base: bool = False) -> FileType:
     if str(path) == "/dev/stdin":
         return "playbook"
 
+    if path.name == "pattern.json":
+        # This is a pattern file
+        return "pattern"
+
     # Unknown file types report a empty string (evaluated as False)
     return ""
 

--- a/src/ansiblelint/file_utils.py
+++ b/src/ansiblelint/file_utils.py
@@ -169,10 +169,6 @@ def kind_from_path(path: Path, *, base: bool = False) -> FileType:
     if str(path) == "/dev/stdin":
         return "playbook"
 
-    if "pattern.json" in str(path):
-        # This is a pattern file
-        return "pattern"
-
     # Unknown file types report a empty string (evaluated as False)
     return ""
 

--- a/src/ansiblelint/schemas/__store__.json
+++ b/src/ansiblelint/schemas/__store__.json
@@ -24,7 +24,7 @@
     "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/inventory.json"
   },
   "meta": {
-    "etag": "60f3ce2a78ec4fb705c589da409a384ac97315e17810379c5049169986ce3097",
+    "etag": "001ce2e0b8074db4ba553c2fd960659db7389160e12166bc7d809fef2ee0ca26",
     "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/meta.json"
   },
   "meta-runtime": {


### PR DESCRIPTION
### SUMMARY

**Problem**: The kind_from_path function was incorrectly identifying files like `some-filename-ending-with-pattern.json` as pattern type files due to using "pattern.json" in str(path), which would match any filename containing that substring. This caused non-pattern files to be incorrectly validated by the schema[pattern] rule.

**Solution**: Changed the pattern detection logic from `"pattern.json" in str(path)` to `path.name == "pattern.json"` to ensure only files exactly named "pattern.json" are identified as pattern files.

Fixes: https://github.com/ansible/ansible-lint/issues/4709