### PR TITLE
fix: pin to python3.13 for the pre-commit action

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -8,6 +8,9 @@
   description: This hook runs ansible-lint.
   entry: python3 -m ansiblelint -v --force-color
   language: python
+  # version is needed to avoid accidental use of python3.10 on some platforms
+  # as this is not supportted by recent versions of a ansible-lint and ansible-core
+  language_version: python3.13
   # do not pass files to ansible-lint, see:
   # https://github.com/ansible/ansible-lint/issues/611
   pass_filenames: false


### PR DESCRIPTION
Fixes issue where running recent versions of the pre-commit hook
might fail on systems where default python is 3.10 (which is not
supported).
