### PR TITLE
fix: lock ansible-core to <2.20.0 for ansible 12.2.0 compatibility

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -21,4 +21,4 @@
     # free to override `additional_dependencies` in your own hook config
     # file as we only support latest stable version of ansible-core when used
     # as an action.
-    - ansible-core>=2.19.0
+    - ansible-core>=2.19.0,<2.20.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 ]
 dependencies = [
   "ansible-compat>=25.8.2",
-  "ansible-core>=2.17.10",
+  "ansible-core>=2.17.10,<2.20.0",
   "black>=24.3.0",
   "cffi>=1.17.1",  # indirect dependency of ruamel-yaml
   "cryptography>=38",

--- a/uv.lock
+++ b/uv.lock
@@ -164,7 +164,7 @@ schemas = [
 [package.metadata]
 requires-dist = [
     { name = "ansible-compat", specifier = ">=25.8.2" },
-    { name = "ansible-core", specifier = ">=2.17.10" },
+    { name = "ansible-core", specifier = ">=2.17.10,<2.20.0" },
     { name = "black", specifier = ">=24.3.0" },
     { name = "cffi", specifier = ">=1.17.1" },
     { name = "cryptography", specifier = ">=38" },


### PR DESCRIPTION
ansible-core 2.20.0 is not yet supported by ansible 12.2.0. Lock the upper bound to <2.20.0 to ensure compatibility between ansible-lint and ansible 12.2.0.

relates to 
- https://github.com/Homebrew/homebrew-core/pull/253045
- https://github.com/Homebrew/homebrew-core/issues/173128