### PR TITLE
fix: prevent trailing space on blank comment lines

### DIFF
--- a/examples/playbooks/transform-yaml-comments.transformed.yml
+++ b/examples/playbooks/transform-yaml-comments.transformed.yml
@@ -1,5 +1,7 @@
 ---
 # comment without space
+#
+# second comment after blank
 - name: Fixture
   hosts: localhost
   tasks:

--- a/examples/playbooks/transform-yaml-comments.yml
+++ b/examples/playbooks/transform-yaml-comments.yml
@@ -1,5 +1,7 @@
 ---
 #comment without space
+#
+#second comment after blank
 - name: Fixture
   hosts: localhost
   tasks:

--- a/src/ansiblelint/yaml_utils.py
+++ b/src/ansiblelint/yaml_utils.py
@@ -826,7 +826,7 @@ class FormattedEmitter(Emitter):
             value = self._re_repeat_blank_lines.sub("\n\n", value)
 
         # make sure that comments have a space after #
-        if value.startswith("#") and not value.startswith("# ") and len(value) > 1:
+        if value.startswith("#") and not value.startswith("# ") and value[1:].strip():
             value = "# " + value[1:]
 
         comment.value = value

--- a/test/test_transformer.py
+++ b/test/test_transformer.py
@@ -214,7 +214,7 @@ def fixture_runner_result(
         ),
         pytest.param(
             "examples/playbooks/transform-yaml-comments.yml",
-            2,
+            3,
             True,
             True,
             id="yaml-comments",


### PR DESCRIPTION
## PR Summary
This PR fixes a bug in #4855 where the `yaml[comments]` autofix would incorrectly add a trailing space to blank comment lines (lines with just `#`). The original fix checked `len(value) > 1` to skip blank comments, but comment values include a newline character, so `#\n` (length 2) incorrectly passed the check and became `# \n`. This then triggered `yaml[trailing-spaces]` violations on subsequent runs. The fix replaces the length check with `value[1:].strip()` to only add a space when there's actual text content after the `#`. Test fixtures have been updated to cover this edge case.

Fixes #4866