### PR TITLE
Update configuring.md to reflect correct precommit name

### DIFF
--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -84,7 +84,7 @@ on each change but you can also run the tool yourself using the CI of your choic
     `additional_dependencies`.
 
 Change **rev:** to either a commit sha or tag of Ansible-lint that contains
-`.pre-commit-hooks.yaml`.
+`.pre-commit-config.yaml`.
 
 ```yaml
 ---


### PR DESCRIPTION
As per their docs https://pre-commit.com/ the name of the file is `.pre-commit-config.yaml`