### PR TITLE
fix: retire -p/--parseable option

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -13,7 +13,6 @@ exclude_paths:
   - .cache/ # implicit unless exclude_paths is defined in config
   - test/fixtures/formatting-before/
   - test/fixtures/formatting-prettier/
-# parseable: true
 # quiet: true
 # strict: true
 # verbosity: 1

--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -46,7 +46,6 @@ nodeps
 nomatchestest
 nxos
 octals
-parseable
 pathex
 pbrun
 pfexec

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
     hooks:
       - id: check-useless-excludes
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.9.18
+    rev: 0.9.21
     hooks:
       - id: uv-sync
       - id: uv-lock
@@ -146,7 +146,7 @@ repos:
         entry: yamllint --strict
 
   - repo: https://github.com/tombi-toml/tombi-pre-commit
-    rev: v0.7.11
+    rev: v0.7.14
     hooks:
       - id: tombi-format
         alias: toml

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -17,7 +17,7 @@ Ansible-lint prints output on both `stdout` and `stderr`.
 - `stderr` displays logging and free-form messages like statistics.
 
 Most `ansible-lint` examples use pep8 as the output format (`-p`) which is
-machine parseable.
+machine parsable.
 
 Ansible-lint also print errors using their [annotation] format when it detects
 the `GITHUB_ACTIONS=true` and `GITHUB_WORKFLOW=...` variables.

--- a/src/ansiblelint/app.py
+++ b/src/ansiblelint/app.py
@@ -372,8 +372,8 @@ def choose_formatter_factory(
         r = formatters.CodeclimateJSONFormatter
     elif options_list.format == "sarif":
         r = formatters.SarifFormatter
-    elif options_list.parseable or options_list.format == "pep8":
-        r = formatters.ParseableFormatter
+    elif options_list.format == "pep8":
+        r = formatters.PEP8Formatter
     return r
 
 

--- a/src/ansiblelint/cli.py
+++ b/src/ansiblelint/cli.py
@@ -318,14 +318,6 @@ def get_cli_parser() -> argparse.ArgumentParser:
         help="Specify which rules profile to be used.",
     )
     parser.add_argument(
-        "-p",
-        "--parseable",
-        dest="parseable",
-        default=False,
-        action="store_true",
-        help="parseable output, same as '-f pep8'",
-    )
-    parser.add_argument(
         "--project-dir",
         dest="project_dir",
         default=None,
@@ -493,7 +485,6 @@ def merge_config(file_config: dict[Any, Any], cli_config: Options) -> Options:
     """Combine the file config with the CLI args."""
     bools = (
         "display_relative_path",
-        "parseable",
         "quiet",
         "strict",
         "use_default_rules",
@@ -590,6 +581,11 @@ def get_config(arguments: list[str]) -> Options:
             _logger.warning(
                 "Replaced deprecated '--write' option with '--fix', change you call to avoid future regressions when we remove old option.",
             )
+        # cspell:ignore parseable
+        if value in ("-p", "--parseable"):
+            arguments[i] = "--format=pep8"
+            msg = f"Deprecated `{value}` cli option replaced with current `{arguments[i]}` option. This alias will be removed in a future release."
+            _logger.warning(msg)
     options = Options(**vars(parser.parse_args(arguments)))
 
     # docs is not document, being used for internal documentation building

--- a/src/ansiblelint/config.py
+++ b/src/ansiblelint/config.py
@@ -143,7 +143,6 @@ class Options:  # pylint: disable=too-many-instance-attributes
     list_tags: bool = False
     write_list: list[str] = field(default_factory=list)
     write_exclude_list: list[str] = field(default_factory=list)
-    parseable: bool = False
     quiet: bool = False
     rulesdirs: list[Path] = field(default_factory=list)
     skip_list: list[str] = field(default_factory=list)

--- a/src/ansiblelint/formatters/__init__.py
+++ b/src/ansiblelint/formatters/__init__.py
@@ -89,8 +89,8 @@ class QuietFormatter(BaseFormatter[Any]):
         )
 
 
-class ParseableFormatter(BaseFormatter[Any]):
-    """Parseable uses PEP8 compatible format."""
+class PEP8Formatter(BaseFormatter[Any]):
+    """Parsable uses PEP8 compatible format."""
 
     def apply(self, match: MatchError) -> str:
         result = (

--- a/src/ansiblelint/schemas/ansible-lint-config.json
+++ b/src/ansiblelint/schemas/ansible-lint-config.json
@@ -101,11 +101,6 @@
       "title": "Only Builtins Allow Modules",
       "type": "array"
     },
-    "parseable": {
-      "default": true,
-      "title": "Parseable",
-      "type": "boolean"
-    },
     "profile": {
       "enum": [
         "min",

--- a/test/fixtures/parseable.yml
+++ b/test/fixtures/parseable.yml
@@ -1,3 +1,0 @@
----
-parseable: true
-# vim: et:sw=2:syntax=yaml:ts=2:

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -23,7 +23,6 @@ def fixture_base_arguments() -> list[str]:
 @pytest.mark.parametrize(
     ("args", "config_path"),
     (
-        pytest.param(["-p"], "test/fixtures/parseable.yml", id="1"),
         pytest.param(["-q"], "test/fixtures/quiet.yml", id="2"),
         pytest.param(
             ["-r", "test/fixtures/rules/"],

--- a/test/test_formatter_json.py
+++ b/test/test_formatter_json.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import json
 import pathlib
-import subprocess
-import sys
 
 import pytest
 
@@ -123,20 +121,3 @@ class TestCodeclimateJSONFormatter:
         assert result[0]["location"]["positions"]["begin"]["line"] == 1
         assert result[0]["location"]["positions"]["begin"]["column"] == 42
         assert "lines" not in result[0]["location"]
-
-
-def test_code_climate_parsable_ignored() -> None:
-    """Test that -p option does not alter codeclimate format."""
-    cmd = [
-        sys.executable,
-        "-m",
-        "ansiblelint",
-        "-v",
-        "-p",
-    ]
-    file = "examples/playbooks/empty_playbook.yml"
-    result = subprocess.run([*cmd, file], check=False)
-    result2 = subprocess.run([*cmd, "-p", file], check=False)
-
-    assert result.returncode == result2.returncode
-    assert result.stdout == result2.stdout

--- a/test/test_formatter_sarif.py
+++ b/test/test_formatter_sarif.py
@@ -164,23 +164,6 @@ class TestSarifFormatter:
         assert results[1]["message"]["text"] == self.matches[1].message
 
 
-def test_sarif_parsable_ignored() -> None:
-    """Test that -p option does not alter SARIF format."""
-    cmd = [
-        sys.executable,
-        "-m",
-        "ansiblelint",
-        "-v",
-        "-p",
-    ]
-    file = "examples/playbooks/empty_playbook.yml"
-    result = subprocess.run([*cmd, file], check=False)
-    result2 = subprocess.run([*cmd, "-p", file], check=False)
-
-    assert result.returncode == result2.returncode
-    assert result.stdout == result2.stdout
-
-
 @pytest.mark.parametrize(
     ("file", "return_code"),
     (

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -166,7 +166,7 @@ def test_broken_ansible_cfg() -> None:
 
 
 def test_list_tags() -> None:
-    """Asserts that we can list tags and that the output is parseable yaml."""
+    """Asserts that we can list tags and that the output is parsable yaml."""
     result = subprocess.run(
         ["ansible-lint", "--list-tags"],
         check=True,

--- a/test/test_runner.py
+++ b/test/test_runner.py
@@ -110,7 +110,7 @@ def test_runner_exclude_globs(
     ("formatter_cls"),
     (
         pytest.param(formatters.Formatter, id="Formatter-plain"),
-        pytest.param(formatters.ParseableFormatter, id="ParseableFormatter-colored"),
+        pytest.param(formatters.PEP8Formatter, id="PEP8Formatter-colored"),
         pytest.param(formatters.QuietFormatter, id="QuietFormatter-colored"),
         pytest.param(formatters.Formatter, id="Formatter-colored"),
     ),

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -404,7 +404,7 @@ def test_cli_auto_detect(capfd: CaptureFixture[str]) -> None:
         "-x",
         "schema",  # exclude schema as our test file would fail it
         "-v",
-        "-p",
+        "--format=pep8",
         "--nocolor",
         "--offline",
         "--exclude=examples",


### PR DESCRIPTION
We remove the `-p/--parseable` option. Users can easily switch to `--format=pep8` to achieve the same results, option that was recommend way to change output format for the last 7 years.

An alias and warning message are in place but will be removed in a future released.