### PR TITLE
fix: update documentation to clarify requirement to run from project …

### DIFF
--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -4,8 +4,9 @@ Customize how Ansible-lint runs against automation content to suit your needs.
 You can ignore certain rules, enable `opt-in` rules, and control various other
 settings.
 
-Ansible-lint loads configuration from a file in the current working directory or
-from a file that you specify in the command line.
+Ansible-lint loads configuration from a file in the project root directory (current
+working directory) or from a file that you specify in the command line. Executing the
+linter from the project root is required for correct file discovery and dependency resolution.
 
 Any configuration option that is passed from the command line will override
 the one specified inside the configuration file.
@@ -19,8 +20,11 @@ in your current working directory.
 
 !!! note
 
-    If Ansible-lint cannot find a configuration file in the current directory it attempts to locate it in a parent directory.
-    However Ansible-lint does not try to load configuration that is outside the git repository.
+    If Ansible-lint cannot find a configuration file in the current directory it
+    attempts to locate it in a parent directory. However, Ansible-lint does not
+    try to load configuration that is outside the git repository. **Note that
+    while the config may be found in a parent directory, the linter still
+    expects to be executed from the root of the project being linted.**
 
 ## Specifying configuration files
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -55,6 +55,13 @@ where it failed to work as expected and caused false negatives.
 
 ## Linting playbooks and roles
 
+!!! warning "Execution Directory"
+
+    **Always run `ansible-lint` from the root of your project or collection.**
+    As of version 25.7.0, running the linter from within a subdirectory
+    (such as inside a `roles/` or `tasks/` folder) is not supported and
+    may result in zero errors being reported even if violations exist.
+
 Ansible-lint recommends following the [collection structure layout] whether you
 plan to build a collection or not.
 

--- a/src/ansiblelint/schemas/__store__.json
+++ b/src/ansiblelint/schemas/__store__.json
@@ -1,6 +1,6 @@
 {
   "ansible-lint-config": {
-    "etag": "d08ce380364a2935299f89bf453787601d44a1bc6b70a38afaec4a8b0b80d104",
+    "etag": "1fe2e8bc4dd6a77c4055bf063a0983725fde4133c981335413d6503fe2e543ed",
     "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/ansible-lint-config.json"
   },
   "ansible-navigator-config": {
@@ -24,7 +24,7 @@
     "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/inventory.json"
   },
   "meta": {
-    "etag": "d63b91b4cb6a73cde4d9d98b7b5d9bbaf8ed568173e90682afb5b11cd6ba55b3",
+    "etag": "d2f353a0077365ff075b14876b619ef65e7268129fd12b4f1b571549f2f39f14",
     "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/meta.json"
   },
   "meta-runtime": {


### PR DESCRIPTION
Summary
This PR updates `usage.md` and `configuring.md` to clarify that `ansible-lint` must be executed from the project root for correct file discovery. This documentation fix addresses the "reversed behavior" where linting subdirectories directly could result in false positives.

Fixes #4790