### PR TITLE
fix: ensure exclude_paths are honored for unparseable files

### DIFF
--- a/test/test_runner.py
+++ b/test/test_runner.py
@@ -87,6 +87,25 @@ def test_runner_exclude_paths(default_rules_collection: RulesCollection) -> None
     assert len(matches) == 0
 
 
+def test_exclude_paths_ignores_broken_yaml(
+    default_rules_collection: RulesCollection,
+    tmp_path: Path,
+) -> None:
+    """Ensure exclude_paths prevents parsing of invalid YAML files (#4745)."""
+    broken_yaml = tmp_path / "secrets.yml"
+    broken_yaml.write_text("---\ninvalid: : : : yaml\n", encoding="utf-8")
+
+    runner = Runner(
+        broken_yaml,
+        rules=default_rules_collection,
+        exclude_paths=[str(broken_yaml)],
+    )
+
+    results = runner.run()
+
+    assert len(results) == 0
+
+
 @pytest.mark.parametrize(
     ("exclude_path"),
     (pytest.param("**/playbooks_globs/*b.yml", id="1"),),


### PR DESCRIPTION
## Summary
This PR ensures that `exclude_paths` are correctly honored for unparseable or encrypted files (e.g., SOPS). 

Previously, files that failed to load as valid YAML would trigger a `load-failure` even if they were explicitly excluded in the configuration. This occurred because explicit targets would bypass exclusion checks during the initialization phase.

## Changes
- Updated `Runner._run()` to perform a direct exclusion check when a YAML load exception is encountered.
- Silences `load-failure` errors for any file matching the exclusion patterns, allowing the linter to skip them gracefully instead of crashing.
- Maintains existing behavior where valid YAML files passed via CLI bypass exclusions.

Fixes #4745