### PR TITLE
chore: add almalinux platform to meta schemas

### DIFF
--- a/src/ansiblelint/schemas/meta.json
+++ b/src/ansiblelint/schemas/meta.json
@@ -19,6 +19,25 @@
       "title": "AIXPlatformModel",
       "type": "object"
     },
+    "AlmaLinuxPlatformModel": {
+      "properties": {
+        "name": {
+          "const": "AlmaLinux",
+          "title": "Name",
+          "type": "string"
+        },
+        "versions": {
+          "default": "all",
+          "items": {
+            "enum": ["8", "9", "10", "all"],
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "title": "AlmaLinuxPlatformModel",
+      "type": "object"
+    },
     "AlpinePlatformModel": {
       "properties": {
         "name": {


### PR DESCRIPTION
# Allow new platform: AlmaLinux in meta file

Since AlmaLinux is currently not a valid platform in the meta file, I suggest that it be officially added for versions 8, 9, and 10.

I would be grateful if someone could review and merge the PR if it is OK. Thank you very much!