### PR TITLE
fix: almalinux missing reference in platforms array

### DIFF
--- a/src/ansiblelint/schemas/meta.json
+++ b/src/ansiblelint/schemas/meta.json
@@ -1379,6 +1379,9 @@
             "$ref": "#/$defs/AIXPlatformModel"
           },
           {
+            "$ref": "#/$defs/AlmaLinuxPlatformModel"
+          },
+          {
             "$ref": "#/$defs/AlpinePlatformModel"
           },
           {


### PR DESCRIPTION
# Fix: almalinux not accepted as correct platform

I screwed up in #4893. This is the fix for it to work as expected.

Sorry for the mishap.