### PR TITLE
feat: added exit code 8 for successfully fixed violations (#4674)

### DIFF
--- a/src/ansiblelint/app.py
+++ b/src/ansiblelint/app.py
@@ -198,7 +198,10 @@ class App:
     ) -> int:
         """Display information about how to skip found rules.
 
-        Returns exit code, 2 if errors were found, 0 when only warnings were found.
+        Returns exit code:
+          - 0: when no errors were found
+          - 2: if errors were found
+          - 8: if all errors were fixed automatically
         """
         msg = ""
 
@@ -260,6 +263,8 @@ class App:
                 files_count,
                 is_success=mark_as_success,
             )
+        if not summary.failures and changed_files_count > 0:
+            return RC.FIXED_VIOLATIONS
         if mark_as_success:
             if not files_count:
                 # success without any file being analyzed is reported as failure

--- a/src/ansiblelint/constants.py
+++ b/src/ansiblelint/constants.py
@@ -37,6 +37,7 @@ class RC:  # pylint: disable=too-few-public-methods
     INVALID_CONFIG = 3
     LOCK_TIMEOUT = 4
     NO_FILES_MATCHED = 5
+    FIXED_VIOLATIONS = 8
     EXIT_CONTROL_C = 130
 
 

--- a/src/ansiblelint/schemas/__store__.json
+++ b/src/ansiblelint/schemas/__store__.json
@@ -4,7 +4,7 @@
     "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/ansible-lint-config.json"
   },
   "ansible-navigator-config": {
-    "etag": "730a0572f872af3ce271fb5116bc9d4609da10dc2e35448b5ec1050f12b72e2b",
+    "etag": "5f454fdaeb3d92c4bb2cc15dcc48faa67925fecfbdb72efffeddee01860d6bcb",
     "url": "https://raw.githubusercontent.com/ansible/ansible-navigator/main/src/ansible_navigator/data/ansible-navigator.json"
   },
   "changelog": {
@@ -24,7 +24,7 @@
     "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/inventory.json"
   },
   "meta": {
-    "etag": "fa83d61b00b254d54a7c9a69e4fb8b722f356adec906da7beb733cadda1342bc",
+    "etag": "2f5c7deb174136b48a4bc1d8d4399b1a175379dd4b8a863baa9c9bd56ffda489",
     "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/meta.json"
   },
   "meta-runtime": {

--- a/src/ansiblelint/schemas/ansible-navigator-config.json
+++ b/src/ansiblelint/schemas/ansible-navigator-config.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
     "additionalProperties": false,
-    "description": "See https://docs.ansible.com/projects/navigator/settings/",
+    "description": "See https://ansible.readthedocs.io/projects/navigator/settings/",
     "properties": {
         "ansible-navigator": {
             "additionalProperties": false,
@@ -525,7 +525,7 @@
     "required": [
         "ansible-navigator"
     ],
-    "title": "ansible-navigator settings v25",
+    "title": "ansible-navigator settings v26",
     "type": "object",
-    "version": "25"
+    "version": "26"
 }

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -52,3 +52,26 @@ def test_with_inventory_concurrent_syntax_checks(tmp_path: Path) -> None:
         # https://github.com/ansible/ansible-lint/issues/4446.
         assert "AttributeError" not in result.stderr
         counter += 1
+
+
+def test_app_fixed_violations_coverage(tmp_path: Path) -> None:
+    """Directly test App.report_outcome to get coverage on RC.FIXED_VIOLATIONS."""
+    from ansiblelint.app import App
+    from ansiblelint.config import Options
+    from ansiblelint.runner import LintResult
+
+    options = Options()
+    options.project_dir = str(tmp_path)
+    options.cache_dir = tmp_path / ".cache"
+    options.cache_dir.mkdir()
+
+    app = App(options)
+
+    mock_file = Lintable(tmp_path / "playbook.yml", kind="playbook")
+    mock_file.updated = True
+
+    result = LintResult(files={mock_file}, matches=[])
+
+    exit_code = app.report_outcome(result)
+
+    assert exit_code == RC.FIXED_VIOLATIONS


### PR DESCRIPTION
## Summary
This PR implements a new exit code (`8`) to distinguish between a clean run and a run where all violations were successfully resolved using `--fix`. 

- Added `RC.FIXED_VIOLATIONS = 8` to constants.
- Updated `report_outcome` logic to prioritize the fixed-violations exit code when no failures remain and files were modified.
- Added integration test in `test/test_app.py` to verify the new behavior.

Closes #4674