### PR TITLE
Revert "fix: avoid use of pathspec 1.0.0 until yamllint is updated (#4887)"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
   "filelock>=3.8.2",
   "jsonschema>=4.10.0",
   "packaging>=22.0",
-  "pathspec>=0.10.3,<1.0.0",  # current yamllint not compatible with newer version
+  "pathspec>=0.10.3",
   "pyyaml>=6.0.1 ; python_version < '3.14'",
   "pyyaml>=6.0.1 ; python_version >= '3.14'",  # py314 support
   "referencing>=0.36.2",

--- a/uv.lock
+++ b/uv.lock
@@ -193,7 +193,7 @@ requires-dist = [
     { name = "filelock", specifier = ">=3.8.2" },
     { name = "jsonschema", specifier = ">=4.10.0" },
     { name = "packaging", specifier = ">=22.0" },
-    { name = "pathspec", specifier = ">=0.10.3,<1.0.0" },
+    { name = "pathspec", specifier = ">=0.10.3" },
     { name = "pyyaml", marker = "python_full_version < '3.14'", specifier = ">=6.0.1" },
     { name = "pyyaml", marker = "python_full_version >= '3.14'", specifier = ">=6.0.1" },
     { name = "referencing", specifier = ">=0.36.2" },


### PR DESCRIPTION
This reverts commit 028756027926075bf991d2b03c8b65dde7735372.

See https://github.com/adrienverge/yamllint/pull/802

Fixes https://github.com/ansible/ansible-lint/pull/4887