### PR TITLE
fix: restore correct mapping indentation after anchors (#4935)

### DIFF
--- a/src/ansiblelint/yaml_utils.py
+++ b/src/ansiblelint/yaml_utils.py
@@ -704,7 +704,10 @@ class FormattedEmitter(Emitter):
         super().increase_indent(flow, sequence, indentless)
         # If our previous node was a sequence and we are still trying to indent, don't
         if self.indents.last_seq():
-            self.indent = self.column + 1
+            if self.event and getattr(self.event, "anchor", None):
+                self.indent = self.best_sequence_indent - self.sequence_dash_offset
+            else:
+                self.indent = self.column + 1
 
     def write_indicator(
         self,

--- a/test/test_yaml_utils.py
+++ b/test/test_yaml_utils.py
@@ -1042,3 +1042,20 @@ def test_yamllint_file_config_loaded() -> None:
     config_fixture = Path(fixtures_dir / "yamllint.yml")
     config = ansiblelint.yaml_utils.load_yamllint_config(yamllint_file=config_fixture)
     assert config.rules["line-length"]["max"] == 222
+
+
+def test_formatted_yaml_anchor_indentation() -> None:
+    """Verify that anchors in sequences don't cause runaway indentation (#4935)."""
+    yaml = ansiblelint.yaml_utils.FormattedYAML()
+
+    anchor_input = """---
+- &my_anchor
+  name: my_name
+- <<: *my_anchor
+  name: other_name
+"""
+    data_anchor = yaml.load(anchor_input)
+    output_anchor = yaml.dumps(data_anchor)
+
+    assert "  name: my_name" in output_anchor
+    assert "            name: my_name" not in output_anchor


### PR DESCRIPTION
## Summary

Fixed a bug where using a YAML anchor (like `&anchor`) on a list item caused the next lines to be indented too far to the right. 

The code was accidentally counting the length of the anchor text as part of the indentation. This fix forces the linter to ignore the anchor's length and stick to the standard 2-space.

Fixes #4935