### PR TITLE
fix: use pip instead of uv when setup_python is false

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -100,7 +100,12 @@ runs:
       # git+https://github.com/ansible/ansible-lint@${{ github.action_ref || 'main' }}
       # SETUPTOOLS_SCM_PRETEND_VERSION=${{ github.action_ref || 'main' }}
       run: |
-        uv tool install --python ${{ inputs.python_version }} "ansible-lint[lock] @ git+https://github.com/ansible/ansible-lint@$GH_ACTION_REF"
+        if [[ "${{ inputs.setup_python }}" == "true" ]]; then
+          uv tool install --python ${{ inputs.python_version }} "ansible-lint[lock] @ git+https://github.com/ansible/ansible-lint@$GH_ACTION_REF"
+        else
+          echo "setup_python is false, using pip"
+          pip install "ansible-lint[lock] @ git+https://github.com/ansible/ansible-lint@$GH_ACTION_REF"
+        fi
         ansible-lint --version
 
     - name: Install role and collection dependencies from requirements file

--- a/src/ansiblelint/schemas/__store__.json
+++ b/src/ansiblelint/schemas/__store__.json
@@ -24,7 +24,7 @@
     "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/inventory.json"
   },
   "meta": {
-    "etag": "2f5c7deb174136b48a4bc1d8d4399b1a175379dd4b8a863baa9c9bd56ffda489",
+    "etag": "7767a61b186dda71bd5696652e2b4342615bcbaa0e5e1595debed16a96f898a5",
     "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/meta.json"
   },
   "meta-runtime": {


### PR DESCRIPTION
## Summary
Fixes regression where users with `setup_python: false` get `uv: command not found` errors. Maintains backward compatibility by using pip installation when `setup_python` is false, while using uv when true.

## Issue Reference
- Related to reports in #4939 and comments from users with `setup_python: false`