### PR TITLE
fix: return user home directory instead of /

### DIFF
--- a/src/ansiblelint/cli.py
+++ b/src/ansiblelint/cli.py
@@ -634,6 +634,9 @@ def get_config(arguments: list[str]) -> Options:
             srcs=options.lintables,
             config_file=options.config_file,
         )
+        if method == "file system root":
+            project_dir = Path.home()
+            method = "user home directory"
         options.project_dir = os.path.expanduser(normpath(project_dir))
         log_entries.append(
             (


### PR DESCRIPTION
Per docs/usage.md (Caching), {project_dir} is determined from a CLI argument, config file, git root, or user home directory.

Bug 4943 shows that if no --project-dir is passed and there’s no .git or config file, it falls back to / instead of the home directory. This breaks cache folder initialization for non-root users, who lack write permission on /.

The fix is to rewrite the values of project_dir, method if find_project_root return method "file system root".