### PR TITLE
fix: skip_list with sub-rules no longer skips entire rule

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -116,7 +116,7 @@ repos:
       - id: trailing-whitespace
         exclude: >
           (?x)^(
-            examples/playbooks/(with-skip-tag-id|unicode).yml|
+            examples/playbooks/(with-skip-tag-id|unicode|with-multiple-yaml-violations).yml|
             examples/playbooks/example.yml|
             examples/yamllint/.*|
             test/eco/.*.result|

--- a/examples/playbooks/with-multiple-yaml-violations.yml
+++ b/examples/playbooks/with-multiple-yaml-violations.yml
@@ -1,0 +1,6 @@
+---
+- hosts: all
+  tasks:
+    - name: Trailing whitespace on this line      
+      ansible.builtin.debug:
+        msg :  "Too many spaces around colon"

--- a/src/ansiblelint/rules/__init__.py
+++ b/src/ansiblelint/rules/__init__.py
@@ -506,7 +506,6 @@ class RulesCollection:
                 continue
 
             is_targeted = any(t.startswith(f"{rule.id}[") for t in tags)
-            is_skipped = any(t.startswith(f"{rule.id}[") for t in skip_list)
 
             # rule selection logic
             if (
@@ -525,7 +524,7 @@ class RulesCollection:
 
                 # rule-level skip check
                 rule_definition = set(rule.tags) | {rule.id}
-                if rule_definition.isdisjoint(skip_list) and not is_skipped:
+                if rule_definition.isdisjoint(skip_list):
                     matches.extend(rule.getmatches(file))
 
         if tags or skip_list:
@@ -544,7 +543,8 @@ class RulesCollection:
                         filtered_matches.append(m)
                 else:
                     # no tags requested, so keep everything that wasn't skipped
-                    filtered_matches.append(m)
+                    if m.tag not in skip_list:
+                        filtered_matches.append(m)
             matches = filtered_matches
 
         return matches

--- a/test/test_with_skip_tagid.py
+++ b/test/test_with_skip_tagid.py
@@ -71,3 +71,12 @@ def test_run_skip_rule() -> None:
     )
     assert result.returncode == 0
     assert not result.stdout
+
+
+def test_skip_specific_subrule(collection: RulesCollection) -> None:
+    """Verify skipping one yaml subrule does not skip others."""
+    lintable = "examples/playbooks/with-multiple-yaml-violations.yml"
+    errs = Runner(lintable, rules=collection, skip_list=["yaml[trailing-spaces]"]).run()
+    found_tags = {e.tag for e in errs}
+    assert "yaml[trailing-spaces]" not in found_tags
+    assert "yaml[colons]" in found_tags


### PR DESCRIPTION
## PR Summary
Adding a sub-rule like `yaml[trailing-spaces]` to `skip_list` was skipping all yaml checks instead of just that one. This was a regression from PR #4892 where the skip filtering got lost during the tags refactor. The rule now runs and only the specific sub-rule matches get filtered out.

Fixes #4952.
Fixes #4040.