### PR TITLE
fix: update pre-commit hook to support Python 3.14

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -10,7 +10,7 @@
   language: python
   # version is needed to avoid accidental use of python3.10 on some platforms
   # as this is not supported by recent versions of ansible-lint and ansible-core
-  language_version: python3.13
+  language_version: python3.14
   # do not pass files to ansible-lint, see:
   # https://github.com/ansible/ansible-lint/issues/611
   pass_filenames: false


### PR DESCRIPTION
## Summary

Updates the pre-commit hook configuration to support Python 3.14 by changing `language_version` from `python3.13` to `python3.14` in `.pre-commit-hooks.yaml`.

## Problem

Users running Python 3.14 cannot use the pre-commit hook because it's pinned to Python 3.13, causing the error:
```
RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.13'
```

## Solution

The project already supports Python 3.14:
- It's listed in the Python classifiers in pyproject.toml
- `requires-python = ">=3.10"` allows 3.14
- Only the pre-commit hook config needed updating

## Testing

Users with Python 3.14 will now be able to use the pre-commit hook without encountering the interpreter error.

Fixes #4946