### PR TITLE
fix(file_utils): prevent Python files from being classified as YAML

### DIFF
--- a/src/ansiblelint/file_utils.py
+++ b/src/ansiblelint/file_utils.py
@@ -134,6 +134,13 @@ def kind_from_path(path: Path, *, base: bool = False) -> FileType:
     When called with base=True, it will return the base file type instead
     of the explicit one. That is expected to return 'yaml' for any yaml files.
     """
+    
+    # Ensure Python files are never treated as YAML.
+    # This prevents generated mock modules (mock_modules) from being
+    # incorrectly linted by yamllint.
+    if path.suffix.lower() == ".py":
+        return "text/x-python" if base else "python"
+
     # We attempt to use a relative path to the project root for glob matching.
     # This prevents parent directory names (like 'tasks') from triggering
     # false positives in kind discovery. See #4763.

--- a/test/test_kind_from_path.py
+++ b/test/test_kind_from_path.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+from ansiblelint.file_utils import kind_from_path
+
+
+def test_kind_from_path_python_basic():
+    """Ensure Python files are not treated as YAML."""
+    p = Path("example.py")
+
+    assert kind_from_path(p, base=True) == "text/x-python"
+    assert kind_from_path(p, base=False) == "python"
+
+
+def test_kind_from_path_mock_module():
+    """Ensure mock module paths are not treated as YAML."""
+    p = Path(
+        ".ansible/collections/ansible_collections/x/y/plugins/modules/test.py"
+    )
+
+    assert kind_from_path(p, base=True) == "text/x-python"
+    assert kind_from_path(p, base=False) == "python"


### PR DESCRIPTION
## Summary

Fixes an issue where Python files (including generated mock modules via `mock_modules`) are incorrectly classified as YAML files, causing yamllint to run on them and produce false-positive errors.

## Root Cause

`kind_from_path()` relies on pattern matching which may classify `.py` files as `text/yaml` in certain paths (e.g., generated mock modules under `.ansible/collections/...`).

## Fix

Added an early guard in `kind_from_path()` to ensure `.py` files are always classified as Python:

```python
if path.suffix.lower() == ".py":
    return "text/x-python" if base else "python"
```

## Result

* Prevents YAML linting from running on Python files
* Eliminates false-positive errors such as:

  * `yaml[new-line-at-end-of-file]`
  * YAML parsing failures on mock modules

## Tests

Added tests to verify:

* Python files are not classified as YAML
* Mock module paths are handled correctly

## Impact

* Minimal and safe change
* Only affects `.py` files
* No impact on YAML or other file type detection

Fixes #5013