### PR TITLE
fix: ensure configuration errors are visible to user

### DIFF
--- a/src/ansiblelint/cli.py
+++ b/src/ansiblelint/cli.py
@@ -26,6 +26,7 @@ from ansiblelint.file_utils import (
     normpath,
 )
 from ansiblelint.loaders import IGNORE_FILE
+from ansiblelint.output import console_stderr
 from ansiblelint.schemas.main import validate_file_schema
 from ansiblelint.yaml_utils import clean_json
 
@@ -74,7 +75,9 @@ def load_config(
     if config_file:
         config_path = os.path.abspath(config_file)
         if not os.path.exists(config_path):
-            _logger.error("Config file not found '%s'", config_path)
+            msg = f"Config file not found '{config_path}'"
+            _logger.error(msg)
+            console_stderr.print(f"[error]{msg}[/]")
             sys.exit(RC.INVALID_CONFIG)
     config_path = config_path or get_config_path(None, project_path=project_path)
     if not config_path or not os.path.exists(config_path):
@@ -90,7 +93,9 @@ def load_config(
     )
 
     for error in validate_file_schema(config_lintable):
-        _logger.error("Invalid configuration file %s. %s", config_path, error)
+        msg = f"Invalid configuration file {config_path}. {error}"
+        _logger.error(msg)
+        console_stderr.print(f"[error]{msg}[/]")
         sys.exit(RC.INVALID_CONFIG)
 
     config = clean_json(config_lintable.data)

--- a/src/ansiblelint/cli.py
+++ b/src/ansiblelint/cli.py
@@ -76,7 +76,11 @@ def load_config(
         config_path = os.path.abspath(config_file)
         if not os.path.exists(config_path):
             msg = f"Config file not found '{config_path}'"
-            if any(isinstance(h, logging.FileHandler) and h.baseFilename != os.path.abspath(os.devnull) for h in logging.root.handlers):
+            if any(
+                isinstance(h, logging.FileHandler)
+                and h.baseFilename != os.path.abspath(os.devnull)
+                for h in logging.root.handlers
+            ):
                 _logger.error(msg)
             console_stderr.print(f"[error]{msg}[/]")
             sys.exit(RC.INVALID_CONFIG)
@@ -95,7 +99,11 @@ def load_config(
 
     for error in validate_file_schema(config_lintable):
         msg = f"Invalid configuration file {config_path}. {error}"
-        if any(isinstance(h, logging.FileHandler) and h.baseFilename != os.path.abspath(os.devnull) for h in logging.root.handlers):
+        if any(
+            isinstance(h, logging.FileHandler)
+            and h.baseFilename != os.path.abspath(os.devnull)
+            for h in logging.root.handlers
+        ):
             _logger.error(msg)
         console_stderr.print(f"[error]{msg}[/]")
         sys.exit(RC.INVALID_CONFIG)

--- a/src/ansiblelint/cli.py
+++ b/src/ansiblelint/cli.py
@@ -76,7 +76,8 @@ def load_config(
         config_path = os.path.abspath(config_file)
         if not os.path.exists(config_path):
             msg = f"Config file not found '{config_path}'"
-            _logger.error(msg)
+            if any(isinstance(h, logging.FileHandler) and h.baseFilename != os.path.abspath(os.devnull) for h in logging.root.handlers):
+                _logger.error(msg)
             console_stderr.print(f"[error]{msg}[/]")
             sys.exit(RC.INVALID_CONFIG)
     config_path = config_path or get_config_path(None, project_path=project_path)
@@ -94,7 +95,8 @@ def load_config(
 
     for error in validate_file_schema(config_lintable):
         msg = f"Invalid configuration file {config_path}. {error}"
-        _logger.error(msg)
+        if any(isinstance(h, logging.FileHandler) and h.baseFilename != os.path.abspath(os.devnull) for h in logging.root.handlers):
+            _logger.error(msg)
         console_stderr.print(f"[error]{msg}[/]")
         sys.exit(RC.INVALID_CONFIG)
 

--- a/test/test_issue_4898.py
+++ b/test/test_issue_4898.py
@@ -1,0 +1,72 @@
+"""Tests for issue #4898: Silent configuration errors when log_path is set."""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from ansiblelint import cli
+
+
+def test_config_error_with_log_path(tmp_path: Path) -> None:
+    """Verify that configuration errors are printed to stderr even with log_path."""
+    # 1. Setup temporary paths
+    ansible_cfg = tmp_path / "ansible.cfg"
+    lint_cfg = tmp_path / ".ansible-lint"
+    log_file = tmp_path / "ansible-lint.log"
+
+    # 2. Create ansible.cfg with log_path
+    ansible_cfg.write_text(f"[defaults]\nlog_path={log_file}\n")
+
+    # 3. Create invalid .ansible-lint
+    lint_cfg.write_text("invalid_option: true\n")
+
+    # 4. Run cli.get_config and verify console_stderr.print was called
+    os.environ["ANSIBLE_CONFIG"] = str(ansible_cfg)
+
+    try:
+        with (
+            patch(
+                "ansiblelint.cli.console_stderr.print",
+            ) as mock_print,
+            pytest.raises(SystemExit) as exc,
+        ):
+            cli.get_config(["-c", str(lint_cfg)])
+
+        assert exc.value.code == 3
+
+        # 5. Verify console_stderr.print was called with error message
+        mock_print.assert_called()
+        args, _ = mock_print.call_args
+        assert "Invalid configuration file" in args[0]
+        assert "invalid_option" in args[0]
+    finally:
+        os.environ.pop("ANSIBLE_CONFIG", None)
+
+
+def test_missing_config_error_with_log_path(tmp_path: Path) -> None:
+    """Verify that missing configuration file errors are printed to stderr even with log_path."""
+    ansible_cfg = tmp_path / "ansible.cfg"
+    log_file = tmp_path / "ansible-lint.log"
+    missing_cfg = tmp_path / "non-existent.yml"
+
+    ansible_cfg.write_text(f"[defaults]\nlog_path={log_file}\n")
+    os.environ["ANSIBLE_CONFIG"] = str(ansible_cfg)
+
+    try:
+        with (
+            patch(
+                "ansiblelint.cli.console_stderr.print",
+            ) as mock_print,
+            pytest.raises(SystemExit) as exc,
+        ):
+            cli.get_config(["-c", str(missing_cfg)])
+
+        assert exc.value.code == 3
+
+        mock_print.assert_called()
+        args, _ = mock_print.call_args
+        assert "Config file not found" in args[0]
+    finally:
+        os.environ.pop("ANSIBLE_CONFIG", None)

--- a/test/test_issue_4898.py
+++ b/test/test_issue_4898.py
@@ -1,5 +1,6 @@
 """Tests for issue #4898: Silent configuration errors when log_path is set."""
 
+import logging
 import os
 from pathlib import Path
 from unittest.mock import patch
@@ -10,7 +11,7 @@ from ansiblelint import cli
 
 
 def test_config_error_with_log_path(tmp_path: Path) -> None:
-    """Verify that configuration errors are printed to stderr even with log_path."""
+    """Verify that configuration errors are printed to stderr and logged to log_path."""
     # 1. Setup temporary paths
     ansible_cfg = tmp_path / "ansible.cfg"
     lint_cfg = tmp_path / ".ansible-lint"
@@ -22,14 +23,18 @@ def test_config_error_with_log_path(tmp_path: Path) -> None:
     # 3. Create invalid .ansible-lint
     lint_cfg.write_text("invalid_option: true\n")
 
-    # 4. Run cli.get_config and verify console_stderr.print was called
+    # 4. Run cli.get_config and verify console_stderr.print and _logger.error were called
     os.environ["ANSIBLE_CONFIG"] = str(ansible_cfg)
+    original_handlers = list(logging.root.handlers)
+
+    # Simulate Ansible's FileHandler setup when log_path is configured in a fresh process
+    handler = logging.FileHandler(str(log_file))
+    logging.root.addHandler(handler)
 
     try:
         with (
-            patch(
-                "ansiblelint.cli.console_stderr.print",
-            ) as mock_print,
+            patch("ansiblelint.cli.console_stderr.print") as mock_print,
+            patch("ansiblelint.cli._logger.error") as mock_error,
             pytest.raises(SystemExit) as exc,
         ):
             cli.get_config(["-c", str(lint_cfg)])
@@ -41,24 +46,68 @@ def test_config_error_with_log_path(tmp_path: Path) -> None:
         args, _ = mock_print.call_args
         assert "Invalid configuration file" in args[0]
         assert "invalid_option" in args[0]
+
+        # 6. Verify _logger.error was also called because handlers are configured
+        mock_error.assert_called_once()
+        args, _ = mock_error.call_args
+        assert "Invalid configuration file" in args[0]
     finally:
         os.environ.pop("ANSIBLE_CONFIG", None)
+        handler.close()
+        logging.root.handlers = original_handlers
+
+
+def test_config_error_without_log_path(tmp_path: Path) -> None:
+    """Verify that configuration errors are printed to stderr but NOT logged via _logger to avoid duplicates."""
+    # 1. Setup temporary paths
+    lint_cfg = tmp_path / ".ansible-lint"
+
+    # 2. Create invalid .ansible-lint
+    lint_cfg.write_text("invalid_option: true\n")
+
+    original_handlers = list(logging.root.handlers)
+
+    # 3. Run cli.get_config and verify only console_stderr.print is called
+    try:
+        with (
+            patch("ansiblelint.cli.console_stderr.print") as mock_print,
+            patch("ansiblelint.cli._logger.error") as mock_error,
+            pytest.raises(SystemExit) as exc,
+        ):
+            cli.get_config(["-c", str(lint_cfg)])
+
+        assert exc.value.code == 3
+
+        # 4. Verify console_stderr.print was called
+        mock_print.assert_called()
+        args, _ = mock_print.call_args
+        assert "Invalid configuration file" in args[0]
+        assert "invalid_option" in args[0]
+
+        # 5. Verify _logger.error was NOT called to avoid duplicate output to stderr
+        mock_error.assert_not_called()
+    finally:
+        logging.root.handlers = original_handlers
 
 
 def test_missing_config_error_with_log_path(tmp_path: Path) -> None:
-    """Verify that missing configuration file errors are printed to stderr even with log_path."""
+    """Verify that missing configuration file errors are printed to stderr and logged even with log_path."""
     ansible_cfg = tmp_path / "ansible.cfg"
     log_file = tmp_path / "ansible-lint.log"
     missing_cfg = tmp_path / "non-existent.yml"
 
     ansible_cfg.write_text(f"[defaults]\nlog_path={log_file}\n")
     os.environ["ANSIBLE_CONFIG"] = str(ansible_cfg)
+    original_handlers = list(logging.root.handlers)
+
+    # Simulate Ansible's FileHandler setup when log_path is configured in a fresh process
+    handler = logging.FileHandler(str(log_file))
+    logging.root.addHandler(handler)
 
     try:
         with (
-            patch(
-                "ansiblelint.cli.console_stderr.print",
-            ) as mock_print,
+            patch("ansiblelint.cli.console_stderr.print") as mock_print,
+            patch("ansiblelint.cli._logger.error") as mock_error,
             pytest.raises(SystemExit) as exc,
         ):
             cli.get_config(["-c", str(missing_cfg)])
@@ -68,5 +117,36 @@ def test_missing_config_error_with_log_path(tmp_path: Path) -> None:
         mock_print.assert_called()
         args, _ = mock_print.call_args
         assert "Config file not found" in args[0]
+
+        mock_error.assert_called_once()
+        args, _ = mock_error.call_args
+        assert "Config file not found" in args[0]
     finally:
         os.environ.pop("ANSIBLE_CONFIG", None)
+        handler.close()
+        logging.root.handlers = original_handlers
+
+
+def test_missing_config_error_without_log_path(tmp_path: Path) -> None:
+    """Verify that missing configuration file errors are printed but not logged via _logger when log_path is not set."""
+    missing_cfg = tmp_path / "non-existent.yml"
+    original_handlers = list(logging.root.handlers)
+
+    try:
+        with (
+            patch("ansiblelint.cli.console_stderr.print") as mock_print,
+            patch("ansiblelint.cli._logger.error") as mock_error,
+            pytest.raises(SystemExit) as exc,
+        ):
+            cli.get_config(["-c", str(missing_cfg)])
+
+        assert exc.value.code == 3
+
+        mock_print.assert_called()
+        args, _ = mock_print.call_args
+        assert "Config file not found" in args[0]
+
+        # Should not log via _logger to prevent duplicate output to stderr
+        mock_error.assert_not_called()
+    finally:
+        logging.root.handlers = original_handlers


### PR DESCRIPTION
Resolves the 'silent failure' bug where configuration errors were suppressed when a log_path was configured.

### Changes:
- **Bug Fix**: Refactored load_config in cli.py to explicitly route critical schema and file-not-found errors to console_stderr. This ensures immediate terminal feedback regardless of logging configuration.
- **Regression Testing**: Added test/test_issue_4898.py to verify the fix and prevent future regressions.
- **Infrastructure**: Updated src/ansiblelint/schemas/__store__.json to resolve workspace linting issues.

Fixes #4898
Closes #5022