### PR TITLE
fix: update malformed block regex and bump pathspec upper bound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
   "filelock>=3.8.2",
   "jsonschema>=4.10.0",
   "packaging>=22.0",
-  "pathspec>=1.0.3,<1.1.0",
+  "pathspec>=1.0.3,<1.2.0",
   "pyyaml>=6.0.1 ; python_version < '3.14'",
   "pyyaml>=6.0.1 ; python_version >= '3.14'",  # py314 support
   "referencing>=0.36.2",

--- a/src/ansiblelint/rules/syntax_check.py
+++ b/src/ansiblelint/rules/syntax_check.py
@@ -57,7 +57,7 @@ OUTPUT_PATTERNS = (
     KnownError(
         tag="malformed",
         regex=re.compile(
-            rf"^(statically imported: (?P<filename>[\w\/\.\-]+)\n)?{_ansible_error_prefix}(?P<title>A malformed block was encountered while loading a block[^\n]*)",
+            rf"^(statically imported: (?P<filename>[\w\/\.\-]+)\n)?{_ansible_error_prefix}(?P<title>A malformed block was encountered while loading (?:a block|[a-z_]+\.)[^\n]*)",
             re.MULTILINE | re.DOTALL | re.DOTALL,
         ),
     ),

--- a/src/ansiblelint/rules/syntax_check.py
+++ b/src/ansiblelint/rules/syntax_check.py
@@ -57,7 +57,7 @@ OUTPUT_PATTERNS = (
     KnownError(
         tag="malformed",
         regex=re.compile(
-            rf"^(statically imported: (?P<filename>[\w\/\.\-]+)\n)?{_ansible_error_prefix}(?P<title>A malformed block was encountered while loading (?:a block|[a-z_]+\.)[^\n]*)",
+            rf"^(statically imported: (?P<filename>[\w\/\.\-]+)\n)?{_ansible_error_prefix}(?P<title>A malformed block was encountered while loading (?:a )?block[^\n]*)",
             re.MULTILINE | re.DOTALL | re.DOTALL,
         ),
     ),

--- a/uv.lock
+++ b/uv.lock
@@ -194,7 +194,7 @@ requires-dist = [
     { name = "filelock", specifier = ">=3.8.2" },
     { name = "jsonschema", specifier = ">=4.10.0" },
     { name = "packaging", specifier = ">=22.0" },
-    { name = "pathspec", specifier = ">=1.0.3,<1.1.0" },
+    { name = "pathspec", specifier = ">=1.0.3,<1.2.0" },
     { name = "pyyaml", marker = "python_full_version < '3.14'", specifier = ">=6.0.1" },
     { name = "pyyaml", marker = "python_full_version >= '3.14'", specifier = ">=6.0.1" },
     { name = "referencing", specifier = ">=0.36.2" },


### PR DESCRIPTION
## Summary

- [ansible/ansible#86603](https://github.com/ansible/ansible/pull/86603) refactored `block.py` and changed the error message from `"loading a block"` to `"loading block"` (dropped `"a "`), breaking the hardcoded regex in `syntax_check.py` that matches malformed block errors
- This caused `test_import_tasks[1]` to fail on `py312-devel` and `py314-devel` since April 1, which cascaded to fail the required `tox / check` gate
- Updated the regex to match both old (`"loading a block"`) and new (`"loading block"`) formats
- Bumped `pathspec` upper bound from `<1.1.0` to `<1.2.0` to fix Fedora Rawhide RPM builds — the old bound was a Renovate artifact, not intentional, and pathspec 1.1.x has no breaking changes affecting ansible-lint

## Test plan

- [x] `test_import_tasks[1]` passes locally with ansible-core devel (2.22.0.dev0)
- [x] `test_example_syntax_error[1]` still passes (no false positive matching)
- [x] `py312-devel` and `py314-devel` CI jobs pass
- [x] `tox / check` gate passes
- [x] `rpm-build:fedora-rawhide-x86_64` passes