### PR TITLE
fix: role argument spec: fix typo in attribute schema

### DIFF
--- a/src/ansiblelint/schemas/role-arg-spec.json
+++ b/src/ansiblelint/schemas/role-arg-spec.json
@@ -44,7 +44,7 @@
             }
           ]
         },
-        "platform": {
+        "platforms": {
           "oneOf": [
             {
               "type": "string"


### PR DESCRIPTION
It looks like I introduced a typo in #4018 for the `platforms` parameter (I wrote `platform` in that PR). The correct name is `platforms`, as can be seen here: https://github.com/ansible-community/antsibull-docs/blob/656fdf39130ebe1180070f53813bede1b8bc949b/src/antsibull_docs/schemas/docs/base.py#L633