### PR TITLE
fix: support example format indicator, prevent ansible-lint from producing load-failure on valid non-YAML examples

### DIFF
--- a/examples/.collection/plugins/modules/tests/gamma.py
+++ b/examples/.collection/plugins/modules/tests/gamma.py
@@ -28,10 +28,9 @@ notes:
 """
 
 EXAMPLES = """
-- name: test task-1
-  company_name.coll_1.mod_1:
-    foo: some value
-    bar: candidate
+# fmt: text
+
+This is some text. Nothing to see.
 """
 
 RETURN = """

--- a/src/ansiblelint/runner.py
+++ b/src/ansiblelint/runner.py
@@ -662,9 +662,9 @@ class Runner:
 
     def plugin_children(self, lintable: Lintable) -> list[Lintable]:
         """Collect lintable sections from plugin file."""
-        offset, content = parse_examples_from_plugin(lintable)
-        if not content:
-            # No examples, nothing to see here
+        offset, content, content_type = parse_examples_from_plugin(lintable)
+        if not content or content_type != "yaml":
+            # No (YAML) examples, nothing to see here
             return []
         examples = Lintable(
             name=lintable.name,

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -116,6 +116,10 @@ LINE_COLUMN_REGEX = re.compile(
     r".*line (?P<line>\d+), column (?P<column>\d+).*", flags=re.MULTILINE
 )
 
+# cspell: ignore yamllinter
+# Taken from ansible-core's test/lib/ansible_test/_util/controller/sanity/yamllint/yamllinter.py
+FMT_RE = re.compile(r"^# fmt:\s+(\S+)")
+
 
 _logger = logging.getLogger(__name__)
 
@@ -1351,7 +1355,7 @@ def convert_to_boolean(value: Any) -> bool:
     return bool(boolean(value))  # type: ignore[no-untyped-call]
 
 
-def parse_examples_from_plugin(lintable: Lintable) -> tuple[int, str]:
+def parse_examples_from_plugin(lintable: Lintable) -> tuple[int, str, str]:
     """Parse yaml inside plugin EXAMPLES string.
 
     Store a line number offset to realign returned line numbers later
@@ -1366,11 +1370,22 @@ def parse_examples_from_plugin(lintable: Lintable) -> tuple[int, str]:
                 break
 
     docs = read_docstring(str(lintable.path.resolve(strict=False)))  # type: ignore[no-untyped-call]
-    examples = docs["plainexamples"]
+    examples = docs["plainexamples"] or ""
+
+    # Extract example format type (if present).
+    # See https://github.com/ansible/ansible/pull/71184 and https://github.com/ansible/ansible-lint/issues/5037
+    examples_type = "yaml"
+    if examples:
+        fmt_match = FMT_RE.match(examples.lstrip())
+        if fmt_match:
+            examples_type = fmt_match.group(1)
 
     # Ignore the leading newline and lack of document start
     # as including those in EXAMPLES would be weird.
-    return offset, (f"---{examples}" if examples else "")
+    if examples_type == "yaml":
+        examples = f"---{examples}" if examples else ""
+
+    return offset, examples, examples_type
 
 
 @lru_cache


### PR DESCRIPTION
Support example format indicator for Ansible plugin/module documentation. This prevents ansible-lint from producing load-failure on valid non-YAML examples that are tagged correctly as non-YAML.

Fixes #5037.