### PR TITLE
fix: Update stale rulebook schema to match upstream ansible-rulebook

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -1,7 +1,6 @@
 CLICOLOR
 Chamoulaud
 Codeclimate
-DOTGLOB
 FQCN
 FQCNs
 Fimport

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -12,6 +12,8 @@ dictionaries:
   - python
   - python-common
   - words
+words:
+  - DOTGLOB
 enabled: true
 useGitignore: true
 ignorePaths:

--- a/src/ansiblelint/schemas/__store__.json
+++ b/src/ansiblelint/schemas/__store__.json
@@ -52,7 +52,7 @@
     "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/role-arg-spec.json"
   },
   "rulebook": {
-    "etag": "2edc2ea8cd40771769ffe13618c08ea24c8c39af99b8141dfb9468249f04879b",
+    "etag": "2e542d6cee7f9f08897220ac3460112e6df7f16b2a41b95b23b427d188051d9f",
     "url": "https://raw.githubusercontent.com/ansible/ansible-rulebook/main/ansible_rulebook/schema/ruleset_schema.json"
   },
   "tasks": {

--- a/src/ansiblelint/schemas/rulebook.json
+++ b/src/ansiblelint/schemas/rulebook.json
@@ -221,9 +221,6 @@
                             },
                             {
                                 "$ref": "#/$defs/shutdown-action"
-                            },
-                            {
-                                "$ref": "#/$defs/pg-notify-action"
                             }
                         ]
                     }
@@ -262,9 +259,6 @@
                         },
                         {
                             "$ref": "#/$defs/shutdown-action"
-                        },
-                        {
-                            "$ref": "#/$defs/pg-notify-action"
                         }
                     ]
                 }
@@ -568,42 +562,6 @@
             },
             "required": [
                 "run_workflow_template"
-            ],
-            "additionalProperties": false
-        },
-        "pg-notify-action": {
-            "type": "object",
-            "properties": {
-                "pg_notify": {
-                    "type": "object",
-                    "properties": {
-                        "dsn": {
-                            "type": "string"
-                        },
-                        "channel": {
-                            "type": "string"
-                        },
-                        "event": {
-                            "type": [
-                                "string",
-                                "object"
-                            ]
-                        },
-                        "remove_meta": {
-                            "type": "boolean",
-                            "default": false
-                        }
-                    },
-                    "required": [
-                        "dsn",
-                        "channel",
-                        "event"
-                    ],
-                    "additionalProperties": false
-                }
-            },
-            "required": [
-                "pg_notify"
             ],
             "additionalProperties": false
         },


### PR DESCRIPTION
## Summary

The upstream ansible-rulebook project removed the `pg_notify` action in ansible/ansible-rulebook#912 (merged May 19, 2026). This caused `tox -e lint` to fail because the `update json schemas` prek hook detects the drift and auto-modifies the local schema copy, leaving the git tree dirty.

 Additionally, the cspell + remove unused and sort dictionary hook was removing DOTGLOB from `.config/dictionary.txt` during CI runs because it only appears as part of `wcmatch.pathlib.DOTGLOB` in code, not as a standalone word.

Fixes `tox / lint-pkg-schemas-eco` CI failure on main.

## Changes

- **`src/ansiblelint/schemas/rulebook.json`** — Removed the `pg-notify-action` definition and all `$ref` references to it (synced with upstream).
- **`src/ansiblelint/schemas/__store__.json`** — Updated the etag hash for the rulebook schema.
 - **`cspell.config.yaml`** — Added DOTGLOB to inline words: list to prevent pre-commit hook from removing it
  - **`.config/dictionary.txt`** — Removed DOTGLOB (moved to inline config to prevent auto-removal)

Schema changes were auto-generated by `prek run --all-files` (`update json schemas` hook). Dictionary changes prevent the cspell hook from causing dirty git status in CI.


## Test plan

- [x] `tox -e lint` passes locally after applying these changes.
- [x] CI `tox / lint-pkg-schemas-eco` should go green.