### PR TITLE
chore: clarify yaml reformatting under fix

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -78,7 +78,8 @@ warn_list:
 # Some rules can transform files to fix (or make it easier to fix) identified
 # errors. `ansible-lint --fix` will reformat YAML files and run these transforms.
 # By default it will run all transforms (effectively `write_list: ["all"]`).
-# You can disable running transforms by setting `write_list: ["none"]`.
+# You can disable running rule-specific transforms by setting `write_list: ["none"]`.
+# This does not disable YAML reformatting when `--fix` is used.
 # Or only enable a subset of rule transforms by listing rules/tags here.
 # write_list:
 #   - all

--- a/docs/autofix.md
+++ b/docs/autofix.md
@@ -2,9 +2,16 @@
 
 Ansible-lint autofix can fix or simplify fixing issues identified by that rule. `ansible-lint --fix` will reformat YAML files and run transform for the given
 rules. You can limit the effective rule transforms (the 'write_list') by passing
-a keywords 'all' or 'none' or a comma separated list of rule ids or rule tags.
+the keywords 'all' or 'none' or a comma separated list of rule ids or rule tags.
 By default it will run all transforms (effectively `write_list: ["all"]`).
-You can disable running transforms by setting `write_list: ["none"]`. Or only enable a subset of rule transforms by listing rules/tags here.
+You can disable running rule-specific transforms by setting
+`write_list: ["none"]`. Or only enable a subset of rule transforms by listing
+rules/tags here.
+
+The `write_list` controls rule-specific transforms only. YAML reformatting still
+runs whenever `--fix` is used, even when `write_list` is set to `["none"]` or
+when specific `yaml[...]` rules are listed in `skip_list` or `warn_list`. Run
+without `--fix` if you need to keep YAML formatting unchanged.
 
 Following is the list of supported rules covered under autofix functionality.
 

--- a/src/ansiblelint/rules/yaml.md
+++ b/src/ansiblelint/rules/yaml.md
@@ -21,6 +21,12 @@ skip_list:
   - yaml[indentation]
 ```
 
+These settings control whether YAML violations are reported. They do not disable
+YAML reformatting performed by [`--fix`](../autofix.md). When `--fix` is used,
+Ansible-lint can still update YAML formatting for files that contain skipped
+`yaml[...]` violations. Run without `--fix` if you need to leave those formatting
+details untouched.
+
 If you want Ansible-lint to report YAML syntax violations as warnings, and not
 fatal errors, add tag identifiers to the `warn_list` in your configuration, for
 example:


### PR DESCRIPTION
## Summary
- Clarify that write_list controls rule-specific transforms, not YAML reformatting.
- Note that skipped or warned yaml[...] rules can still be reformatted when --fix is used.
- Update the sample config comments to match the autofix behavior.

Fixes #4344

## Testing
- git diff --cached --check
- git diff --check