### PR TITLE
fix: ignore skip lookup across rules

### DIFF
--- a/src/ansiblelint/__main__.py
+++ b/src/ansiblelint/__main__.py
@@ -70,8 +70,9 @@ from ansiblelint.skip_utils import normalize_tag
 from ansiblelint.version import __version__
 
 if TYPE_CHECKING:
-    # RulesCollection must be imported lazily or ansible gets imported too early.
+    from collections.abc import Iterable
 
+    # RulesCollection must be imported lazily or ansible gets imported too early.
     from ansiblelint.rules import RulesCollection
     from ansiblelint.runner import LintResult
 
@@ -286,10 +287,10 @@ def fix(runtime_options: Options, result: LintResult, rules: RulesCollection) ->
 # to the rule, it is treated as skipped here and does not show up
 # even as a warning.
 # [1] https://github.com/ansible/ansible-lint/issues/3068
-def _rule_is_skipped(tag: str, rules: set[IgnoreRule]) -> bool:
+def _rule_is_skipped(tag: str, rules: Iterable[IgnoreRule]) -> bool:
     for rule in rules:
         if tag != rule.rule:
-            return False
+            continue
         return IgnoreRuleQualifier.SKIP in rule.qualifiers
     return False
 

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -2,8 +2,10 @@
 
 from pathlib import Path
 
+from ansiblelint.__main__ import _rule_is_skipped
 from ansiblelint.constants import RC
 from ansiblelint.file_utils import Lintable
+from ansiblelint.loaders import IgnoreRule, IgnoreRuleQualifier
 from ansiblelint.testing import run_ansible_lint
 
 
@@ -115,6 +117,16 @@ def test_ignore_file_without_skip_and_strict(tmp_path: Path) -> None:
 
     # Should return 2 because there's a warning and we're in strict mode
     assert result.returncode == RC.VIOLATIONS_FOUND
+
+
+def test_rule_is_skipped_checks_all_ignore_rules() -> None:
+    """Validate that skip qualifier lookup does not stop at an unrelated rule."""
+    rules = (
+        IgnoreRule("yaml[truthy]", frozenset()),
+        IgnoreRule("yaml[indentation]", frozenset({IgnoreRuleQualifier.SKIP})),
+    )
+
+    assert _rule_is_skipped("yaml[indentation]", rules)
 
 
 def test_skip_list_and_strict(tmp_path: Path) -> None:


### PR DESCRIPTION
Fixes #5059.

## Summary
- continue scanning ignore rules when the current entry does not match the lint tag
- add a regression test where the matching skip rule appears after an unrelated rule

## Testing
- uv run --no-dev --with ruff ruff check src/ansiblelint/__main__.py test/test_app.py
- uv run --no-dev --with pytest --with mypy python -m pytest test/test_app.py -k 'rule_is_skipped or ignore_file_with_skip_and_strict or ignore_file_without_skip_and_strict'