### PR TITLE
fix(ci): switch devel tests from py312 to py313

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -32,7 +32,7 @@ jobs:
         lint-pkg-schemas-eco:tox -e lint;tox -e pkg;tox -e schemas;tox -e eco
         hook
         docs
-        py312-devel
+        py313-devel
         py310-lower
         py312-lower
         py314-devel

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -39,7 +39,9 @@ from collections.abc import (
     MutableMapping,
     Sequence,
 )
-from dataclasses import _MISSING_TYPE, dataclass, field
+from dataclasses import MISSING, dataclass, field
+
+_MISSING_TYPE = type(MISSING)
 from functools import cache, lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING, Any

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -40,8 +40,6 @@ from collections.abc import (
     Sequence,
 )
 from dataclasses import MISSING, dataclass, field
-
-_MISSING_TYPE = type(MISSING)
 from functools import cache, lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -909,8 +907,8 @@ class Task(Mapping[str, Any]):
 
     raw_task: MutableMapping[str, Any]
     filename: str = ""
-    _normalized_task: MutableMapping[str, Any] | _MISSING_TYPE = field(
-        init=False, repr=False
+    _normalized_task: MutableMapping[str, Any] = field(
+        init=False, repr=False, default=MISSING  # type: ignore[assignment]
     )
     error: MatchError | None = None
     position: str = ""
@@ -971,7 +969,7 @@ class Task(Mapping[str, Any]):
                 # When we cannot normalize it, we just use the raw task instead
                 # to avoid adding extra complexity to the rules.
                 self._normalized_task = self.raw_task
-        if isinstance(self._normalized_task, _MISSING_TYPE):
+        if self._normalized_task is MISSING:
             msg = "Task was not normalized"
             raise TypeError(msg)
         return self._normalized_task

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -907,8 +907,10 @@ class Task(Mapping[str, Any]):
 
     raw_task: MutableMapping[str, Any]
     filename: str = ""
-    _normalized_task: MutableMapping[str, Any] = field(
-        init=False, repr=False, default=MISSING  # type: ignore[assignment]
+    _normalized_task: MutableMapping[str, Any] | Any = field(
+        init=False,
+        repr=False,
+        default=MISSING,
     )
     error: MatchError | None = None
     position: str = ""


### PR DESCRIPTION
## Summary
- ansible-core devel (2.22.0.dev0) dropped Python 3.12 support, requiring Python >= 3.13
- This broke the `py312-devel` CI job across all PRs and main
- Switches `py312-devel` → `py313-devel` in the tox workflow to match the updated support matrix
- `py314-devel` is already in the matrix and passing, confirming devel works on Python >= 3.13
- Fixes Python 3.15 compatibility for Fedora rawhide RPM build by replacing the private `_MISSING_TYPE` import with `type(MISSING)`

Ref: https://github.com/ansible/tox-ansible/pull/562