### PR TITLE
fix: respect skip_list for yaml[comments] during --fix

### DIFF
--- a/src/ansiblelint/transformer.py
+++ b/src/ansiblelint/transformer.py
@@ -50,6 +50,10 @@ class Transformer:
         """Initialize a Transformer instance."""
         self.write_set = self.effective_write_set(options.write_list)
         self.write_exclude_set = self.effective_write_set(options.write_exclude_list)
+        self.fix_comment_spaces = not any(
+            tag in (options.skip_list or [])
+            for tag in ("yaml[comments]", "yaml")
+        )
 
         self.matches: list[MatchError] = result.matches
         self.files: set[Lintable] = result.files
@@ -110,6 +114,7 @@ class Transformer:
                 yaml = FormattedYAML(
                     # Ansible only uses YAML 1.1, but others files should use newer 1.2 (ruamel.yaml defaults to 1.2)
                     version=(1, 1) if file.is_owned_by_ansible() else None,
+                    fix_comment_spaces=self.fix_comment_spaces,
                 )
 
                 ruamel_data = yaml.load(data)

--- a/src/ansiblelint/yaml_utils.py
+++ b/src/ansiblelint/yaml_utils.py
@@ -620,6 +620,10 @@ class FormattedEmitter(Emitter):
 
     _in_empty_flow_map = False
 
+    # Set to False when yaml[comments] is in skip_list to avoid reformatting
+    # comments even while other fixes are applied. See github issue #5048.
+    fix_comment_spaces = True
+
     @property
     def _is_root_level_sequence(self) -> bool:
         """Return True if this is a sequence at the root level of the yaml document."""
@@ -831,7 +835,8 @@ class FormattedEmitter(Emitter):
             # single blank lines in post comments
             value = self._re_repeat_blank_lines.sub("\n\n", value)
 
-        value = self._re_missing_comment_space.sub(r"\1 ", value)
+        if self.fix_comment_spaces:
+            value = self._re_missing_comment_space.sub(r"\1 ", value)
 
         comment.value = value
 
@@ -871,6 +876,7 @@ class FormattedYAML(YAML):
         plug_ins: list[str] | None = None,
         version: tuple[int, int] | None = None,
         config: dict[str, bool | int | str] | None = None,
+        fix_comment_spaces: bool = True,
     ):
         """Return a configured ``ruamel.yaml.YAML`` instance.
 
@@ -964,6 +970,16 @@ class FormattedYAML(YAML):
 
         # If someone doesn't want our FormattedEmitter, they can change it.
         self.Emitter = FormattedEmitter
+
+        # When yaml[comments] is in skip_list, disable the comment-space
+        # reformatting in the emitter so --fix doesn't touch comments even
+        # while applying other transforms (see github issue #5048).
+        if not fix_comment_spaces:
+
+            class _FormattedEmitterNoCommentFix(FormattedEmitter):
+                fix_comment_spaces = False
+
+            self.Emitter = _FormattedEmitterNoCommentFix
 
         # ignore invalid preferred_quote setting
         if preferred_quote in ['"', "'"]:

--- a/src/ansiblelint/yaml_utils.py
+++ b/src/ansiblelint/yaml_utils.py
@@ -624,6 +624,10 @@ class FormattedEmitter(Emitter):
 
     _in_empty_flow_map = False
 
+    # Set to False when yaml[comments] is in skip_list to avoid reformatting
+    # comments even while other fixes are applied. See github issue #5048.
+    fix_comment_spaces = True
+
     @property
     def _is_root_level_sequence(self) -> bool:
         """Return True if this is a sequence at the root level of the yaml document."""
@@ -835,7 +839,8 @@ class FormattedEmitter(Emitter):
             # single blank lines in post comments
             value = self._re_repeat_blank_lines.sub("\n\n", value)
 
-        value = self._re_missing_comment_space.sub(r"\1 ", value)
+        if self.fix_comment_spaces:
+            value = self._re_missing_comment_space.sub(r"\1 ", value)
 
         comment.value = value
 
@@ -875,6 +880,7 @@ class FormattedYAML(YAML):
         plug_ins: list[str] | None = None,
         version: tuple[int, int] | None = None,
         config: dict[str, bool | int | str] | None = None,
+        fix_comment_spaces: bool = True,
     ):
         """Return a configured ``ruamel.yaml.YAML`` instance.
 
@@ -968,6 +974,16 @@ class FormattedYAML(YAML):
 
         # If someone doesn't want our FormattedEmitter, they can change it.
         self.Emitter = FormattedEmitter
+
+        # When yaml[comments] is in skip_list, disable the comment-space
+        # reformatting in the emitter so --fix doesn't touch comments even
+        # while applying other transforms (see github issue #5048).
+        if not fix_comment_spaces:
+
+            class _FormattedEmitterNoCommentFix(FormattedEmitter):
+                fix_comment_spaces = False
+
+            self.Emitter = _FormattedEmitterNoCommentFix
 
         # ignore invalid preferred_quote setting
         if preferred_quote in ['"', "'"]:


### PR DESCRIPTION
## Summary

Fixes #5048.

When `yaml[comments]` is in `skip_list`, `--fix` was still modifying comments (e.g. `#test-comment` → `# test-comment`). This is a regression introduced in v25.12.1.

## Root cause

PR that introduced the comment-space normalization added this line to `FormattedEmitter.write_comment()` in `yaml_utils.py`:

```python
value = self._re_missing_comment_space.sub(r"\1 ", value)
```

This fires unconditionally on every `yaml.dumps()` call, regardless of `skip_list`. The transformer correctly skips the `yaml[comments]` rule transform, but the YAML dumper runs independently and reformats comments as a side-effect of writing any other fix.

## Fix

Three small changes:

1. **`FormattedEmitter`**: add `fix_comment_spaces = True` class variable; guard the regex substitution behind it.

2. **`FormattedYAML.__init__`**: accept `fix_comment_spaces: bool = True` kwarg; when `False`, install a dynamic subclass of `FormattedEmitter` with `fix_comment_spaces = False` (avoids mutating the shared class variable).

3. **`Transformer.__init__`**: compute `self.fix_comment_spaces` from `options.skip_list` — `False` when `yaml[comments]` or `yaml` is in the skip list — and pass it to `FormattedYAML`.

## Verification

With `yaml[comments]` in `skip_list` and `--fix`:
- **Before fix**: `#test-comment` → `# test-comment` (file modified)
- **After fix**: file left untouched

Without `skip_list` entry, behaviour is unchanged — comments are still normalised.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * YAML rewrites now preserve comments without automatically inserting a space after the comment marker when comment formatting checks are skipped.
  * Other YAML formatting continues to be applied as expected.
  * Improved control over comment formatting during automatic file updates, reducing unintended changes to existing YAML comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->