### PR TITLE
fix: suppress ruff PLW0717 to unblock renovate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -321,6 +321,7 @@ ignore = [
   "PERF203",
   "PLR",
   "PLW0603",  # global lock file in cache dir
+  "PLW0717",  # try-too-many-statements, too many to refactor now
   "RUF012",  # Mutable class attributes should be annotated with `typing.ClassVar`
   "RUF045",  # Assignment without annotation found in dataclass body
   # part of preview rules:


### PR DESCRIPTION
## Summary
- ruff 0.15.17 enables PLW0717 (try-too-many-statements) by default, which breaks the renovate lock file PR (#5075)
- Added PLW0717 to the ruff ignore list — same as what was done in vscode-ansible (#2719)

## Test plan
- [ ] CI passes (lint-pkg-schemas-eco specifically)
- [ ] Renovate PR #5075 passes after rebase