### PR TITLE
fix: detect role roots in namespace subdirectories (#5079)

### DIFF
--- a/examples/namespace_roles_repro/.ansible-lint.yml
+++ b/examples/namespace_roles_repro/.ansible-lint.yml
@@ -1,0 +1,2 @@
+---
+offline: true

--- a/examples/namespace_roles_repro/ansible.cfg
+++ b/examples/namespace_roles_repro/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+roles_path = ./roles/my_namespace

--- a/examples/namespace_roles_repro/roles/my_namespace/myBadRoleName/meta/main.yml
+++ b/examples/namespace_roles_repro/roles/my_namespace/myBadRoleName/meta/main.yml
@@ -1,0 +1,7 @@
+---
+galaxy_info:
+  author: test
+  description: reproducer for issue 5079
+  license: MIT
+  min_ansible_version: "2.16"
+dependencies: []

--- a/examples/namespace_roles_repro/roles/my_namespace/myBadRoleName/tasks/main.yml
+++ b/examples/namespace_roles_repro/roles/my_namespace/myBadRoleName/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Example task
+  ansible.builtin.debug:
+    msg: hello

--- a/src/ansiblelint/file_utils.py
+++ b/src/ansiblelint/file_utils.py
@@ -16,7 +16,6 @@ import pathspec
 import wcmatch.pathlib
 from yaml.error import YAMLError
 
-from ansiblelint.app import get_app
 from ansiblelint.config import ANSIBLE_OWNED_KINDS, BASE_KINDS, Options, options
 from ansiblelint.constants import CONFIG_FILENAMES, FileType, States
 
@@ -27,6 +26,28 @@ if TYPE_CHECKING:
 
 
 _logger = logging.getLogger(__package__)
+
+ROLE_SUBDIRS = ("tasks", "meta", "vars", "defaults", "handlers")
+
+
+def _has_role_subdirs(path: Path) -> bool:
+    """Return true if path is a directory with typical role subfolders."""
+    return path.is_dir() and any((path / subdir).is_dir() for subdir in ROLE_SUBDIRS)
+
+
+def find_role_dir(path: Path) -> Path | None:
+    """Return the innermost roles/ descendant that looks like a role root."""
+    current = path if path.is_dir() else path.parent
+    found: Path | None = None
+    while current.name:
+        if (
+            "roles" in current.parts
+            and current.name != "roles"
+            and _has_role_subdirs(current)
+        ):
+            found = current
+        current = current.parent
+    return found
 
 
 def abspath(path: str, base_dir: str) -> str:
@@ -156,21 +177,29 @@ def kind_from_path(path: Path, *, base: bool = False) -> FileType:
                     | wcmatch.pathlib.DOTGLOB
                 ),
             ):
-                return str(k)  # type: ignore[return-value]
+                matched_kind = str(k)
+                # Namespace folders under roles/ can match **/roles/*/ without
+                # being role roots themselves. See #5079.
+                if (
+                    matched_kind == "role"
+                    and path.is_dir()
+                    and not _has_role_subdirs(path)
+                ):
+                    continue
+                return matched_kind  # type: ignore[return-value]
 
     if base:
         # Unknown base file type is default
         return ""
 
+    if path.is_dir() and _has_role_subdirs(path):
+        return "role"
+
     if path.is_dir():
-        known_role_subfolders = ("tasks", "meta", "vars", "defaults", "handlers")
-        for filename in known_role_subfolders:
-            if (path / filename).is_dir():
-                return "role"
         _logger.debug(
             "Folder `%s` does not look like a role due to missing any of the common subfolders such: %s.",
             path,
-            ", ".join(known_role_subfolders),
+            ", ".join(ROLE_SUBDIRS),
         )
 
     if str(path) == "/dev/stdin":
@@ -235,18 +264,9 @@ class Lintable:
 
         # if the lintable is part of a role, we save role folder name
         self.role = ""
-        parts = self.path.parent.parts
-        if "roles" in parts:
-            role = self.path
-            roles_path = get_app(cached=True).runtime.config.default_roles_path
-            while (
-                str(role.parent.absolute()) not in roles_path
-                and role.parent.name != "roles"
-                and role.name
-            ):
-                role = role.parent
-            if role.exists():
-                self.role = role.name
+        role_path = find_role_dir(self.path)
+        if role_path is not None:
+            self.role = role_path.name
 
         if str(self.path) in ["/dev/stdin", "-"]:
             # pylint: disable=consider-using-with
@@ -544,6 +564,15 @@ def find_project_root(
     return directory, "file system root"
 
 
+def path_is_inside(child: Path, parent: Path) -> bool:
+    """Return true when child is parent or a descendant of parent."""
+    try:
+        child.resolve().relative_to(parent.resolve())
+    except ValueError:
+        return False
+    return True
+
+
 def expand_dirs_in_lintables(lintables: set[Lintable]) -> None:
     """Return all recognized lintables within given directory."""
     should_expand = False
@@ -560,18 +589,15 @@ def expand_dirs_in_lintables(lintables: set[Lintable]) -> None:
         for item in copy.copy(lintables):
             if item.path.is_dir():
                 for filename in all_files:
-                    if filename.startswith((str(item.path), str(item.path.absolute()))):
+                    if path_is_inside(Path(filename), item.path):
                         lintables.add(Lintable(filename))
 
 
 def _guess_parent(lintable: Lintable) -> Lintable | None:
     """Return a parent directory for a lintable."""
-    try:
-        if lintable.path.parents[2].name == "roles":
-            # role_name = lintable.parents[1].name
-            return Lintable(lintable.path.parents[1], kind="role")
-    except IndexError:
-        pass
+    role_path = find_role_dir(lintable.path)
+    if role_path is not None:
+        return Lintable(role_path, kind="role")
     return None
 
 

--- a/src/ansiblelint/runner.py
+++ b/src/ansiblelint/runner.py
@@ -48,6 +48,7 @@ from ansiblelint.types import (  # pyright: ignore[reportAttributeAccessIssue]
 from ansiblelint.utils import (
     PLAYBOOK_DIR,
     HandleChildren,
+    extend_with_roles,
     parse_examples_from_plugin,
     template,
 )
@@ -99,6 +100,11 @@ class Runner:
         if exclude_paths is None:
             exclude_paths = []
 
+        had_directory_lintable = any(
+            (item.path if isinstance(item, Lintable) else Path(item)).is_dir()
+            for item in lintables
+        )
+
         # Assure consistent type and configure given lintables as explicit (so
         # excludes paths would not apply on them).
         for item in lintables:
@@ -109,6 +115,10 @@ class Runner:
 
         # Expand folders (roles) to their components
         expand_dirs_in_lintables(self.lintables)
+        if had_directory_lintable:
+            expanded = list(self.lintables)
+            extend_with_roles(expanded)
+            self.lintables.update(expanded)
 
         self.tags = tags
         self.skip_list = skip_list

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -91,7 +91,7 @@ from ansiblelint.constants import (
     FileType,
 )
 from ansiblelint.errors import MatchError
-from ansiblelint.file_utils import Lintable, discover_lintables
+from ansiblelint.file_utils import Lintable, discover_lintables, find_role_dir
 from ansiblelint.skip_utils import is_nested_task
 from ansiblelint.text import has_jinja, is_fqcn, removeprefix
 from ansiblelint.types import (
@@ -1332,24 +1332,21 @@ def get_lintables(
 
         # stage 2: guess roles from current lintables, as there is no unique
         # file that must be present in any kind of role.
-        _extend_with_roles(lintables)
+        extend_with_roles(lintables)
 
     return lintables
 
 
-def _extend_with_roles(lintables: list[Lintable]) -> None:
+def extend_with_roles(lintables: list[Lintable]) -> None:
     """Detect roles among lintables and adds them to the list."""
     for lintable in lintables:
-        parts = lintable.path.parent.parts
-        if "roles" in parts:
-            role = lintable.path
-            while role.parent.name != "roles" and role.name:
-                role = role.parent
-            if role.exists() and not role.is_file():
-                lintable = Lintable(role)
-                if lintable.kind == "role" and lintable not in lintables:
-                    _logger.debug("Added role: %s", lintable)
-                    lintables.append(lintable)
+        role_path = find_role_dir(lintable.path)
+        if role_path is None:
+            continue
+        role_lintable = Lintable(role_path)
+        if role_lintable.kind == "role" and role_lintable not in lintables:
+            _logger.debug("Added role: %s", role_lintable)
+            lintables.append(role_lintable)
 
 
 def convert_to_boolean(value: Any) -> bool:

--- a/test/test_cli_role_paths.py
+++ b/test/test_cli_role_paths.py
@@ -234,6 +234,25 @@ def test_run_role_identified_prefix_missing(local_test_dir: Path) -> None:
     assert (
         "Variables names from within roles should use bar_ as a prefix" in result.stdout
     )
-    assert (
-        "Variables names from within roles should use bar_ as a prefix" in result.stdout
-    )
+
+
+def test_role_name_namespace_subdir_autodiscovery() -> None:
+    """Role-specific rules apply to roles under namespace subdirectories.
+
+    See https://github.com/ansible/ansible-lint/issues/5079
+    """
+    cwd = Path(__file__).resolve().parent.parent / "examples" / "namespace_roles_repro"
+    env = {"NO_COLOR": "1"}
+    expected = "role-name: Role name myBadRoleName does not match"
+
+    result = run_ansible_lint(".", cwd=cwd, env=env)
+    assert result.returncode == RC.VIOLATIONS_FOUND, result.stdout
+    assert expected in strip_ansi_escape(result.stdout)
+
+    result = run_ansible_lint("roles/my_namespace/", cwd=cwd, env=env)
+    assert result.returncode == RC.VIOLATIONS_FOUND, result.stdout
+    assert expected in strip_ansi_escape(result.stdout)
+
+    result = run_ansible_lint("roles/my_namespace/myBadRoleName/", cwd=cwd, env=env)
+    assert result.returncode == RC.VIOLATIONS_FOUND, result.stdout
+    assert expected in strip_ansi_escape(result.stdout)

--- a/test/test_file_utils.py
+++ b/test/test_file_utils.py
@@ -12,15 +12,19 @@ from typing import TYPE_CHECKING, Any
 import pytest
 
 from ansiblelint import cli, file_utils
+from ansiblelint.config import options
 from ansiblelint.file_utils import (
     Lintable,
     cwd,
+    expand_dirs_in_lintables,
     expand_path_vars,
     expand_paths_vars,
     find_project_root,
+    find_role_dir,
     kind_from_path,
     normpath,
     normpath_path,
+    path_is_inside,
 )
 from ansiblelint.runner import Runner
 
@@ -596,3 +600,52 @@ def test_kind_from_path_outside_project_root(tmp_path: Path) -> None:
     kind = kind_from_path(outside_file)
 
     assert kind == "yaml"
+
+
+def test_find_role_dir_namespace_subdir(tmp_path: Path) -> None:
+    """Roles nested under a namespace directory resolve to the role root."""
+    role_dir = tmp_path / "roles" / "my_namespace" / "myBadRoleName"
+    (role_dir / "tasks").mkdir(parents=True)
+    (role_dir / "meta").mkdir()
+    task_file = role_dir / "tasks" / "main.yml"
+    task_file.write_text("---\n- debug: msg=hi\n", encoding="utf-8")
+
+    assert find_role_dir(task_file) == role_dir
+    assert find_role_dir(role_dir.parent) is None
+
+
+def test_kind_from_path_namespace_folder_is_not_role(tmp_path: Path) -> None:
+    """Namespace folders under roles/ must not be classified as roles."""
+    project_dir = tmp_path / "project"
+    namespace_dir = project_dir / "roles" / "my_namespace"
+    role_dir = namespace_dir / "myBadRoleName"
+    (role_dir / "tasks").mkdir(parents=True)
+    (role_dir / "meta").mkdir()
+    (project_dir / ".git").mkdir()
+
+    assert kind_from_path(namespace_dir) != "role"
+    assert kind_from_path(role_dir) == "role"
+
+
+def test_expand_dirs_in_lintables_relative_paths(tmp_path: Path) -> None:
+    """Directory expansion must work when the lintable path is '.'."""
+    project_dir = tmp_path / "project"
+    role_dir = project_dir / "roles" / "my_namespace" / "myBadRoleName"
+    (role_dir / "tasks").mkdir(parents=True)
+    task_file = role_dir / "tasks" / "main.yml"
+    task_file.write_text("---\n- debug: msg=hi\n", encoding="utf-8")
+
+    original_cwd = Path.cwd()
+    try:
+        os.chdir(project_dir)
+        lintables: set[Lintable] = {Lintable(".")}
+        options.lintables = ["."]
+        options.exclude_paths = []
+        expand_dirs_in_lintables(lintables)
+        assert any(
+            path_is_inside(lintable.path, project_dir)
+            and lintable.path.name == "main.yml"
+            for lintable in lintables
+        )
+    finally:
+        os.chdir(original_cwd)


### PR DESCRIPTION
## Summary
Fixes #5079.
Role-specific rules (such as `role-name`) were not enforced when linting projects that store roles under namespace subdirectories (`roles/<namespace>/<role_name>/`). The rules only triggered when the role path was passed directly.
This PR correctly identifies role roots in nested layouts, avoids treating namespace folders as roles, and ensures role discovery runs after directory expansion in the Runner.
## Changes
- Added `is_role_dir()`, `find_role_dir()`, and `path_is_inside()` helpers in `file_utils.py` to locate role roots by checking for standard role subdirectories (`tasks/`, `meta/`, etc.)
- Fixed `kind_from_path()` so namespace folders under `roles/` are not classified as roles
- Fixed `expand_dirs_in_lintables()` to include all files under the project when the lintable path is `.` (previously relied on `startswith(".")`, which missed relative paths like `roles/...`)
- Called `extend_with_roles()` from `Runner` after directory expansion so role lintables are discovered for explicit paths, not only during auto-discovery
- Promoted `_extend_with_roles()` to public `extend_with_roles()` for cross-module use
- Removed unused `get_app` import from `file_utils.py`
- Added `examples/namespace_roles_repro/` fixture reproducing the issue
- Added unit tests for role discovery, kind detection, and directory expansion
- Added integration test verifying `role-name` is reported for:
  - `ansible-lint .`
  - `ansible-lint roles/my_namespace/`
  - `ansible-lint roles/my_namespace/myBadRoleName/`