### PR TITLE
fix(docs): remove mkdocstrings plugin to unblock docs CI

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -104,7 +104,6 @@ matchtask
 matchtasks
 matchvar
 matchyaml
-mkdocstrings
 mockings
 modifyitems
 mytag

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -147,19 +147,6 @@ plugins:
   - material/tags
   # https://github.com/manuzhang/mkdocs-htmlproofer-plugin
   # - htmlproofer
-  - mkdocstrings:
-      handlers:
-        python:
-          paths: [src]
-          options:
-            # Sphinx is for historical reasons, but we could consider switching if needed
-            # https://mkdocstrings.github.io/griffe/docstrings/
-            docstring_style: sphinx
-            merge_init_into_class: yes
-            show_submodules: yes
-          inventories:
-            - url: https://docs.ansible.com/projects/ansible/latest/objects.inv
-              domains: [py, std]
 
 markdown_extensions:
   - markdown_include.include:


### PR DESCRIPTION
## Summary

- Remove the `mkdocstrings` plugin from `mkdocs.yml` — it fetches `objects.inv` from `docs.ansible.com` which is returning HTTP 429 (Too Many Requests), causing all docs builds to fail in strict mode
- The plugin was configured but never actually used — no `:::` autodoc directives exist anywhere in the docs
- This unblocks docs CI for all open PRs

Ref: Sorin flagged this in the devtools channel as a blocker for pending releases.

Assisted by Claude Code.