### PR TITLE
fix: remove stale words from cspell dictionary

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -28,7 +28,6 @@ Tsukinowa
 WSLENV
 addoption
 addopts
-alertmanager
 ansiblelint
 apport
 argparsing
@@ -92,12 +91,10 @@ languageservice
 libyaml
 licensedb
 lineinfile
-linenums
 lintable
 lintables
 localectl
 machinectl
-magiclink
 matchdir
 matcherror
 matchlines
@@ -129,7 +126,6 @@ posargs
 prek
 prerun
 pyargs
-pymdownx
 redirections
 reformatter
 releasenotes


### PR DESCRIPTION
Remove 4 stale dictionary entries (alertmanager, linenums, magiclink, pymdownx) that the CI cspell hook flags as unused, causing the scheduled lint job on main to fail with a dirty git status. Restores CI health on the main branch.

Fixes the failure in https://github.com/ansible/ansible-lint/actions/runs/29216052408

Assisted by Claude Code.