### PR TITLE
fix(deps): exclude ansible-core 2.17.x (CVE-2026-11332)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 ]
 dependencies = [
   "ansible-compat>=26.3.0",
-  "ansible-core>=2.16.14",
+  "ansible-core>=2.16.19,!=2.17.*",
   "black>=24.3.0",
   "cffi>=1.15.1",  # indirect dependency of ruamel-yaml
   "cryptography>=37",

--- a/uv.lock
+++ b/uv.lock
@@ -17,7 +17,7 @@ name = "ansible-compat"
 version = "26.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ansible-core", version = "2.17.14", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "ansible-core", version = "2.16.19", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "ansible-core", version = "2.19.11", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "ansible-core", version = "2.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "jsonschema" },
@@ -32,7 +32,7 @@ wheels = [
 
 [[package]]
 name = "ansible-core"
-version = "2.17.14"
+version = "2.16.19"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.11'",
@@ -44,9 +44,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "resolvelib", version = "1.0.1", source = { registry = "https://pypi.org/simple" } },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/80/2925a0564f6f99a8002c3be3885b83c3a1dc5f57ebf00163f528889865f5/ansible_core-2.17.14.tar.gz", hash = "sha256:7c17fee39f8c29d70e3282a7e9c10bd70d5cd4fd13ddffc5dcaa52adbd142ff8", size = 3119687, upload-time = "2025-09-08T18:28:03.158Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/75/b73552520a48c6a7822445f760e23a59612c0d77df481ba1b9ba8ed4e1d9/ansible_core-2.16.19.tar.gz", hash = "sha256:5125f26412039ffb99a3a7723618535ab80e6ef38944aa2453997350388f4ef4", size = 3172397, upload-time = "2026-06-18T19:40:08.358Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/86/29/d694562f1a875b50aa74f691521fe493704f79cf1938cd58f28f7e2327d2/ansible_core-2.17.14-py3-none-any.whl", hash = "sha256:34a49582a57c2f2af17ede2cefd3b3602a2d55d22089f3928570d52030cafa35", size = 2189656, upload-time = "2025-09-08T18:28:00.375Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/0a/fdb88b61521a1f263acf420d27bca357a38a2ac5865364016cedd41c15a5/ansible_core-2.16.19-py3-none-any.whl", hash = "sha256:d7a32ba0f96f9c6582b7ff159a4a6f0e694662cfc4840497c88fed63bf58cd14", size = 2261447, upload-time = "2026-06-18T19:40:06.223Z" },
 ]
 
 [[package]]
@@ -107,7 +107,7 @@ name = "ansible-lint"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-compat" },
-    { name = "ansible-core", version = "2.17.14", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "ansible-core", version = "2.16.19", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "ansible-core", version = "2.19.11", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "ansible-core", version = "2.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "black" },
@@ -190,7 +190,7 @@ schemas = [
 [package.metadata]
 requires-dist = [
     { name = "ansible-compat", specifier = ">=26.3.0" },
-    { name = "ansible-core", specifier = ">=2.16.14" },
+    { name = "ansible-core", specifier = ">=2.16.19,!=2.17.*" },
     { name = "black", specifier = ">=24.3.0" },
     { name = "cffi", specifier = ">=1.15.1" },
     { name = "cryptography", specifier = ">=37" },


### PR DESCRIPTION
Exclude the entire ansible-core 2.17.x range from the dependency spec. 2.17 is EOL and will never receive the fix for CVE-2026-11332 (argument injection in ansible-galaxy role install, CVSS 7.8).

With this change, Python 3.10 users get ansible-core 2.16.19 (patched) and Python 3.11+ users get 2.18+ (patched). Nobody resolves to the vulnerable 2.17.x anymore.

Reference: https://github.com/advisories/GHSA-w8p5-mx5w-cpqj
Fix PR: https://github.com/ansible/ansible/pull/87070

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the supported Ansible Core runtime version range to require 2.16.19 or later, while excluding the 2.17 release series.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->