### PR TITLE
fix: expose ansible-galaxy on the uv tool-install path

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -101,7 +101,8 @@ runs:
       # SETUPTOOLS_SCM_PRETEND_VERSION=${{ github.action_ref || 'main' }}
       run: |
         if [[ "${{ inputs.setup_python }}" == "true" ]]; then
-          uv tool install --python ${{ inputs.python_version }} "ansible-lint[lock] @ git+https://github.com/ansible/ansible-lint@$GH_ACTION_REF"
+          # --with-executables-from requires uv >= 0.8.5 (provided by setup-uv latest above)
+          uv tool install --python ${{ inputs.python_version }} --with-executables-from ansible-core "ansible-lint[lock] @ git+https://github.com/ansible/ansible-lint@$GH_ACTION_REF"
         else
           echo "setup_python is false, using pip"
           pip install "ansible-lint[lock] @ git+https://github.com/ansible/ansible-lint@$GH_ACTION_REF"


### PR DESCRIPTION
## Summary

When `setup_python` is `true` (the action's default), `action.yml` installs ansible-lint with `uv tool install`, which links only the `ansible-lint` console script onto `PATH`. `ansible-core` is installed into the same isolated tool venv, but its executables, including `ansible-galaxy`, are not exposed. The `requirements_file` step then runs a bare `ansible-galaxy install -r ...` and fails with `ansible-galaxy: command not found` (exit 127) before linting runs.

This is #5034.

## Fix

Add `--with-executables-from ansible-core` to the existing `uv tool install` invocation. This links ansible-core's console scripts from the same tool venv `ansible-lint` uses onto `PATH`: `ansible`, `ansible-playbook`, `ansible-doc`, `ansible-vault`, `ansible-config`, `ansible-inventory`, and `ansible-galaxy`. `ansible-galaxy` is the one #5034 needs; exposing the rest of ansible-core's entry points from the linter's own venv is harmless and, if anything, desirable, since they are the exact tools that back what ansible-lint checks. The `requirements_file` step is unchanged and now resolves on both the uv (`setup_python: true`) and pip (`setup_python: false`) paths. One line.

## Minimum uv version

`--with-executables-from` was added in uv 0.8.5 (astral-sh/uv#14014). The `Set up uv` step uses `astral-sh/setup-uv` with no `version:` pin, so it installs the latest uv, which is well past 0.8.5. That step lives in this same `action.yml`, so the action controls the uv it runs against and this flag can't silently regress out from under it. I've left a one-line comment on the install line recording the floor rather than pinning setup-uv, to keep the change minimal and avoid interacting with Renovate's version management of that step.

## Verification

- **Still present on latest:** reproduces on v26.6.0 and current `main` (the install step uses `uv tool install`; the requirements step is a bare `ansible-galaxy install -r ...`). The issue was originally reported against 26.4.0.
- **Clean-room repro:** `uv tool install ansible-lint` links `ansible-lint` but not `ansible-galaxy`; a bare `ansible-galaxy install -r requirements.yml` exits 127.
- **With the fix:** `ansible-galaxy` resolves from the ansible-lint tool venv (`ansible-core` 2.21.2, the same core the linter uses), and a real `ansible-galaxy install -r requirements.yml` (community.general) completes rc 0; `ansible-lint` runs unchanged afterward. The pip path is untouched. Tested with uv 0.11.31, ansible-lint 26.6.0.

## Alternative considered

The `requirements_file` step could instead call `ansible-galaxy` by its tool-venv path (`"$(uv tool dir)/ansible-lint/bin/ansible-galaxy"`). That also works, but it hardcodes uv's internal tool layout; `--with-executables-from` uses uv's public API and leaves the requirements step untouched, so it is preferred here. Happy to switch to the requirements-step form if you would rather keep the change localized there.

Fixes #5034


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Ansible lint installation when Python setup is enabled by installing the full `ansible-lint[lock]` toolchain with access to Ansible Core executables.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->