### PR TITLE
fix: apply profile-level skip list

### DIFF
--- a/src/ansiblelint/app.py
+++ b/src/ansiblelint/app.py
@@ -43,6 +43,8 @@ class App:
 
     def __init__(self, options: Options):
         """Construct app run based on already loaded configuration."""
+        if options.profile:
+            options.skip_list.extend(PROFILES[options.profile].get("skip_list", []))
         options.skip_list = _sanitize_list_options(options.skip_list)
         options.warn_list = _sanitize_list_options(options.warn_list)
 

--- a/test/test_profiles.py
+++ b/test/test_profiles.py
@@ -3,11 +3,13 @@
 import platform
 import subprocess
 import sys
+from pathlib import Path
 
 from _pytest.capture import CaptureFixture
 
 from ansiblelint.rules import RulesCollection, filter_rules_with_profile
 from ansiblelint.rules.risky_shell_pipe import ShellWithoutPipefail
+from ansiblelint.testing import run_ansible_lint
 from ansiblelint.text import strip_ansi_escape
 
 
@@ -37,6 +39,29 @@ def test_profile_min_with_enable_list(empty_rule_collection: RulesCollection) ->
     assert len(empty_rule_collection.rules) == 5, (
         "enable_list rule was incorrectly removed by profile filtering."
     )
+
+
+def test_profile_skip_list(tmp_path: Path) -> None:
+    """Profile-specific skip entries are applied when linting."""
+    (tmp_path / ".ansible-lint").write_text("profile: basic\n", encoding="utf-8")
+    playbook = tmp_path / "playbook.yml"
+    playbook.write_text(
+        "---\n"
+        "- name: Test\n"
+        "  hosts: localhost\n"
+        "  gather_facts: false\n"
+        "  tasks:\n"
+        "    - name: test {{ variable }} task\n"
+        "      ansible.builtin.debug:\n"
+        "        msg: OK\n",
+        encoding="utf-8",
+    )
+
+    result = run_ansible_lint(playbook, cwd=tmp_path)
+
+    assert result.returncode == 0
+    assert "name[casing]" not in result.stdout
+    assert "name[template]" not in result.stdout
 
 
 def test_profile_listing(capfd: CaptureFixture[str]) -> None:


### PR DESCRIPTION
Closes #5087

The `basic` profile declares `name[casing]` and `name[template]` in its profile-level `skip_list`, but those entries never reached the runtime options. Merge the selected profile's skip entries during app initialization and add an end-to-end regression covering both subrules.

Tested with `pytest test/test_profiles.py test/test_app.py` (14 passed), plus Ruff check and format validation on the changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Profile-specific skip rules are now applied correctly during linting.
  - Configured profiles can suppress their designated rule violations as expected.
  - Linting results now better reflect the selected profile’s rule configuration, reducing unexpected warnings.

- **Tests**
  - Added coverage confirming profile-based skip behavior for naming and template rules.
  - Verified that playbooks using supported profile exceptions complete linting successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->