### PR TITLE
fix: resolve short mock modules during syntax check

### DIFF
--- a/src/ansiblelint/app.py
+++ b/src/ansiblelint/app.py
@@ -416,6 +416,19 @@ def _add_module_path_if_needed(
             module_paths.insert(0, str(mock_path))
 
 
+def _update_path_env(
+    env: dict[str, str],
+    varname: str,
+    paths: list[str],
+) -> None:
+    """Prepend path entries to an environment variable without duplicates."""
+    if not paths:
+        return
+    current = env.get(varname, "")
+    values = [*paths, *(current.split(os.pathsep) if current else [])]
+    env[varname] = os.pathsep.join(dict.fromkeys(values))
+
+
 def get_app(*, offline: bool | None = None, cached: bool = False) -> App:
     """Return the application instance, caching the return value."""
     # Avoids ever running the app initialization twice if cached argument
@@ -458,7 +471,11 @@ def get_app(*, offline: bool | None = None, cached: bool = False) -> App:
 
     # https://github.com/ansible/ansible-lint/issues/4973
     _add_collections_path_if_needed(app.options, app.runtime.config.collections_paths)
-    _add_module_path_if_needed(app.options, app.runtime.config.default_module_path)
+    default_module_paths = app.runtime.config.default_module_path
+    module_paths = default_module_paths.copy()
+    _add_module_path_if_needed(app.options, module_paths)
+    if module_paths != default_module_paths:
+        _update_path_env(app.runtime.environ, "ANSIBLE_LIBRARY", module_paths)
 
     app.runtime.prepare_environment(
         install_local=(not offline),

--- a/test/test_mockings.py
+++ b/test/test_mockings.py
@@ -79,3 +79,19 @@ def test_mock_modules_stub_is_lintable(tmp_path: Path) -> None:
     )
     result = run_ansible_lint("playbook.yml", cwd=tmp_path)
     assert result.returncode == 0, result.stdout
+
+
+def test_short_mock_modules_stub_is_lintable(tmp_path: Path) -> None:
+    """Ensure short-name mock modules are resolved during syntax-check."""
+    (tmp_path / ".ansible-lint.yml").write_text("mock_modules:\n  - custom_module\n")
+    (tmp_path / "playbook.yml").write_text(
+        "---\n"
+        "- name: Test mocked short module\n"
+        "  hosts: localhost\n"
+        "  gather_facts: false\n"
+        "  tasks:\n"
+        "    - name: Run mocked short module\n"
+        "      custom_module:\n"
+    )
+    result = run_ansible_lint("playbook.yml", cwd=tmp_path)
+    assert result.returncode == 0, result.stdout


### PR DESCRIPTION
## Summary

- Fix short-name `mock_modules` so generated stubs are visible to `ansible-playbook --syntax-check`.
- Keep the existing collection mock behavior unchanged by only exporting `ANSIBLE_LIBRARY` when short mock module paths are added.
- Add an end-to-end regression test for a short-name mocked module.

Fixes #5126

## Testing

- `uv run pytest test/test_mockings.py::test_short_mock_modules_stub_is_lintable test/test_mockings.py::test_mock_modules_stub_is_lintable test/test_app.py::test_add_module_path_for_plain_mock_modules test/test_app.py::test_add_module_path_skips_collection_only_mocks`
- `uv run ruff check src/ansiblelint/app.py test/test_mockings.py test/test_app.py`
- `uv run ruff format --check src/ansiblelint/app.py test/test_mockings.py test/test_app.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of custom module search paths to preserve existing environment settings and avoid duplicate entries.
  - Ensured playbooks using short custom module names can be linted successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->