### PR TITLE
fix: deduplicate ANSIBLE_HOME isolation check

### DIFF
--- a/src/ansiblelint/__main__.py
+++ b/src/ansiblelint/__main__.py
@@ -54,6 +54,7 @@ from ansiblelint.config import (
     Options,
     get_deps_versions,
     get_version_warning,
+    has_custom_ansible_env,
     log_entries,
     options,
 )
@@ -143,19 +144,9 @@ def initialize_options(arguments: list[str] | None = None) -> BaseFileLock | Non
         or options.list_rules
         or options.list_tags
     ):
-        # respecting user's env vars
-        ansible_env_vars = (
-            "ANSIBLE_HOME",
-            "ANSIBLE_LIBRARY",
-            "ANSIBLE_ROLES_PATH",
-            "ANSIBLE_COLLECTIONS_PATH",
-        )
-        has_custom_ansible_env = any(var in os.environ for var in ansible_env_vars)
-        is_isolated = not options.offline and not has_custom_ansible_env
-
         options.cache_dir = get_cache_dir(
             pathlib.Path(options.project_dir),
-            isolated=is_isolated,
+            isolated=not options.offline and not has_custom_ansible_env(),
         )
 
     options.project_dir = Path(options.project_dir).resolve().as_posix()

--- a/src/ansiblelint/app.py
+++ b/src/ansiblelint/app.py
@@ -14,7 +14,12 @@ from ansible_compat.runtime import Runtime
 
 from ansiblelint import formatters
 from ansiblelint._mockings import _perform_mockings
-from ansiblelint.config import PROFILES, Options, get_version_warning
+from ansiblelint.config import (
+    PROFILES,
+    Options,
+    get_version_warning,
+    has_custom_ansible_env,
+)
 from ansiblelint.config import options as default_options
 from ansiblelint.constants import RC, RULE_DOC_URL
 from ansiblelint.loaders import IGNORE_FILE
@@ -46,18 +51,9 @@ class App:
         formatter_factory = choose_formatter_factory(options)
         self.formatter = formatter_factory(options.cwd, options.display_relative_path)
 
-        ansible_env_vars = (
-            "ANSIBLE_HOME",
-            "ANSIBLE_LIBRARY",
-            "ANSIBLE_ROLES_PATH",
-            "ANSIBLE_COLLECTIONS_PATH",
-        )
-        has_custom_ansible_env = any(var in os.environ for var in ansible_env_vars)
-        is_isolated = not options.offline and not has_custom_ansible_env
-
         self.runtime = Runtime(
             project_dir=Path(options.project_dir),
-            isolated=is_isolated,
+            isolated=not options.offline and not has_custom_ansible_env(),
             require_module=True,
             verbosity=options.verbosity,
         )

--- a/src/ansiblelint/config.py
+++ b/src/ansiblelint/config.py
@@ -120,6 +120,19 @@ ANSIBLE_OWNED_KINDS = {
 
 PROFILES = yaml_from_file(Path(__file__).parent / "data" / "profiles.yml")
 
+ANSIBLE_ENV_VARS = (
+    "ANSIBLE_HOME",
+    "ANSIBLE_LIBRARY",
+    "ANSIBLE_ROLES_PATH",
+    "ANSIBLE_COLLECTIONS_PATH",
+)
+
+
+def has_custom_ansible_env() -> bool:
+    """Return True when any ANSIBLE_* path env var is set by the user."""
+    return any(var in os.environ for var in ANSIBLE_ENV_VARS)
+
+
 LOOP_VAR_PREFIX = "^(__|{role}_)"
 
 


### PR DESCRIPTION
## Summary

Extracts the duplicated `ansible_env_vars` tuple and `has_custom_ansible_env` check from `__main__.py` and `app.py` into a shared constant and helper function in `config.py`.

Follow-up cleanup to #5105.

## Test plan

- [x] `pytest test/test_main.py -k "version or fetch_latest or cache"` (11 passed)
- [x] `ruff check` on all changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of custom Ansible environment settings.
  * Ensured cache and runtime isolation consistently respond to configured Ansible path variables.
* **Refactor**
  * Centralized Ansible environment detection for more consistent behavior across application startup and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->