### PR TITLE
fix: ensure runtime cache dir is prepended to collections paths (#5137)

### DIFF
--- a/src/ansiblelint/app.py
+++ b/src/ansiblelint/app.py
@@ -464,6 +464,11 @@ def get_app(*, offline: bool | None = None, cached: bool = False) -> App:
     _add_collections_path_if_needed(app.options, app.runtime.config.collections_paths)
     _add_module_path_if_needed(app.options, app.runtime.config.default_module_path)
 
+    if app.runtime.cache_dir and app.runtime.config.collections_paths is not None:
+        target_dir = str(app.runtime.cache_dir / "collections")
+        if target_dir not in app.runtime.config.collections_paths:
+            app.runtime.config.collections_paths.insert(0, target_dir)
+
     app.runtime.prepare_environment(
         install_local=(not offline),
         offline=offline,

--- a/src/ansiblelint/schemas/__store__.json
+++ b/src/ansiblelint/schemas/__store__.json
@@ -24,7 +24,7 @@
     "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/inventory.json"
   },
   "meta": {
-    "etag": "7ebcf3f8341cb445cde52df9e1e0c954fd2954268b20faa38d8b6b33f6709c4c",
+    "etag": "ab85bc72a018cf4c1134d25f14746401b449058fe5f336392659c7ecd47359b1",
     "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/meta.json"
   },
   "meta-runtime": {

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -177,3 +177,27 @@ def test_skip_list_and_strict(tmp_path: Path) -> None:
 
     # Should return 0 because rule is in skip_list
     assert result.returncode == RC.SUCCESS
+
+
+def test_get_app_prepends_cache_collections_dir(tmp_path: Path) -> None:
+    """Ensure runtime cache directory is prepended to collections_paths."""
+    from ansiblelint.app import App, _add_collections_path_if_needed
+    from ansiblelint.config import Options
+
+    options = Options()
+    options.project_dir = str(tmp_path)
+    options.cache_dir = tmp_path / ".ansible"
+    options.cache_dir.mkdir(parents=True, exist_ok=True)
+
+    app = App(options)
+
+    # Run the setup steps executed during app initialization
+    _add_collections_path_if_needed(app.options, app.runtime.config.collections_paths)
+    if app.runtime.cache_dir and app.runtime.config.collections_paths is not None:
+        target_dir = str(app.runtime.cache_dir / "collections")
+        if target_dir not in app.runtime.config.collections_paths:
+            app.runtime.config.collections_paths.insert(0, target_dir)
+
+    if app.runtime.cache_dir:
+        expected_target = str(app.runtime.cache_dir / "collections")
+        assert app.runtime.config.collections_paths[0] == expected_target

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+import pytest
+
 from ansiblelint.__main__ import _rule_is_skipped
 from ansiblelint.constants import RC
 from ansiblelint.file_utils import Lintable
@@ -179,25 +181,25 @@ def test_skip_list_and_strict(tmp_path: Path) -> None:
     assert result.returncode == RC.SUCCESS
 
 
-def test_get_app_prepends_cache_collections_dir(tmp_path: Path) -> None:
-    """Ensure runtime cache directory is prepended to collections_paths."""
-    from ansiblelint.app import App, _add_collections_path_if_needed
-    from ansiblelint.config import Options
+def test_get_app_prepends_cache_collections_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ensure runtime cache directory is prepended to collections_paths when external paths exist."""
+    from unittest.mock import patch
 
-    options = Options()
-    options.project_dir = str(tmp_path)
-    options.cache_dir = tmp_path / ".ansible"
-    options.cache_dir.mkdir(parents=True, exist_ok=True)
+    from ansiblelint.app import get_app
+    from ansiblelint.config import options as default_options
 
-    app = App(options)
+    # 1. Seed external collections path and cache dir on default_options BEFORE get_app runs
+    external_path = "/usr/share/ansible/collections"
+    monkeypatch.setattr(default_options, "cache_dir", tmp_path / ".ansible")
+    monkeypatch.setenv("ANSIBLE_COLLECTIONS_PATH", external_path)
 
-    # Run the setup steps executed during app initialization
-    _add_collections_path_if_needed(app.options, app.runtime.config.collections_paths)
-    if app.runtime.cache_dir and app.runtime.config.collections_paths is not None:
-        target_dir = str(app.runtime.cache_dir / "collections")
-        if target_dir not in app.runtime.config.collections_paths:
-            app.runtime.config.collections_paths.insert(0, target_dir)
+    # 2. Mock network/environment prep so get_app() runs fast without side-effects
+    with patch("ansible_compat.runtime.Runtime.prepare_environment"):
+        app = get_app(offline=True)
 
-    if app.runtime.cache_dir:
-        expected_target = str(app.runtime.cache_dir / "collections")
-        assert app.runtime.config.collections_paths[0] == expected_target
+    # 3. Verify production logic inside get_app prepended target_dir and preserved external_path
+    expected_cache_target = str(app.runtime.cache_dir / "collections")
+    assert app.runtime.config.collections_paths[0] == expected_cache_target
+    assert external_path in app.runtime.config.collections_paths


### PR DESCRIPTION
## Summary
Fixes #5137 by prepending the runtime cache collections directory to `app.runtime.config.collections_paths`.

## Cause
An external `ANSIBLE_COLLECTIONS_PATH` prevented `ansible-compat` from prioritizing the isolated runtime cache, causing collection module lookups to fail during syntax checks.

## Solution
- Prepend `<cache_dir>/collections` to `collections_paths` in `src/ansiblelint/app.py`.
- Add regression test in `test/test_app.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Ansible collection discovery by prioritizing collections available in the runtime cache.
  * Prevented duplicate collection paths during application setup.
  * Preserved externally configured collection locations while adding cached collections.

* **Maintenance**
  * Updated the stored metadata schema validation identifier.
  * Added automated coverage to verify collection path behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->