### PR TITLE
chore(docs): mention MegaLinter in the installing page

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -45,6 +45,11 @@ You can also run Ansible-lint on your source code with the
 [Ansible-lint GitHub action](https://github.com/marketplace/actions/run-ansible-lint)
 instead of installing it directly.
 
+Another way to run Ansible-lint in CI without installing it is through
+[MegaLinter](https://megalinter.io/), an open-source linters aggregator that
+[runs Ansible-lint out of the box](https://megalinter.io/latest/descriptors/ansible_ansible_lint/)
+alongside linters for other languages and formats.
+
 ## Installing the latest version
 
 {{ install_from_adt("ansible-lint") }}


### PR DESCRIPTION
Hi! I maintain MegaLinter, which bundles ansible-lint among its linters, so I added a small line in the install docs next to the GitHub Action mention, since it's another way to get ansible-lint running in CI without installing it.

And of course, if anything on ansible-lint's page on the MegaLinter side looks wrong or outdated, just tell me and I'll fix it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added instructions for running Ansible-lint through MegaLinter in CI.
  * Clarified that Ansible-lint can be used without a direct installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->