### PR TITLE
fix: prepend runtime cache dir to collections paths (#5137)

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -54,6 +54,7 @@ cpuset
 createfile
 dbservers
 deannotate
+delenv
 dellemc
 direnv
 doas

--- a/src/ansiblelint/app.py
+++ b/src/ansiblelint/app.py
@@ -420,6 +420,16 @@ def _add_module_path_if_needed(
             module_paths.insert(0, str(mock_path))
 
 
+def _ensure_cache_collections_first(app: App) -> None:
+    """Ensure the runtime cache collections directory is first in collections_paths."""
+    if not app.runtime.cache_dir or app.runtime.config.collections_paths is None:
+        return
+    target_dir = str(app.runtime.cache_dir / "collections")
+    if target_dir in app.runtime.config.collections_paths:
+        app.runtime.config.collections_paths.remove(target_dir)
+    app.runtime.config.collections_paths.insert(0, target_dir)
+
+
 def get_app(*, offline: bool | None = None, cached: bool = False) -> App:
     """Return the application instance, caching the return value."""
     # Avoids ever running the app initialization twice if cached argument
@@ -464,11 +474,7 @@ def get_app(*, offline: bool | None = None, cached: bool = False) -> App:
     _add_collections_path_if_needed(app.options, app.runtime.config.collections_paths)
     _add_module_path_if_needed(app.options, app.runtime.config.default_module_path)
 
-    if app.runtime.cache_dir and app.runtime.config.collections_paths is not None:
-        target_dir = str(app.runtime.cache_dir / "collections")
-        if target_dir in app.runtime.config.collections_paths:
-            app.runtime.config.collections_paths.remove(target_dir)
-        app.runtime.config.collections_paths.insert(0, target_dir)
+    _ensure_cache_collections_first(app)
 
     app.runtime.prepare_environment(
         install_local=(not offline),

--- a/src/ansiblelint/app.py
+++ b/src/ansiblelint/app.py
@@ -466,8 +466,9 @@ def get_app(*, offline: bool | None = None, cached: bool = False) -> App:
 
     if app.runtime.cache_dir and app.runtime.config.collections_paths is not None:
         target_dir = str(app.runtime.cache_dir / "collections")
-        if target_dir not in app.runtime.config.collections_paths:
-            app.runtime.config.collections_paths.insert(0, target_dir)
+        if target_dir in app.runtime.config.collections_paths:
+            app.runtime.config.collections_paths.remove(target_dir)
+        app.runtime.config.collections_paths.insert(0, target_dir)
 
     app.runtime.prepare_environment(
         install_local=(not offline),

--- a/src/ansiblelint/app.py
+++ b/src/ansiblelint/app.py
@@ -464,6 +464,11 @@ def get_app(*, offline: bool | None = None, cached: bool = False) -> App:
     _add_collections_path_if_needed(app.options, app.runtime.config.collections_paths)
     _add_module_path_if_needed(app.options, app.runtime.config.default_module_path)
 
+    if app.runtime.cache_dir and app.runtime.config.collections_paths is not None:
+        target_dir = str(app.runtime.cache_dir / "collections")
+        if target_dir not in app.runtime.config.collections_paths:
+            app.runtime.config.collections_paths.insert(0, target_dir)
+
     app.runtime.prepare_environment(
         install_local=(not offline),
         offline=offline,

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+import pytest
+
 from ansiblelint.__main__ import _rule_is_skipped
 from ansiblelint.constants import RC
 from ansiblelint.file_utils import Lintable
@@ -177,3 +179,24 @@ def test_skip_list_and_strict(tmp_path: Path) -> None:
 
     # Should return 0 because rule is in skip_list
     assert result.returncode == RC.SUCCESS
+
+
+def test_get_app_prepends_cache_collections_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ensure runtime cache directory is prepended to collections_paths when external paths exist."""
+    from unittest.mock import patch
+
+    from ansiblelint.app import get_app
+    from ansiblelint.config import options as default_options
+
+    external_path = "/usr/share/ansible/collections"
+    monkeypatch.setattr(default_options, "cache_dir", tmp_path / ".ansible")
+    monkeypatch.setenv("ANSIBLE_COLLECTIONS_PATH", external_path)
+
+    with patch("ansible_compat.runtime.Runtime.prepare_environment"):
+        app = get_app(offline=True)
+
+    expected_cache_target = str(app.runtime.cache_dir / "collections")
+    assert app.runtime.config.collections_paths[0] == expected_cache_target
+    assert external_path in app.runtime.config.collections_paths

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -200,3 +200,23 @@ def test_get_app_prepends_cache_collections_dir(
     expected_cache_target = str(app.runtime.cache_dir / "collections")
     assert app.runtime.config.collections_paths[0] == expected_cache_target
     assert external_path in app.runtime.config.collections_paths
+
+
+def test_get_app_skips_prepend_when_no_external_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ensure no duplicate prepend when cache dir is already in collections_paths."""
+    from unittest.mock import patch
+
+    from ansiblelint.app import get_app
+    from ansiblelint.config import options as default_options
+
+    monkeypatch.setattr(default_options, "cache_dir", tmp_path / ".ansible")
+    monkeypatch.delenv("ANSIBLE_COLLECTIONS_PATH", raising=False)
+
+    with patch("ansible_compat.runtime.Runtime.prepare_environment"):
+        app = get_app(offline=True)
+
+    if app.runtime.config.collections_paths is not None:
+        cache_target = str(app.runtime.cache_dir / "collections")
+        assert app.runtime.config.collections_paths.count(cache_target) <= 1

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -202,10 +202,10 @@ def test_get_app_prepends_cache_collections_dir(
     assert external_path in app.runtime.config.collections_paths
 
 
-def test_get_app_skips_prepend_when_no_external_path(
+def test_get_app_prepends_cache_dir_without_external_path(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Ensure no duplicate prepend when cache dir is already in collections_paths."""
+    """Ensure cache dir is prepended exactly once even without external collections path."""
     from unittest.mock import patch
 
     from ansiblelint.app import get_app
@@ -217,6 +217,28 @@ def test_get_app_skips_prepend_when_no_external_path(
     with patch("ansible_compat.runtime.Runtime.prepare_environment"):
         app = get_app(offline=True)
 
-    if app.runtime.config.collections_paths is not None:
-        cache_target = str(app.runtime.cache_dir / "collections")
-        assert app.runtime.config.collections_paths.count(cache_target) <= 1
+    assert app.runtime.config.collections_paths is not None
+    cache_target = str(app.runtime.cache_dir / "collections")
+    assert app.runtime.config.collections_paths[0] == cache_target
+    assert app.runtime.config.collections_paths.count(cache_target) == 1
+
+
+def test_get_app_moves_existing_cache_dir_to_front(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ensure cache dir is moved to index 0 when it already exists at a later position."""
+    from unittest.mock import patch
+
+    from ansiblelint.app import get_app
+    from ansiblelint.config import options as default_options
+
+    external_path = "/usr/share/ansible/collections"
+    monkeypatch.setattr(default_options, "cache_dir", tmp_path / ".ansible")
+    monkeypatch.setenv("ANSIBLE_COLLECTIONS_PATH", external_path)
+
+    with patch("ansible_compat.runtime.Runtime.prepare_environment"):
+        app = get_app(offline=True)
+
+    cache_target = str(app.runtime.cache_dir / "collections")
+    assert app.runtime.config.collections_paths[0] == cache_target
+    assert app.runtime.config.collections_paths.count(cache_target) == 1

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -181,6 +181,21 @@ def test_skip_list_and_strict(tmp_path: Path) -> None:
     assert result.returncode == RC.SUCCESS
 
 
+def test_ensure_cache_collections_first_noop_without_cache_dir() -> None:
+    """Ensure helper is a no-op when cache_dir is not set."""
+    from unittest.mock import MagicMock
+
+    from ansiblelint.app import _ensure_cache_collections_first
+
+    app = MagicMock()
+    app.runtime.cache_dir = None
+    app.runtime.config.collections_paths = ["/some/path"]
+
+    _ensure_cache_collections_first(app)
+
+    assert app.runtime.config.collections_paths == ["/some/path"]
+
+
 def test_get_app_prepends_cache_collections_dir(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes #5137. Picks up the fix from #5142 to unblock the release tagging deadline for the upstream release cycle.

When `ANSIBLE_COLLECTIONS_PATH` is set externally, `ansible-compat`'s isolated runtime cache directory was not prioritized, causing collection module lookups to fail during syntax checks.

## Changes

- Prepend `<cache_dir>/collections` to `collections_paths` in `get_app()` before `prepare_environment` runs
- Add regression test validating the prepend behavior

## Credit

Original fix by @jkhall81 in #5142. Opened this PR to get CI green ahead of the release deadline.

## Test plan

- [x] Regression test `test_get_app_prepends_cache_collections_dir` added
- [ ] CI passes (all tox jobs, codecov, SonarCloud)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved collection discovery by prioritizing cached collections while preserving configured paths.
  * Prevented duplicate collection entries and ensured consistent resolution during offline operation.

* **Tests**
  * Added coverage for cached collection ordering, deduplication, and configuration handling.

* **Chores**
  * Updated recognized terminology in the project dictionary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->