### PR TITLE
fix: propagate extra_vars to import_playbook syntax check

### DIFF
--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -574,17 +574,7 @@ class HandleChildren:
         v: Sequence[Any],
         parent_type: FileType,
     ) -> list[Lintable]:
-        """Discover lintable files for roles declared in a playbook or role.
-        
-        Parameters:
-        	lintable (Lintable): File containing the role declarations.
-        	k (str): Key identifying the role declaration section.
-        	v (Sequence[Any]): Role declarations to resolve.
-        	parent_type (FileType): Type of the containing file.
-        
-        Returns:
-        	list[Lintable]: Files found for the declared roles.
-        """
+        """Roles children."""
         # pylint: disable=unused-argument # parent_type)
         basedir = str(lintable.path.parent)
         results: list[Lintable] = []
@@ -613,15 +603,11 @@ class HandleChildren:
         return results
 
     def _recheck_playbook_with_extra_vars(self, possible_path: Path) -> bool:
-        """
-        Re-check a playbook's syntax using the configured extra variables.
-        
-        Parameters:
-            possible_path (Path): Path to the playbook to validate.
-        
-        Returns:
-            bool: `True` if the syntax check succeeds with the configured extra
-            variables, `False` if no extra variables are configured or the check fails.
+        """Re-check playbook syntax with configured extra_vars.
+
+        has_playbook() runs its syntax check without our configured extra_vars,
+        so it wrongly fails on a local playbook that only loads once those vars
+        are defined. Re-check with them before giving up.
         """
         extra_vars = self.app.options.extra_vars
         if not extra_vars:
@@ -646,18 +632,7 @@ class HandleChildren:
         parent_type: FileType,
         name: str,
     ) -> list[Lintable] | str:
-        """
-        Validate a candidate playbook path and return its lintable representation or an error message.
-        
-        Parameters:
-            possible_path (Path): Candidate playbook path.
-            is_collection (bool): Whether the playbook belongs to a foreign collection.
-            parent_type (FileType): File type assigned to the resulting lintable.
-            name (str): Playbook name used in error messages.
-        
-        Returns:
-            list[Lintable] | str: A list containing the lintable playbook, an empty list for foreign collection playbooks, or an error message.
-        """
+        """Check a single playbook path and return Lintable or error message."""
         if not possible_path.exists():
             return f"Failed to find {name} playbook."
         if not self.app.runtime.has_playbook(str(possible_path)):
@@ -677,16 +652,7 @@ class HandleChildren:
         v: Any,
         parent_type: FileType,
     ) -> list[Lintable]:
-        """
-        Resolve an imported playbook and return its lintable child files.
-        
-        Parameters:
-            v (Any): A local or fully qualified playbook name.
-            parent_type (FileType): The file type of the importing parent.
-        
-        Returns:
-            list[Lintable]: Lintable files discovered from the playbook, or an empty list when the playbook cannot be resolved.
-        """
+        """Include import_playbook children."""
         if not isinstance(v, str):
             return []
 
@@ -740,15 +706,6 @@ class HandleChildren:
         ]
 
     def _look_for_role_files(self, basedir: str, role: str) -> list[Lintable]:
-        """Recursively collect YAML files from the task, metadata, handler, variable, and default directories of a role.
-        
-        Parameters:
-            basedir (str): Base directory used to resolve the role.
-            role (str): Role name or path to search.
-        
-        Returns:
-            list[Lintable]: Lintable objects for the role's discovered YAML files.
-        """
         role_path = self._rolepath(basedir, role)
         if not role_path:  # pragma: no branch
             return []

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -602,6 +602,49 @@ class HandleChildren:
                 results.extend(self._look_for_role_files(basedir, role))
         return results
 
+    def _recheck_playbook_with_extra_vars(self, possible_path: Path) -> bool:
+        """Re-check playbook syntax with configured extra_vars.
+
+        has_playbook() runs its syntax check without our configured extra_vars,
+        so it wrongly fails on a local playbook that only loads once those vars
+        are defined. Re-check with them before giving up.
+        """
+        extra_vars = self.app.options.extra_vars
+        if not extra_vars:
+            return False
+        return (
+            self.app.runtime.run(
+                [
+                    "ansible-playbook",
+                    "--syntax-check",
+                    str(possible_path),
+                    "--extra-vars",
+                    json.dumps(extra_vars),
+                ],
+            ).returncode
+            == 0
+        )
+
+    def _resolve_playbook_path(
+        self,
+        possible_path: Path,
+        is_collection: bool,
+        parent_type: FileType,
+        name: str,
+    ) -> list[Lintable] | str:
+        """Check a single playbook path and return Lintable or error message."""
+        if not possible_path.exists():
+            return f"Failed to find {name} playbook."
+        if not self.app.runtime.has_playbook(str(possible_path)):
+            if not is_collection and self._recheck_playbook_with_extra_vars(
+                possible_path
+            ):
+                return [Lintable(possible_path, kind=parent_type)]
+            return f"Failed to load {name} playbook due to failing syntax check."
+        if is_collection:
+            return []  # don't lint foreign playbook
+        return [Lintable(possible_path, kind=parent_type)]
+
     def import_playbook_children(
         self,
         lintable: Lintable,
@@ -610,79 +653,59 @@ class HandleChildren:
         parent_type: FileType,
     ) -> list[Lintable]:
         """Include import_playbook children."""
-
-        def append_playbook_path(loc: str, playbook_path: list[str]) -> None:
-            possible_paths.append(
-                Path(
-                    path_dwim(
-                        os.path.expanduser(loc),
-                        os.path.join(
-                            "ansible_collections",
-                            namespace_name,
-                            collection_name,
-                            "playbooks",
-                            *playbook_path,
-                        ),
-                    ),
-                ),
-            )
-
-        # import_playbook only accepts a string as argument (no dict syntax)
         if not isinstance(v, str):
             return []
 
-        possible_paths = []
         namespace_name, collection_name, *playbook_path = parse_fqcn(v)
-        if namespace_name and collection_name:
-            for loc in self.app.runtime.config.collections_paths:
-                append_playbook_path(
-                    loc,
-                    [*playbook_path[:-1], f"{playbook_path[-1]}.yml"],
-                )
-                append_playbook_path(
-                    loc,
-                    [*playbook_path[:-1], f"{playbook_path[-1]}.yaml"],
-                )
-        else:
-            possible_paths.append(lintable.path.parent / v)
+        is_collection = bool(namespace_name and collection_name)
+        possible_paths = self._get_playbook_paths(
+            lintable, v, namespace_name, collection_name, playbook_path
+        )
 
         for possible_path in possible_paths:
-            if not possible_path.exists():
-                msg = f"Failed to find {v} playbook."
-            elif not self.app.runtime.has_playbook(
-                str(possible_path),
-            ):
-                extra_vars = self.app.options.extra_vars
-                is_collection = bool(namespace_name and collection_name)
-                # has_playbook() runs its syntax check without our configured
-                # extra_vars, so it wrongly fails on a local playbook that only
-                # loads once those vars are defined. Re-check with them before
-                # giving up, while still reporting genuinely broken playbooks.
-                if (
-                    extra_vars
-                    and not is_collection
-                    and self.app.runtime.run(
-                        [
-                            "ansible-playbook",
-                            "--syntax-check",
-                            str(possible_path),
-                            "--extra-vars",
-                            json.dumps(extra_vars),
-                        ],
-                    ).returncode
-                    == 0
-                ):
-                    return [Lintable(possible_path, kind=parent_type)]
-                msg = f"Failed to load {v} playbook due to failing syntax check."
-                break
-            elif namespace_name and collection_name:
-                # don't lint foreign playbook
+            result = self._resolve_playbook_path(
+                possible_path, is_collection, parent_type, v
+            )
+            if isinstance(result, list):
+                return result
+            if "syntax check" in result:
+                _logger.error(result)
                 return []
-            else:
-                return [Lintable(possible_path, kind=parent_type)]
 
-        _logger.error(msg)
+        _logger.error("Failed to find %s playbook.", v)
         return []
+
+    def _get_playbook_paths(
+        self,
+        lintable: Lintable,
+        v: str,
+        namespace_name: str,
+        collection_name: str,
+        playbook_path: list[str],
+    ) -> list[Path]:
+        """Build list of possible playbook paths to check."""
+        if not (namespace_name and collection_name):
+            return [lintable.path.parent / v]
+
+        paths: list[Path] = []
+        for loc in self.app.runtime.config.collections_paths:
+            for ext in (".yml", ".yaml"):
+                paths.append(
+                    Path(
+                        path_dwim(
+                            os.path.expanduser(loc),
+                            os.path.join(
+                                "ansible_collections",
+                                namespace_name,
+                                collection_name,
+                                "playbooks",
+                                *playbook_path[:-1],
+                                f"{playbook_path[-1]}{ext}",
+                            ),
+                        ),
+                    ),
+                )
+        return paths
 
     def _look_for_role_files(self, basedir: str, role: str) -> list[Lintable]:
         role_path = self._rolepath(basedir, role)

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -121,6 +121,8 @@ FMT_RE = re.compile(r"^# fmt:\s+(\S+)")
 
 _logger = logging.getLogger(__name__)
 
+_SYNTAX_CHECK_FAILED = "syntax_check_failed"
+
 # Vault secrets are resolved on first use and cached for the process lifetime.
 _vault_secrets: list[tuple[str, Any]] | None = None
 
@@ -631,16 +633,19 @@ class HandleChildren:
         is_collection: bool,
         parent_type: FileType,
         name: str,
-    ) -> list[Lintable] | str:
-        """Check a single playbook path and return Lintable or error message."""
+    ) -> list[Lintable] | tuple[str, str]:
+        """Check a single playbook path and return Lintable list or (tag, message) on failure."""
         if not possible_path.exists():
-            return f"Failed to find {name} playbook."
+            return ("not_found", f"Failed to find {name} playbook.")
         if not self.app.runtime.has_playbook(str(possible_path)):
             if not is_collection and self._recheck_playbook_with_extra_vars(
                 possible_path
             ):
                 return [Lintable(possible_path, kind=parent_type)]
-            return f"Failed to load {name} playbook due to failing syntax check."
+            return (
+                _SYNTAX_CHECK_FAILED,
+                f"Failed to load {name} playbook due to failing syntax check.",
+            )
         if is_collection:
             return []  # don't lint foreign playbook
         return [Lintable(possible_path, kind=parent_type)]
@@ -668,8 +673,9 @@ class HandleChildren:
             )
             if isinstance(result, list):
                 return result
-            if "syntax check" in result:
-                _logger.error(result)
+            tag, message = result
+            if tag == _SYNTAX_CHECK_FAILED:
+                _logger.error(message)
                 return []
 
         _logger.error("Failed to find %s playbook.", v)
@@ -683,7 +689,7 @@ class HandleChildren:
         collection_name: str,
         playbook_path: list[str],
     ) -> list[Path]:
-        """Build list of possible playbook paths to check."""
+        """Build list of possible playbook paths to check for an import_playbook reference."""
         if not (namespace_name and collection_name):
             return [lintable.path.parent / v]
 

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -687,25 +687,23 @@ class HandleChildren:
         if not (namespace_name and collection_name):
             return [lintable.path.parent / v]
 
-        paths: list[Path] = []
-        for loc in self.app.runtime.config.collections_paths:
-            for ext in (".yml", ".yaml"):
-                paths.append(
-                    Path(
-                        path_dwim(
-                            os.path.expanduser(loc),
-                            os.path.join(
-                                "ansible_collections",
-                                namespace_name,
-                                collection_name,
-                                "playbooks",
-                                *playbook_path[:-1],
-                                f"{playbook_path[-1]}{ext}",
-                            ),
-                        ),
+        return [
+            Path(
+                path_dwim(
+                    os.path.expanduser(loc),
+                    os.path.join(
+                        "ansible_collections",
+                        namespace_name,
+                        collection_name,
+                        "playbooks",
+                        *playbook_path[:-1],
+                        f"{playbook_path[-1]}{ext}",
                     ),
-                )
-        return paths
+                ),
+            )
+            for loc in self.app.runtime.config.collections_paths
+            for ext in (".yml", ".yaml")
+        ]
 
     def _look_for_role_files(self, basedir: str, role: str) -> list[Lintable]:
         role_path = self._rolepath(basedir, role)

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -28,6 +28,7 @@ import collections.abc
 import contextlib
 import copy
 import inspect
+import json
 import logging
 import os
 import re
@@ -651,6 +652,27 @@ class HandleChildren:
             elif not self.app.runtime.has_playbook(
                 str(possible_path),
             ):
+                extra_vars = self.app.options.extra_vars
+                is_collection = bool(namespace_name and collection_name)
+                # has_playbook() runs its syntax check without our configured
+                # extra_vars, so it wrongly fails on a local playbook that only
+                # loads once those vars are defined. Re-check with them before
+                # giving up, while still reporting genuinely broken playbooks.
+                if (
+                    extra_vars
+                    and not is_collection
+                    and self.app.runtime.run(
+                        [
+                            "ansible-playbook",
+                            "--syntax-check",
+                            str(possible_path),
+                            "--extra-vars",
+                            json.dumps(extra_vars),
+                        ],
+                    ).returncode
+                    == 0
+                ):
+                    return [Lintable(possible_path, kind=parent_type)]
                 msg = f"Failed to load {v} playbook due to failing syntax check."
                 break
             elif namespace_name and collection_name:

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -574,7 +574,17 @@ class HandleChildren:
         v: Sequence[Any],
         parent_type: FileType,
     ) -> list[Lintable]:
-        """Roles children."""
+        """Discover lintable files for roles declared in a playbook or role.
+        
+        Parameters:
+        	lintable (Lintable): File containing the role declarations.
+        	k (str): Key identifying the role declaration section.
+        	v (Sequence[Any]): Role declarations to resolve.
+        	parent_type (FileType): Type of the containing file.
+        
+        Returns:
+        	list[Lintable]: Files found for the declared roles.
+        """
         # pylint: disable=unused-argument # parent_type)
         basedir = str(lintable.path.parent)
         results: list[Lintable] = []
@@ -603,11 +613,15 @@ class HandleChildren:
         return results
 
     def _recheck_playbook_with_extra_vars(self, possible_path: Path) -> bool:
-        """Re-check playbook syntax with configured extra_vars.
-
-        has_playbook() runs its syntax check without our configured extra_vars,
-        so it wrongly fails on a local playbook that only loads once those vars
-        are defined. Re-check with them before giving up.
+        """
+        Re-check a playbook's syntax using the configured extra variables.
+        
+        Parameters:
+            possible_path (Path): Path to the playbook to validate.
+        
+        Returns:
+            bool: `True` if the syntax check succeeds with the configured extra
+            variables, `False` if no extra variables are configured or the check fails.
         """
         extra_vars = self.app.options.extra_vars
         if not extra_vars:
@@ -632,7 +646,18 @@ class HandleChildren:
         parent_type: FileType,
         name: str,
     ) -> list[Lintable] | str:
-        """Check a single playbook path and return Lintable or error message."""
+        """
+        Validate a candidate playbook path and return its lintable representation or an error message.
+        
+        Parameters:
+            possible_path (Path): Candidate playbook path.
+            is_collection (bool): Whether the playbook belongs to a foreign collection.
+            parent_type (FileType): File type assigned to the resulting lintable.
+            name (str): Playbook name used in error messages.
+        
+        Returns:
+            list[Lintable] | str: A list containing the lintable playbook, an empty list for foreign collection playbooks, or an error message.
+        """
         if not possible_path.exists():
             return f"Failed to find {name} playbook."
         if not self.app.runtime.has_playbook(str(possible_path)):
@@ -652,7 +677,16 @@ class HandleChildren:
         v: Any,
         parent_type: FileType,
     ) -> list[Lintable]:
-        """Include import_playbook children."""
+        """
+        Resolve an imported playbook and return its lintable child files.
+        
+        Parameters:
+            v (Any): A local or fully qualified playbook name.
+            parent_type (FileType): The file type of the importing parent.
+        
+        Returns:
+            list[Lintable]: Lintable files discovered from the playbook, or an empty list when the playbook cannot be resolved.
+        """
         if not isinstance(v, str):
             return []
 
@@ -706,6 +740,15 @@ class HandleChildren:
         ]
 
     def _look_for_role_files(self, basedir: str, role: str) -> list[Lintable]:
+        """Recursively collect YAML files from the task, metadata, handler, variable, and default directories of a role.
+        
+        Parameters:
+            basedir (str): Base directory used to resolve the role.
+            role (str): Role name or path to search.
+        
+        Returns:
+            list[Lintable]: Lintable objects for the role's discovered YAML files.
+        """
         role_path = self._rolepath(basedir, role)
         if not role_path:  # pragma: no branch
             return []

--- a/test/test_import_playbook.py
+++ b/test/test_import_playbook.py
@@ -1,7 +1,10 @@
 """Test ability to import playbooks."""
 
+from pathlib import Path
+
 from ansiblelint.rules import RulesCollection
 from ansiblelint.runner import Runner
+from ansiblelint.testing import run_ansible_lint
 
 
 def test_task_hook_import_playbook(default_rules_collection: RulesCollection) -> None:
@@ -44,3 +47,23 @@ def test_import_playbook_invalid(
     assert results[0].tag == "syntax-check[specific]"
     # ansible-core devel changes line number reported to 4 (better)
     assert results[0].lineno in (2, 4)
+
+
+def test_import_playbook_extra_vars(tmp_path: Path) -> None:
+    """Assure extra_vars reach a playbook imported via import_playbook (#5042)."""
+    (tmp_path / ".ansible-lint").write_text("extra_vars:\n  my_host: localhost\n")
+    (tmp_path / "inner.yml").write_text(
+        '---\n- name: Inner play\n  hosts: "{{ my_host }}"\n  gather_facts: false\n'
+        "  tasks:\n    - name: Noop\n      ansible.builtin.debug:\n        msg: hi\n",
+    )
+    (tmp_path / "outer.yml").write_text(
+        "---\n- name: Import inner\n  ansible.builtin.import_playbook: inner.yml\n",
+    )
+
+    result = run_ansible_lint("outer.yml", cwd=tmp_path)
+
+    # Without extra_vars propagation, inner.yml fails its syntax check and is
+    # silently dropped, leaving only one file processed while the run exits 0.
+    assert result.returncode == 0, result.stderr
+    assert "2 files processed" in result.stderr
+    assert "Failed to load" not in result.stderr

--- a/test/test_import_playbook.py
+++ b/test/test_import_playbook.py
@@ -89,12 +89,12 @@ def test_import_playbook_no_extra_vars(tmp_path: Path) -> None:
 
 
 def test_import_playbook_extra_vars_still_fails(tmp_path: Path) -> None:
-    """Verify genuinely broken playbooks still fail even with extra_vars."""
+    """Verify playbooks needing different vars still fail even with extra_vars."""
+    # extra_vars has my_host but the inner playbook needs undefined_var
     (tmp_path / ".ansible-lint").write_text("extra_vars:\n  my_host: localhost\n")
-    # This playbook has a genuine syntax error (invalid YAML indentation)
     (tmp_path / "inner.yml").write_text(
-        "---\n- name: Inner play\n  hosts: localhost\n  gather_facts: false\n"
-        "  tasks:\n  - name: Broken\n      ansible.builtin.debug:\n        msg: hi\n",
+        '---\n- name: Inner play\n  hosts: "{{ undefined_var }}"\n  gather_facts: false\n'
+        "  tasks:\n    - name: Noop\n      ansible.builtin.debug:\n        msg: hi\n",
     )
     (tmp_path / "outer.yml").write_text(
         "---\n- name: Import inner\n  ansible.builtin.import_playbook: inner.yml\n",
@@ -102,5 +102,5 @@ def test_import_playbook_extra_vars_still_fails(tmp_path: Path) -> None:
 
     result = run_ansible_lint("outer.yml", cwd=tmp_path)
 
-    # Even with extra_vars, genuinely broken playbooks should still fail.
+    # The re-check with extra_vars still fails because undefined_var is not defined.
     assert "Failed to load" in result.stderr

--- a/test/test_import_playbook.py
+++ b/test/test_import_playbook.py
@@ -67,3 +67,40 @@ def test_import_playbook_extra_vars(tmp_path: Path) -> None:
     assert result.returncode == 0, result.stderr
     assert "2 files processed" in result.stderr
     assert "Failed to load" not in result.stderr
+
+
+def test_import_playbook_no_extra_vars(tmp_path: Path) -> None:
+    """Verify imported playbook needing vars is dropped when no extra_vars configured."""
+    # No .ansible-lint config, so no extra_vars
+    (tmp_path / "inner.yml").write_text(
+        '---\n- name: Inner play\n  hosts: "{{ my_host }}"\n  gather_facts: false\n'
+        "  tasks:\n    - name: Noop\n      ansible.builtin.debug:\n        msg: hi\n",
+    )
+    (tmp_path / "outer.yml").write_text(
+        "---\n- name: Import inner\n  ansible.builtin.import_playbook: inner.yml\n",
+    )
+
+    result = run_ansible_lint("outer.yml", cwd=tmp_path)
+
+    # Without extra_vars, the imported playbook fails syntax check and is dropped.
+    # Only outer.yml is processed.
+    assert "1 file" in result.stderr
+    assert "Failed to load" in result.stderr
+
+
+def test_import_playbook_extra_vars_still_fails(tmp_path: Path) -> None:
+    """Verify genuinely broken playbooks still fail even with extra_vars."""
+    (tmp_path / ".ansible-lint").write_text("extra_vars:\n  my_host: localhost\n")
+    # This playbook has a genuine syntax error (invalid YAML indentation)
+    (tmp_path / "inner.yml").write_text(
+        "---\n- name: Inner play\n  hosts: localhost\n  gather_facts: false\n"
+        "  tasks:\n  - name: Broken\n      ansible.builtin.debug:\n        msg: hi\n",
+    )
+    (tmp_path / "outer.yml").write_text(
+        "---\n- name: Import inner\n  ansible.builtin.import_playbook: inner.yml\n",
+    )
+
+    result = run_ansible_lint("outer.yml", cwd=tmp_path)
+
+    # Even with extra_vars, genuinely broken playbooks should still fail.
+    assert "Failed to load" in result.stderr

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -854,7 +854,7 @@ def test_import_playbook_children_extra_vars_success(
     monkeypatch.setattr(
         utils.HandleChildren,
         "_recheck_playbook_with_extra_vars",
-        lambda self, _: True,
+        lambda _self, _path: True,
     )
 
     lintable = Lintable(outer)
@@ -892,7 +892,7 @@ def test_import_playbook_children_extra_vars_recheck_fails(
     monkeypatch.setattr(
         utils.HandleChildren,
         "_recheck_playbook_with_extra_vars",
-        lambda self, _: False,
+        lambda _self, _path: False,
     )
 
     lintable = Lintable(outer)
@@ -930,7 +930,7 @@ def test_import_playbook_children_no_extra_vars(
     # _recheck_playbook_with_extra_vars returns False when no extra_vars
     recheck_called = []
 
-    def mock_recheck(self: Any, _: Path) -> bool:
+    def mock_recheck(_self: Any, _path: Path) -> bool:
         recheck_called.append(True)
         return False
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -832,8 +832,6 @@ def test_import_playbook_children_extra_vars_success(
     monkeypatch: MonkeyPatch,
 ) -> None:
     """Verify import_playbook_children re-checks with extra_vars on initial failure."""
-    from unittest.mock import MagicMock
-
     from ansiblelint.app import App
     from ansiblelint.config import Options
     from ansiblelint.rules import RulesCollection
@@ -852,10 +850,12 @@ def test_import_playbook_children_extra_vars_success(
 
     # Mock has_playbook to return False (initial check fails)
     monkeypatch.setattr(app.runtime, "has_playbook", lambda _: False)
-    # Mock run to return success (re-check with extra_vars passes)
-    mock_result = MagicMock()
-    mock_result.returncode = 0
-    monkeypatch.setattr(app.runtime, "run", lambda _: mock_result)
+    # Mock _recheck_playbook_with_extra_vars at class level to return True
+    monkeypatch.setattr(
+        utils.HandleChildren,
+        "_recheck_playbook_with_extra_vars",
+        lambda self, _: True,
+    )
 
     lintable = Lintable(outer)
     children = handler.import_playbook_children(
@@ -872,8 +872,6 @@ def test_import_playbook_children_extra_vars_recheck_fails(
     caplog: LogCaptureFixture,
 ) -> None:
     """Verify import_playbook_children logs error when re-check also fails."""
-    from unittest.mock import MagicMock
-
     from ansiblelint.app import App
     from ansiblelint.config import Options
     from ansiblelint.rules import RulesCollection
@@ -890,10 +888,12 @@ def test_import_playbook_children_extra_vars_recheck_fails(
     handler = utils.HandleChildren(rules=rules, app=app)
 
     monkeypatch.setattr(app.runtime, "has_playbook", lambda _: False)
-    # Re-check also fails
-    mock_result = MagicMock()
-    mock_result.returncode = 1
-    monkeypatch.setattr(app.runtime, "run", lambda _: mock_result)
+    # Mock _recheck_playbook_with_extra_vars at class level to return False
+    monkeypatch.setattr(
+        utils.HandleChildren,
+        "_recheck_playbook_with_extra_vars",
+        lambda self, _: False,
+    )
 
     lintable = Lintable(outer)
     with caplog.at_level(logging.ERROR):
@@ -927,9 +927,18 @@ def test_import_playbook_children_no_extra_vars(
     handler = utils.HandleChildren(rules=rules, app=app)
 
     monkeypatch.setattr(app.runtime, "has_playbook", lambda _: False)
-    # run() should NOT be called since extra_vars is empty
-    run_called = []
-    monkeypatch.setattr(app.runtime, "run", lambda _: run_called.append(True))
+    # _recheck_playbook_with_extra_vars returns False when no extra_vars
+    recheck_called = []
+
+    def mock_recheck(self: Any, _: Path) -> bool:
+        recheck_called.append(True)
+        return False
+
+    monkeypatch.setattr(
+        utils.HandleChildren,
+        "_recheck_playbook_with_extra_vars",
+        mock_recheck,
+    )
 
     lintable = Lintable(outer)
     with caplog.at_level(logging.ERROR):
@@ -939,4 +948,5 @@ def test_import_playbook_children_no_extra_vars(
 
     assert children == []
     assert "Failed to load" in caplog.text
-    assert not run_called  # run() was never called
+    # recheck is called but returns False due to empty extra_vars
+    assert recheck_called

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -991,7 +991,8 @@ def test_resolve_playbook_path_not_exists(
 
     missing = tmp_path / "missing.yml"
     result = handler._resolve_playbook_path(missing, False, "playbook", "missing.yml")  # ruff:ignore[private-member-access]
-    assert result == "Failed to find missing.yml playbook."
+    assert isinstance(result, tuple)
+    assert result == ("not_found", "Failed to find missing.yml playbook.")
 
 
 def test_resolve_playbook_path_collection_success(

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -950,3 +950,162 @@ def test_import_playbook_children_no_extra_vars(
     assert "Failed to load" in caplog.text
     # recheck is called but returns False due to empty extra_vars
     assert recheck_called
+
+
+def test_recheck_playbook_with_extra_vars_no_vars(
+    tmp_path: Path,
+) -> None:
+    """Verify _recheck_playbook_with_extra_vars returns False when no extra_vars."""
+    from ansiblelint.app import App
+    from ansiblelint.config import Options
+    from ansiblelint.rules import RulesCollection
+
+    playbook = tmp_path / "test.yml"
+    playbook.write_text("---\n- hosts: localhost\n  tasks: []\n")
+
+    options = Options()
+    options.extra_vars = {}
+    app = App(options=options)
+    rules = RulesCollection(app=app)
+    handler = utils.HandleChildren(rules=rules, app=app)
+
+    result = handler._recheck_playbook_with_extra_vars(playbook)  # ruff:ignore[private-member-access]
+    assert result is False
+
+
+def test_resolve_playbook_path_not_exists(
+    tmp_path: Path,
+) -> None:
+    """Verify _resolve_playbook_path returns error when path doesn't exist."""
+    from ansiblelint.app import App
+    from ansiblelint.config import Options
+    from ansiblelint.rules import RulesCollection
+
+    outer = tmp_path / "outer.yml"
+    outer.write_text("---\n- import_playbook: missing.yml\n")
+
+    options = Options()
+    app = App(options=options)
+    rules = RulesCollection(app=app)
+    handler = utils.HandleChildren(rules=rules, app=app)
+
+    missing = tmp_path / "missing.yml"
+    result = handler._resolve_playbook_path(missing, False, "playbook", "missing.yml")  # ruff:ignore[private-member-access]
+    assert result == "Failed to find missing.yml playbook."
+
+
+def test_resolve_playbook_path_collection_success(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Verify _resolve_playbook_path returns empty list for valid collection playbook."""
+    from ansiblelint.app import App
+    from ansiblelint.config import Options
+    from ansiblelint.rules import RulesCollection
+
+    playbook = tmp_path / "test.yml"
+    playbook.write_text("---\n- hosts: localhost\n  tasks: []\n")
+
+    options = Options()
+    app = App(options=options)
+    rules = RulesCollection(app=app)
+    handler = utils.HandleChildren(rules=rules, app=app)
+
+    monkeypatch.setattr(app.runtime, "has_playbook", lambda _: True)
+
+    result = handler._resolve_playbook_path(playbook, True, "playbook", "test.yml")  # ruff:ignore[private-member-access]
+    assert result == []
+
+
+def test_resolve_playbook_path_local_success(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Verify _resolve_playbook_path returns Lintable for valid local playbook."""
+    from ansiblelint.app import App
+    from ansiblelint.config import Options
+    from ansiblelint.rules import RulesCollection
+
+    playbook = tmp_path / "test.yml"
+    playbook.write_text("---\n- hosts: localhost\n  tasks: []\n")
+
+    options = Options()
+    app = App(options=options)
+    rules = RulesCollection(app=app)
+    handler = utils.HandleChildren(rules=rules, app=app)
+
+    monkeypatch.setattr(app.runtime, "has_playbook", lambda _: True)
+
+    result = handler._resolve_playbook_path(playbook, False, "playbook", "test.yml")  # ruff:ignore[private-member-access]
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0].path == playbook
+
+
+def test_get_playbook_paths_local(tmp_path: Path) -> None:
+    """Verify _get_playbook_paths returns local path for non-collection."""
+    from ansiblelint.app import App
+    from ansiblelint.config import Options
+    from ansiblelint.rules import RulesCollection
+
+    outer = tmp_path / "outer.yml"
+    outer.write_text("---\n- import_playbook: inner.yml\n")
+
+    options = Options()
+    app = App(options=options)
+    rules = RulesCollection(app=app)
+    handler = utils.HandleChildren(rules=rules, app=app)
+
+    lintable = Lintable(outer)
+    paths = handler._get_playbook_paths(lintable, "inner.yml", "", "", [])  # ruff:ignore[private-member-access]
+    assert len(paths) == 1
+    assert paths[0] == tmp_path / "inner.yml"
+
+
+def test_import_playbook_children_non_string(tmp_path: Path) -> None:
+    """Verify import_playbook_children returns empty for non-string v."""
+    from ansiblelint.app import App
+    from ansiblelint.config import Options
+    from ansiblelint.rules import RulesCollection
+
+    outer = tmp_path / "outer.yml"
+    outer.write_text("---\n- import_playbook: inner.yml\n")
+
+    options = Options()
+    app = App(options=options)
+    rules = RulesCollection(app=app)
+    handler = utils.HandleChildren(rules=rules, app=app)
+
+    lintable = Lintable(outer)
+    # Pass a dict instead of string
+    result = handler.import_playbook_children(
+        lintable, "import_playbook", {"name": "invalid"}, "playbook"
+    )
+    assert result == []
+
+
+def test_import_playbook_children_missing_playbook(
+    tmp_path: Path,
+    caplog: LogCaptureFixture,
+) -> None:
+    """Verify import_playbook_children logs error for missing playbook."""
+    from ansiblelint.app import App
+    from ansiblelint.config import Options
+    from ansiblelint.rules import RulesCollection
+
+    outer = tmp_path / "outer.yml"
+    outer.write_text("---\n- import_playbook: missing.yml\n")
+
+    options = Options()
+    app = App(options=options)
+    rules = RulesCollection(app=app)
+    handler = utils.HandleChildren(rules=rules, app=app)
+
+    lintable = Lintable(outer)
+    with caplog.at_level(logging.ERROR):
+        result = handler.import_playbook_children(
+            lintable, "import_playbook", "missing.yml", "playbook"
+        )
+
+    assert result == []
+    assert "Failed to find missing.yml playbook" in caplog.text

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -825,3 +825,118 @@ def test_parser_error_helpers_cover_extracted_branches(
             {"name": "broken"},
             task,
         )
+
+
+def test_import_playbook_children_extra_vars_success(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Verify import_playbook_children re-checks with extra_vars on initial failure."""
+    from unittest.mock import MagicMock
+
+    from ansiblelint.app import App
+    from ansiblelint.config import Options
+    from ansiblelint.rules import RulesCollection
+
+    # Create a playbook file
+    inner = tmp_path / "inner.yml"
+    inner.write_text("---\n- hosts: localhost\n  tasks: []\n")
+    outer = tmp_path / "outer.yml"
+    outer.write_text("---\n- import_playbook: inner.yml\n")
+
+    options = Options()
+    options.extra_vars = {"my_host": "localhost"}
+    app = App(options=options)
+    rules = RulesCollection(app=app)
+    handler = utils.HandleChildren(rules=rules, app=app)
+
+    # Mock has_playbook to return False (initial check fails)
+    monkeypatch.setattr(app.runtime, "has_playbook", lambda _: False)
+    # Mock run to return success (re-check with extra_vars passes)
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    monkeypatch.setattr(app.runtime, "run", lambda _: mock_result)
+
+    lintable = Lintable(outer)
+    children = handler.import_playbook_children(
+        lintable, "import_playbook", "inner.yml", "playbook"
+    )
+
+    assert len(children) == 1
+    assert children[0].path.name == "inner.yml"
+
+
+def test_import_playbook_children_extra_vars_recheck_fails(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    caplog: LogCaptureFixture,
+) -> None:
+    """Verify import_playbook_children logs error when re-check also fails."""
+    from unittest.mock import MagicMock
+
+    from ansiblelint.app import App
+    from ansiblelint.config import Options
+    from ansiblelint.rules import RulesCollection
+
+    inner = tmp_path / "inner.yml"
+    inner.write_text("---\n- hosts: localhost\n  tasks: []\n")
+    outer = tmp_path / "outer.yml"
+    outer.write_text("---\n- import_playbook: inner.yml\n")
+
+    options = Options()
+    options.extra_vars = {"my_host": "localhost"}
+    app = App(options=options)
+    rules = RulesCollection(app=app)
+    handler = utils.HandleChildren(rules=rules, app=app)
+
+    monkeypatch.setattr(app.runtime, "has_playbook", lambda _: False)
+    # Re-check also fails
+    mock_result = MagicMock()
+    mock_result.returncode = 1
+    monkeypatch.setattr(app.runtime, "run", lambda _: mock_result)
+
+    lintable = Lintable(outer)
+    with caplog.at_level(logging.ERROR):
+        children = handler.import_playbook_children(
+            lintable, "import_playbook", "inner.yml", "playbook"
+        )
+
+    assert children == []
+    assert "Failed to load" in caplog.text
+
+
+def test_import_playbook_children_no_extra_vars(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    caplog: LogCaptureFixture,
+) -> None:
+    """Verify import_playbook_children skips re-check when no extra_vars."""
+    from ansiblelint.app import App
+    from ansiblelint.config import Options
+    from ansiblelint.rules import RulesCollection
+
+    inner = tmp_path / "inner.yml"
+    inner.write_text("---\n- hosts: localhost\n  tasks: []\n")
+    outer = tmp_path / "outer.yml"
+    outer.write_text("---\n- import_playbook: inner.yml\n")
+
+    options = Options()
+    options.extra_vars = {}  # No extra_vars
+    app = App(options=options)
+    rules = RulesCollection(app=app)
+    handler = utils.HandleChildren(rules=rules, app=app)
+
+    monkeypatch.setattr(app.runtime, "has_playbook", lambda _: False)
+    # run() should NOT be called since extra_vars is empty
+    run_called = []
+    monkeypatch.setattr(app.runtime, "run", lambda _: run_called.append(True))
+
+    lintable = Lintable(outer)
+    with caplog.at_level(logging.ERROR):
+        children = handler.import_playbook_children(
+            lintable, "import_playbook", "inner.yml", "playbook"
+        )
+
+    assert children == []
+    assert "Failed to load" in caplog.text
+    assert not run_called  # run() was never called


### PR DESCRIPTION
## Summary

- Re-checks imported playbooks with configured `extra_vars` when initial syntax check fails
- Adds regression test for the fix

## What

`ansible-lint` honors `extra_vars` from config when you lint a playbook directly, but not when the same playbook is reached through `import_playbook:`. Imported playbooks are discovered via `has_playbook()`, which runs `ansible-playbook --syntax-check` with no `extra_vars`, so a child whose `hosts:` (or any syntax-relevant field) depends on an extra var fails that check and is silently dropped from linting. The run still exits 0, which makes the gap easy to miss in CI.

This re-checks such a playbook with the configured `extra_vars` before giving up, so it gets linted whether it is passed directly or imported. Genuinely broken playbooks still fail the re-check and keep the current "Failed to load … syntax check" diagnostic.


Fixes #5042

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of imported local playbooks that require configured extra variables during syntax validation.
  * These playbooks are retried with the configured variables and can now be linted successfully instead of producing load errors.
  * Playbooks without extra variables continue to follow the standard validation flow.
  * Existing error handling is preserved when validation still fails.
  * Collection playbooks remain excluded from linting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->