### PR TITLE
fix: resolve short mock modules during syntax check

### DIFF
--- a/src/ansiblelint/app.py
+++ b/src/ansiblelint/app.py
@@ -420,6 +420,19 @@ def _add_module_path_if_needed(
             module_paths.insert(0, str(mock_path))
 
 
+def _update_path_env(
+    env: dict[str, str],
+    varname: str,
+    paths: list[str],
+) -> None:
+    """Prepend path entries to an environment variable without duplicates."""
+    if not paths:
+        return
+    current = env.get(varname, "")
+    values = [*paths, *(current.split(os.pathsep) if current else [])]
+    env[varname] = os.pathsep.join(dict.fromkeys(values))
+
+
 def _ensure_cache_collections_first(app: App) -> None:
     """Ensure the runtime cache collections directory is first in collections_paths."""
     if not app.runtime.cache_dir or app.runtime.config.collections_paths is None:
@@ -472,7 +485,11 @@ def get_app(*, offline: bool | None = None, cached: bool = False) -> App:
 
     # https://github.com/ansible/ansible-lint/issues/4973
     _add_collections_path_if_needed(app.options, app.runtime.config.collections_paths)
-    _add_module_path_if_needed(app.options, app.runtime.config.default_module_path)
+    default_module_paths = app.runtime.config.default_module_path
+    module_paths = default_module_paths.copy()
+    _add_module_path_if_needed(app.options, module_paths)
+    if module_paths != default_module_paths:
+        _update_path_env(app.runtime.environ, "ANSIBLE_LIBRARY", module_paths)
 
     _ensure_cache_collections_first(app)
 

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -111,6 +111,47 @@ def test_add_module_path_skips_collection_only_mocks(tmp_path: Path) -> None:
     assert module_paths == ["/usr/share/ansible/plugins/modules"]
 
 
+def test_update_path_env_prepends_without_duplicates() -> None:
+    """Verify _update_path_env prepends paths and removes duplicates."""
+    import os
+
+    from ansiblelint.app import _update_path_env
+
+    env: dict[str, str] = {"ANSIBLE_LIBRARY": "/existing/path"}
+    paths = ["/new/path", "/existing/path"]
+
+    _update_path_env(env, "ANSIBLE_LIBRARY", paths)
+
+    # Should prepend new paths and deduplicate
+    expected = os.pathsep.join(["/new/path", "/existing/path"])
+    assert env["ANSIBLE_LIBRARY"] == expected
+
+
+def test_update_path_env_empty_paths() -> None:
+    """Verify _update_path_env does nothing when paths is empty."""
+    from ansiblelint.app import _update_path_env
+
+    env: dict[str, str] = {"ANSIBLE_LIBRARY": "/existing/path"}
+    _update_path_env(env, "ANSIBLE_LIBRARY", [])
+
+    assert env["ANSIBLE_LIBRARY"] == "/existing/path"
+
+
+def test_update_path_env_no_existing_var() -> None:
+    """Verify _update_path_env works when env var doesn't exist."""
+    import os
+
+    from ansiblelint.app import _update_path_env
+
+    env: dict[str, str] = {}
+    paths = ["/new/path1", "/new/path2"]
+
+    _update_path_env(env, "ANSIBLE_LIBRARY", paths)
+
+    expected = os.pathsep.join(["/new/path1", "/new/path2"])
+    assert env["ANSIBLE_LIBRARY"] == expected
+
+
 def test_ignore_file_with_skip_and_strict(tmp_path: Path) -> None:
     """Test that .ansible-lint-ignore with skip qualifier returns exit code 0 with --strict.
 

--- a/test/test_mockings.py
+++ b/test/test_mockings.py
@@ -79,3 +79,19 @@ def test_mock_modules_stub_is_lintable(tmp_path: Path) -> None:
     )
     result = run_ansible_lint("playbook.yml", cwd=tmp_path)
     assert result.returncode == 0, result.stdout
+
+
+def test_short_mock_modules_stub_is_lintable(tmp_path: Path) -> None:
+    """Ensure short-name mock modules are resolved during syntax-check."""
+    (tmp_path / ".ansible-lint.yml").write_text("mock_modules:\n  - custom_module\n")
+    (tmp_path / "playbook.yml").write_text(
+        "---\n"
+        "- name: Test mocked short module\n"
+        "  hosts: localhost\n"
+        "  gather_facts: false\n"
+        "  tasks:\n"
+        "    - name: Run mocked short module\n"
+        "      custom_module:\n"
+    )
+    result = run_ansible_lint("playbook.yml", cwd=tmp_path)
+    assert result.returncode == 0, result.stdout


### PR DESCRIPTION
Short-name mock_modules (non-FQCN) were not visible to `ansible-playbook --syntax-check` because the generated stubs in the cache directory were not exported via ANSIBLE_LIBRARY.

- Add _update_path_env helper to prepend paths to env vars without duplicates
- Export ANSIBLE_LIBRARY when short mock module paths are added
- Keep existing collection mock behavior unchanged by only updating the env when module_paths differs from defaults
- Add end-to-end regression test for short-name mocked module

Fixes #5126

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resolution of short-name mocked modules during syntax checking.
  * Prevented duplicate or unintended changes to configured module search paths.
  * Ensured mock module paths are applied without altering the original configuration.
  * Improved environment path handling when adding, preserving, or initializing module search paths.

* **Tests**
  * Added coverage confirming that short-name mocked modules lint successfully.
  * Added coverage for path prepending, deduplication, empty inputs, and missing environment variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->