### PR TITLE
fix: apply profile-level skip list during linting

### DIFF
--- a/src/ansiblelint/app.py
+++ b/src/ansiblelint/app.py
@@ -43,6 +43,8 @@ class App:
 
     def __init__(self, options: Options):
         """Construct app run based on already loaded configuration."""
+        if options.profile:
+            options.skip_list.extend(PROFILES[options.profile].get("skip_list", []))
         options.skip_list = _sanitize_list_options(options.skip_list)
         options.warn_list = _sanitize_list_options(options.warn_list)
 

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -58,6 +58,23 @@ def test_with_inventory_concurrent_syntax_checks(tmp_path: Path) -> None:
         counter += 1
 
 
+def test_app_profile_skip_list_merged(tmp_path: Path) -> None:
+    """Profile skip_list entries are merged into options.skip_list during App init."""
+    from ansiblelint.app import App
+    from ansiblelint.config import Options
+
+    options = Options()
+    options.project_dir = str(tmp_path)
+    options.cache_dir = tmp_path / ".cache"
+    options.cache_dir.mkdir()
+    options.profile = "basic"
+
+    App(options)
+
+    assert "name[template]" in options.skip_list
+    assert "name[casing]" in options.skip_list
+
+
 def test_app_fixed_violations_coverage(tmp_path: Path) -> None:
     """Directly test App.report_outcome to get coverage on RC.FIXED_VIOLATIONS."""
     from ansiblelint.app import App

--- a/test/test_profiles.py
+++ b/test/test_profiles.py
@@ -3,11 +3,13 @@
 import platform
 import subprocess
 import sys
+from pathlib import Path
 
 from _pytest.capture import CaptureFixture
 
 from ansiblelint.rules import RulesCollection, filter_rules_with_profile
 from ansiblelint.rules.risky_shell_pipe import ShellWithoutPipefail
+from ansiblelint.testing import run_ansible_lint
 from ansiblelint.text import strip_ansi_escape
 
 
@@ -37,6 +39,29 @@ def test_profile_min_with_enable_list(empty_rule_collection: RulesCollection) ->
     assert len(empty_rule_collection.rules) == 5, (
         "enable_list rule was incorrectly removed by profile filtering."
     )
+
+
+def test_profile_skip_list(tmp_path: Path) -> None:
+    """Profile-specific skip entries are applied when linting."""
+    (tmp_path / ".ansible-lint").write_text("profile: basic\n", encoding="utf-8")
+    playbook = tmp_path / "playbook.yml"
+    playbook.write_text(
+        "---\n"
+        "- name: Test\n"
+        "  hosts: localhost\n"
+        "  gather_facts: false\n"
+        "  tasks:\n"
+        "    - name: test {{ variable }} task\n"
+        "      ansible.builtin.debug:\n"
+        "        msg: OK\n",
+        encoding="utf-8",
+    )
+
+    result = run_ansible_lint(playbook, cwd=tmp_path)
+
+    assert result.returncode == 0
+    assert "name[casing]" not in result.stdout
+    assert "name[template]" not in result.stdout
 
 
 def test_profile_listing(capfd: CaptureFixture[str]) -> None:


### PR DESCRIPTION
## Summary
- Merge the selected profile's `skip_list` entries into runtime options during `App` initialization, so profile-declared skips (e.g. `name[casing]` and `name[template]` in the `basic` profile) are actually honored.
- Add an end-to-end regression test confirming both subrules are suppressed under the `basic` profile.

Closes #5087
Supersedes #5125

## Test plan
- [x] `pytest test/test_profiles.py::test_profile_skip_list` passes
- [ ] Full CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Profile-specific skip rules are now applied correctly during linting.
  - Projects using the basic profile can suppress configured naming violations as expected.

- **Tests**
  - Added integration coverage to verify profile-based suppression for naming and template checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->