### PR TITLE
fix: warn users when directory expansion discovers new files

### DIFF
--- a/src/ansiblelint/file_utils.py
+++ b/src/ansiblelint/file_utils.py
@@ -614,12 +614,23 @@ def expand_dirs_in_lintables(lintables: set[Lintable]) -> None:
     if should_expand:
         # this relies on git and we do not want to call unless needed
         all_files = discover_lintables(options)
+        initial_count = len(lintables)
 
         for item in copy.copy(lintables):
             if item.path.is_dir():
                 for filename in all_files:
                     if path_is_inside(Path(filename), item.path):
                         lintables.add(Lintable(filename))
+
+        expanded_count = len(lintables) - initial_count
+        if expanded_count > 0:
+            _logger.warning(
+                "Directory expansion discovered %d file(s). "
+                "If this is more than expected, use 'exclude_paths' in your "
+                "ansible-lint configuration to narrow the scope. "
+                "See: https://docs.ansible.com/projects/lint/configuring/",
+                expanded_count,
+            )
 
 
 def _guess_parent(lintable: Lintable) -> Lintable | None:

--- a/test/test_file_utils.py
+++ b/test/test_file_utils.py
@@ -684,7 +684,7 @@ def test_expand_dirs_in_lintables_warns_on_expansion(
     lintables: set[Lintable] = {Lintable(".")}
     options.lintables = ["."]
     options.exclude_paths = []
-    with caplog.at_level(logging.WARNING, logger="ansiblelint.file_utils"):
+    with caplog.at_level(logging.WARNING):
         expand_dirs_in_lintables(lintables)
     assert "Directory expansion discovered" in caplog.text
     assert "exclude_paths" in caplog.text

--- a/test/test_file_utils.py
+++ b/test/test_file_utils.py
@@ -671,6 +671,7 @@ def test_expand_dirs_in_lintables_relative_paths(tmp_path: Path) -> None:
 def test_expand_dirs_in_lintables_warns_on_expansion(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
+    monkeypatch: MonkeyPatch,
 ) -> None:
     """Directory expansion emits a warning when new files are discovered."""
     project_dir = tmp_path / "project"
@@ -679,15 +680,11 @@ def test_expand_dirs_in_lintables_warns_on_expansion(
     task_file = role_dir / "tasks" / "main.yml"
     task_file.write_text("---\n- debug: msg=hi\n", encoding="utf-8")
 
-    original_cwd = Path.cwd()
-    try:
-        os.chdir(project_dir)
-        lintables: set[Lintable] = {Lintable(".")}
-        options.lintables = ["."]
-        options.exclude_paths = []
-        with caplog.at_level(logging.WARNING, logger="ansiblelint.file_utils"):
-            expand_dirs_in_lintables(lintables)
-        assert "Directory expansion discovered" in caplog.text
-        assert "exclude_paths" in caplog.text
-    finally:
-        os.chdir(original_cwd)
+    monkeypatch.chdir(project_dir)
+    lintables: set[Lintable] = {Lintable(".")}
+    options.lintables = ["."]
+    options.exclude_paths = []
+    with caplog.at_level(logging.WARNING, logger="ansiblelint.file_utils"):
+        expand_dirs_in_lintables(lintables)
+    assert "Directory expansion discovered" in caplog.text
+    assert "exclude_paths" in caplog.text

--- a/test/test_file_utils.py
+++ b/test/test_file_utils.py
@@ -666,3 +666,28 @@ def test_expand_dirs_in_lintables_relative_paths(tmp_path: Path) -> None:
         )
     finally:
         os.chdir(original_cwd)
+
+
+def test_expand_dirs_in_lintables_warns_on_expansion(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Directory expansion emits a warning when new files are discovered."""
+    project_dir = tmp_path / "project"
+    role_dir = project_dir / "roles" / "my_namespace" / "myRole"
+    (role_dir / "tasks").mkdir(parents=True)
+    task_file = role_dir / "tasks" / "main.yml"
+    task_file.write_text("---\n- debug: msg=hi\n", encoding="utf-8")
+
+    original_cwd = Path.cwd()
+    try:
+        os.chdir(project_dir)
+        lintables: set[Lintable] = {Lintable(".")}
+        options.lintables = ["."]
+        options.exclude_paths = []
+        with caplog.at_level(logging.WARNING, logger="ansiblelint.file_utils"):
+            expand_dirs_in_lintables(lintables)
+        assert "Directory expansion discovered" in caplog.text
+        assert "exclude_paths" in caplog.text
+    finally:
+        os.chdir(original_cwd)


### PR DESCRIPTION
## Summary

- Adds a runtime warning in `expand_dirs_in_lintables()` when directory expansion discovers files, telling users the count and pointing to `exclude_paths` configuration
- Addresses user confusion from #5094 where upgrading from v26.4.0 to v26.6.0 caused CI pipelines to suddenly fail with hundreds of new violations due to the corrected file discovery in #5080

## Test plan

- [x] New test `test_expand_dirs_in_lintables_warns_on_expansion` verifies warning is emitted
- [x] Existing test `test_expand_dirs_in_lintables_relative_paths` still passes
- [x] Manual verification: `ansible-lint --offline --profile=basic .` now shows `WARNING  Directory expansion discovered N file(s)` before violations

Fixes #5094

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Added a warning when directory scanning discovers additional files to lint.
  - The warning reports the number of newly found files and recommends using exclusion paths to narrow the scan.
  - This makes unexpected linting scope more visible and helps users refine directory-based scans.

- **Tests**
  - Added regression coverage confirming the warning appears with the discovered-file count and exclusion guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->