### PR TITLE
fix: resolve nested include_tasks relative paths

### DIFF
--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -213,6 +213,54 @@ def path_dwim(basedir: str, given: str) -> str:
     return str(dataloader.path_dwim(given))
 
 
+def _include_search_basedirs(lintable: Lintable | None, basedir: str) -> list[str]:
+    """Return basedirs to use while resolving nested task includes."""
+    basedirs = [basedir]
+    parent = lintable.parent if lintable else None
+    while parent:
+        if parent.path.is_absolute():
+            parent_basedir = str(parent.path.parent)
+            if parent_basedir not in basedirs:
+                basedirs.append(parent_basedir)
+        parent = parent.parent
+    return basedirs
+
+
+def _resolve_include_path(
+    lintable: Lintable | None,
+    basedir: str,
+    file_name: str,
+) -> str:
+    """Resolve a task include path, accounting for nested include context."""
+    search_basedirs = _include_search_basedirs(lintable, basedir)
+
+    for search_basedir in search_basedirs:
+        for candidate in (
+            path_dwim(search_basedir, file_name),
+            path_dwim(os.path.join(search_basedir, "tasks"), file_name),
+        ):
+            if os.path.exists(candidate):
+                return candidate
+
+    # Keep the historical upward search as a fallback for role layouts and
+    # task files that rely on project-root-relative include paths. When no
+    # candidate exists, return the same final path the old climbing logic used
+    # so missing external-ish includes are not pulled back into the current role.
+    result = path_dwim(basedir, file_name)
+    search_basedir = basedir
+    while True:
+        if os.path.exists(result):
+            return result
+        tasks_result = path_dwim(os.path.join(search_basedir, "tasks"), file_name)
+        if os.path.exists(tasks_result):
+            return tasks_result
+        new_basedir = os.path.dirname(search_basedir)
+        if new_basedir == search_basedir:
+            return result
+        search_basedir = new_basedir
+        result = path_dwim(search_basedir, file_name)
+
+
 def ansible_templar(basedir: Path, templatevars: Any) -> Templar:
     """Create an Ansible Templar using templatevars."""
     # `basedir` is the directory containing the lintable file.
@@ -471,21 +519,11 @@ class HandleChildren:
         else:
             return []
 
-        result = path_dwim(basedir, file)
-        while True:
-            if os.path.exists(result):
-                break
-            tasks_result = path_dwim(os.path.join(basedir, "tasks"), file)
-            if os.path.exists(tasks_result):
-                result = tasks_result
-                break
-            new_basedir = os.path.dirname(basedir)
-            if new_basedir == basedir:
-                break
-            basedir = new_basedir
-            result = path_dwim(basedir, file)
+        result = _resolve_include_path(lintable, basedir, file)
+        child = Lintable(result, kind=parent_type)
+        child.parent = lintable
 
-        return [Lintable(result, kind=parent_type)]
+        return [child]
 
     def taskshandlers_children(
         self,
@@ -514,6 +552,7 @@ class HandleChildren:
                     basedir,
                     k,
                     parent_type,
+                    lintable=lintable,
                 )
                 results.append(children)
                 continue
@@ -788,6 +827,7 @@ def _get_task_handler_children_for_tasks_or_playbooks(
     basedir: str,
     k: Any,
     parent_type: FileType,
+    lintable: Lintable | None = None,
 ) -> Lintable:
     """Try to get children of taskhandler for include/import tasks/playbooks."""
     child_type = k if parent_type == "playbook" else parent_type
@@ -817,20 +857,11 @@ def _get_task_handler_children_for_tasks_or_playbooks(
             if not file_name:
                 # ignore invalid data (syntax check will outside the scope)
                 continue
-            f = path_dwim(basedir, file_name)
-            while True:
-                if os.path.exists(f):
-                    break
-                tasks_f = path_dwim(os.path.join(basedir, "tasks"), file_name)
-                if os.path.exists(tasks_f):
-                    f = tasks_f
-                    break
-                new_basedir = os.path.dirname(basedir)
-                if new_basedir == basedir:
-                    break
-                basedir = new_basedir
-                f = path_dwim(basedir, file_name)
-            return Lintable(f, kind=child_type)
+            f = _resolve_include_path(lintable, basedir, file_name)
+            child = Lintable(f, kind=child_type)
+            if lintable:
+                child.parent = lintable
+            return child
     msg = f"The node contains none of: {', '.join(sorted(INCLUSION_ACTION_NAMES))}"
     raise LookupError(msg)
 

--- a/test/test_file_path_evaluation.py
+++ b/test/test_file_path_evaluation.py
@@ -129,3 +129,54 @@ def test_file_path_evaluation(
 
     assert len(result) == 1
     assert result[0].rule.id == "fqcn"
+
+
+def test_include_tasks_file_path_uses_parent_playbook_context(
+    tmp_path: Path,
+    default_rules_collection: RulesCollection,
+) -> None:
+    """Check include_tasks file paths in nested tasks can use playbook context."""
+    ansible_project_layout = {
+        "extensions/molecule/shared/playbooks/prepare.yml": textwrap.dedent(
+            """\
+            ---
+            - name: Fixture
+              hosts: localhost
+              gather_facts: false
+              tasks:
+                - name: Include scenario prepare tasks
+                  ansible.builtin.include_tasks: ../../default/tasks/prepare/all.yml
+            """,
+        ),
+        "extensions/molecule/default/tasks/prepare/all.yml": textwrap.dedent(
+            """\
+            ---
+            - name: Init state via shared task
+              ansible.builtin.include_tasks:
+                file: ../tasks/state_update.yml
+            """,
+        ),
+        "extensions/molecule/shared/tasks/state_update.yml": textwrap.dedent(
+            """\
+            ---
+            - name: Merge update into state
+              ansible.builtin.debug:
+                msg: State updated
+            """,
+        ),
+    }
+    for file_path, file_content in ansible_project_layout.items():
+        full_path = tmp_path / file_path
+        full_path.parent.mkdir(parents=True, exist_ok=True)
+        full_path.write_text(file_content)
+
+    runner = Runner(
+        str(tmp_path / "extensions/molecule/shared/playbooks/prepare.yml"),
+        rules=default_rules_collection,
+    )
+    result = runner.run()
+
+    assert not [match for match in result if match.rule.id == "load-failure"]
+    assert any(
+        lintable.path.name == "state_update.yml" for lintable in runner.lintables
+    )


### PR DESCRIPTION
## Summary
- Resolve nested task include paths using the parent include/playbook context before falling back to the historical upward search
- Add a regression test for `include_tasks: file: ../tasks/state_update.yml` resolving from an included task file

Fixes #5051

## Tests
- `uv run pytest test/test_task_includes.py test/test_import_tasks.py test/test_import_playbook.py test/test_file_path_evaluation.py test/test_include_miss_file_with_role.py`
- `uv run ruff check src/ansiblelint/utils.py test/test_file_path_evaluation.py`
- `uv run ruff format --check src/ansiblelint/utils.py test/test_file_path_evaluation.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed nested task and handler includes so referenced files resolve correctly from the parent playbook context.
  * Improved include-path searching across relevant project directories and task folders.
  * Nested included files are now linted reliably without false `load-failure` errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->