### PR TITLE
Add validate_argspec to play-level schema keywords

### DIFF
--- a/src/ansiblelint/schemas/ansible.json
+++ b/src/ansiblelint/schemas/ansible.json
@@ -636,6 +636,10 @@
           "title": "Remote User",
           "type": "string"
         },
+        "validate_argspec": {
+          "$ref": "#/$defs/templated-boolean",
+          "title": "Validate Argspec"
+        },
         "vars": {
           "title": "Vars",
           "type": "object"

--- a/src/ansiblelint/schemas/playbook.json
+++ b/src/ansiblelint/schemas/playbook.json
@@ -646,6 +646,10 @@
           "title": "Remote User",
           "type": "string"
         },
+        "validate_argspec": {
+          "$ref": "#/$defs/templated-boolean",
+          "title": "Validate Argspec"
+        },
         "vars": {
           "title": "Vars",
           "type": "object"

--- a/test/schemas/test/playbooks/validate_argspec.yml
+++ b/test/schemas/test/playbooks/validate_argspec.yml
@@ -1,0 +1,8 @@
+- name: Minimal reproducer
+  hosts: localhost
+  gather_facts: false
+  validate_argspec: true
+  tasks:
+    - name: Test
+      ansible.builtin.debug:
+        msg: Test


### PR DESCRIPTION
## Summary

Fixes #5168.

The `validate_argspec` play keyword (a Tech Preview feature in ansible-core for validating role/playbook argument specs) is a valid play-level keyword recognized by ansible-core, but it was missing from ansible-lint's JSON schema for plays. As a result, any playbook using `validate_argspec: true` at the play level was flagged by the `schema[playbook]` rule with an `additionalProperties`/`oneOf` validation error, even though the playbook is valid and runs correctly with ansible-core.

## Fix

- Added `validate_argspec` (as a `templated-boolean`, consistent with similar boolean play keywords like `any_errors_fatal`) to the `play` `$defs` entry in the source schema `src/ansiblelint/schemas/ansible.json`.
- Regenerated the derived `src/ansiblelint/schemas/playbook.json` via the project's own `test/schemas/src/rebuild.py` generator, per the file's own `"do not edit"` comment. I confirmed the regenerated diff is byte-identical to what a manual edit of `playbook.json` would have produced.
- Added a minimal positive test fixture `test/schemas/test/playbooks/validate_argspec.yml` directly reproducing the issue's own repro case.

## Verification

- Ran the real schema test suite (`npm test`, which runs `rebuild.py` then `mocha`/`ajv`) in `test/schemas/`: 287 tests passing, including the new fixture validated against both `ansible.json#/$defs/playbook` and the generated `playbook.json`.
- Revert-check: temporarily reverted the `ansible.json` change (regenerating `playbook.json` from the reverted source) and reran the suite — it reproduces exactly the original error reported in the issue (`additionalProperties`/`oneOf` failures on `validate_argspec`), confirming both the fix and the new test correctly catch the regression.

Signed-off-by: agu2347 <agu2347@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the optional `validate_argspec` setting in play definitions.
  - The setting accepts boolean values and Jinja templates.

- **Tests**
  - Added coverage for playbooks using `validate_argspec: true`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->