### PR TITLE
fix: inject plain-name mock roles path regardless of --offline

### DIFF
--- a/src/ansiblelint/app.py
+++ b/src/ansiblelint/app.py
@@ -422,6 +422,25 @@ def _add_module_path_if_needed(
             module_paths.insert(0, str(mock_path))
 
 
+def _add_roles_path_if_needed(
+    options: Options,
+    roles_paths: list[str],
+) -> None:
+    """Add plain mock roles path to roles_paths if plain-name role mocks exist.
+
+    Mirrors _add_module_path_if_needed / _add_collections_path_if_needed:
+    injecting the mock roles path into the search path must not depend on the
+    runtime's `isolated` setting (which --offline turns off), only on whether
+    _perform_mockings() actually materialized any plain-name role mocks there.
+    """
+    if options.cache_dir and any(
+        len(role_name.split(".")) < 3 for role_name in options.mock_roles
+    ):
+        mock_path = options.cache_dir / "roles"
+        if str(mock_path) not in roles_paths:
+            roles_paths.insert(0, str(mock_path))
+
+
 def _update_path_env(
     env: dict[str, str],
     varname: str,
@@ -492,6 +511,13 @@ def get_app(*, offline: bool | None = None, cached: bool = False) -> App:
     _add_module_path_if_needed(app.options, module_paths)
     if module_paths != default_module_paths:
         _update_path_env(app.runtime.environ, "ANSIBLE_LIBRARY", module_paths)
+
+    # https://github.com/ansible/ansible-lint/issues/5096
+    default_roles_paths = app.runtime.config.default_roles_path
+    roles_paths = default_roles_paths.copy()
+    _add_roles_path_if_needed(app.options, roles_paths)
+    if roles_paths != default_roles_paths:
+        _update_path_env(app.runtime.environ, "ANSIBLE_ROLES_PATH", roles_paths)
 
     _ensure_cache_collections_first(app)
 

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -128,6 +128,41 @@ def test_add_module_path_skips_collection_only_mocks(tmp_path: Path) -> None:
     assert module_paths == ["/usr/share/ansible/plugins/modules"]
 
 
+def test_add_roles_path_for_plain_mock_roles(tmp_path: Path) -> None:
+    """Plain role mocks are exposed through Ansible's roles path.
+
+    Regression test for https://github.com/ansible/ansible-lint/issues/5096: this
+    injection must not depend on Runtime.isolated (which --offline turns off), only
+    on whether _perform_mockings() actually created a plain-name role mock.
+    """
+    from ansiblelint.app import _add_roles_path_if_needed
+    from ansiblelint.config import Options
+
+    options = Options()
+    options.cache_dir = tmp_path / ".ansible"
+    options.mock_roles = ["my_role", "some.collection.role"]
+    roles_paths = ["/usr/share/ansible/roles"]
+
+    _add_roles_path_if_needed(options, roles_paths)
+
+    assert roles_paths[0] == str(options.cache_dir / "roles")
+
+
+def test_add_roles_path_skips_collection_only_mocks(tmp_path: Path) -> None:
+    """Collection-style role mocks are exposed through collection paths instead."""
+    from ansiblelint.app import _add_roles_path_if_needed
+    from ansiblelint.config import Options
+
+    options = Options()
+    options.cache_dir = tmp_path / ".ansible"
+    options.mock_roles = ["some.collection.role"]
+    roles_paths = ["/usr/share/ansible/roles"]
+
+    _add_roles_path_if_needed(options, roles_paths)
+
+    assert roles_paths == ["/usr/share/ansible/roles"]
+
+
 def test_update_path_env_prepends_without_duplicates() -> None:
     """Verify _update_path_env prepends paths and removes duplicates."""
     import os


### PR DESCRIPTION
Fixes #5096.

## Root cause

#5066 changed `Runtime`'s `isolated` setting to `not options.offline`, so `--offline` turns isolation off. But `ansible_compat.runtime.Runtime._prepare_ansible_paths()` only injects the cache dir's mocked roles/modules/collections into ansible-core's search paths when `isolated` is true — so `--offline` silently stopped making plain-name `mock_roles` entries (materialized at `cache_dir/roles/<name>` by `_perform_mockings()`) discoverable via `ANSIBLE_ROLES_PATH`.

Collection-style mocks (`namespace.collection.role`) were unaffected, since `_add_collections_path_if_needed()` in `app.py`'s `get_app()` already injects those into `collections_paths` unconditionally, independent of `isolated`/`offline`.

## Fix

This can be fixed entirely within ansible-lint, without touching `ansible-compat`: the exact same unconditional-injection pattern already exists for plain-name mock **modules**, via `_add_module_path_if_needed()` + `_update_path_env(..., "ANSIBLE_LIBRARY", ...)`. I added `_add_roles_path_if_needed()`, mirroring that function exactly, and wired it into `get_app()` right alongside the module-path injection, pushing `cache_dir/roles` into `ANSIBLE_ROLES_PATH` whenever a plain-name role mock exists — with no dependency on `isolated`/`offline` at all.

## Testing

I want to be upfront about a real limitation: I developed this on Windows, and `ansible-core` imports the Unix-only `fcntl` module at `ansible/utils/display.py` import time, so the project's `test/conftest.py` (which pulls in `ansiblelint.testing` → `ansiblelint.runner` → `ansible.plugins.loader`) fails to even collect on my machine, and I don't have a Linux/WSL environment available to fall back to. So I could not run the actual pytest suite end-to-end.

What I did do:
- Added `test_add_roles_path_for_plain_mock_roles` and `test_add_roles_path_skips_collection_only_mocks` to `test/test_app.py`, mirroring the existing `test_add_module_path_for_plain_mock_modules` / `test_add_module_path_skips_collection_only_mocks` tests exactly.
- Verified both new tests' assertions by importing `ansiblelint.app` and `ansiblelint.config` directly in a plain Python REPL (bypassing the `ansible.plugins.loader` import chain that requires `fcntl`) and running the same logic manually — both pass.
- `ruff check`, `ruff format --check`, and `mypy src/ansiblelint/app.py` are all clean (these are pure static analysis, unaffected by the `fcntl` issue).
- The fix itself is a direct structural mirror of `_add_module_path_if_needed`, which is already shipped, tested (in CI, on Linux), and working for the exact analogous case.

If a maintainer can confirm this against a real run (or point me at a CI-only path to validate it), happy to iterate further.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Plain-name mocked roles are now discovered correctly during linting.
  - Mock role paths are applied even when offline mode is enabled.
  - Collection-style role mocks continue to use the existing role path behavior without unintended changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->