### PR TITLE
fix: use ThreadPoolExecutor for syntax check workers

### DIFF
--- a/src/ansiblelint/runner.py
+++ b/src/ansiblelint/runner.py
@@ -3,12 +3,10 @@
 from __future__ import annotations
 
 import concurrent.futures
-import contextlib
 import json
 import logging
 import math
 import multiprocessing
-import multiprocessing.pool
 import os
 import re
 import subprocess
@@ -312,23 +310,14 @@ class Runner:
         worker: Any,
         files: list[Lintable],
     ) -> list[list[MatchError]]:
-        try:
-            pool = multiprocessing.pool.ThreadPool(processes=threads())
-        except OSError:
-            _logger.info(
-                "ThreadPool creation failed (likely missing /dev/shm), "
-                "falling back to concurrent.futures.ThreadPoolExecutor"
-            )
-            with concurrent.futures.ThreadPoolExecutor(
-                max_workers=threads()
-            ) as executor:
-                return list(executor.map(worker, files))
-
-        try:
-            return pool.map(worker, files, chunksize=1)
-        finally:
-            pool.close()
-            pool.join()
+        # Use ThreadPoolExecutor instead of multiprocessing.pool.ThreadPool.
+        # The latter spawns daemon worker threads that conflict with coverage's
+        # trace hooks under pytest, causing flaky PytestUnraisableExceptionWarning
+        # failures (see scheduled CI on 2026-09-02).
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=threads(),
+        ) as executor:
+            return list(executor.map(worker, files))
 
     def _run_syntax_check_phase(
         self,
@@ -344,11 +333,6 @@ class Runner:
             )
 
         files = self._collect_syntax_check_files()
-
-        # avoid resource leak warning, https://github.com/python/cpython/issues/90549
-        # pylint: disable=unused-variable
-        with contextlib.suppress(OSError):
-            _global_resource = multiprocessing.Semaphore()
 
         return_list = self._map_syntax_check_workers(worker, files)
         for data in return_list:

--- a/src/ansiblelint/runner.py
+++ b/src/ansiblelint/runner.py
@@ -312,8 +312,7 @@ class Runner:
     ) -> list[list[MatchError]]:
         # Use ThreadPoolExecutor instead of multiprocessing.pool.ThreadPool.
         # The latter spawns daemon worker threads that conflict with coverage's
-        # trace hooks under pytest, causing flaky PytestUnraisableExceptionWarning
-        # failures (see scheduled CI on 2026-09-02).
+        # trace hooks under pytest, causing flaky scheduled CI failures.
         with concurrent.futures.ThreadPoolExecutor(
             max_workers=threads(),
         ) as executor:

--- a/src/ansiblelint/schemas/__store__.json
+++ b/src/ansiblelint/schemas/__store__.json
@@ -4,7 +4,7 @@
     "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/ansible-lint-config.json"
   },
   "ansible-navigator-config": {
-    "etag": "5f454fdaeb3d92c4bb2cc15dcc48faa67925fecfbdb72efffeddee01860d6bcb",
+    "etag": "927d967723eafb64a0a46db6b2be4b92472fd443a0f315925e475fddfb1d1e09",
     "url": "https://raw.githubusercontent.com/ansible/ansible-navigator/main/src/ansible_navigator/data/ansible-navigator.json"
   },
   "changelog": {

--- a/src/ansiblelint/schemas/ansible-navigator-config.json
+++ b/src/ansiblelint/schemas/ansible-navigator-config.json
@@ -285,11 +285,12 @@
                     "properties": {
                         "container-engine": {
                             "default": "auto",
-                            "description": "Specify the container engine (auto=podman then docker)",
+                            "description": "Specify the container engine (auto=podman then docker then container)",
                             "enum": [
                                 "auto",
                                 "podman",
-                                "docker"
+                                "docker",
+                                "container"
                             ],
                             "type": "string"
                         },

--- a/test/test_runner.py
+++ b/test/test_runner.py
@@ -351,23 +351,20 @@ def test_build_load_failure_match_empty_args(
     )
 
 
-def test_map_syntax_check_workers_threadpool_fallback(
+def test_map_syntax_check_workers(
     default_rules_collection: RulesCollection,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """OSError during ThreadPool creation must fall back to ThreadPoolExecutor."""
-    import multiprocessing.pool
-
+    """Syntax check workers must map over all files."""
     runner = Runner(
         "examples/playbooks/become.yml",
         rules=default_rules_collection,
     )
-
-    def boom(*_args: Any, **_kwargs: Any) -> Any:
-        msg = "No space left on device"
-        raise OSError(msg)
-
-    monkeypatch.setattr(multiprocessing.pool, "ThreadPool", boom)
-    files = [Lintable("examples/playbooks/become.yml")]
-    results = runner._map_syntax_check_workers(lambda _f: [], files)  # ruff:ignore[private-member-access]
-    assert results == [[]]
+    files = [
+        Lintable("examples/playbooks/become.yml"),
+        Lintable("examples/playbooks/valid.yml"),
+    ]
+    results = runner._map_syntax_check_workers(  # ruff:ignore[private-member-access]
+        lambda lintable: [lintable.path.name],
+        files,
+    )
+    assert results == [["become.yml"], ["valid.yml"]]


### PR DESCRIPTION
## Summary
- Replace `multiprocessing.pool.ThreadPool` with `concurrent.futures.ThreadPoolExecutor` for ansible syntax check workers
- Removes the semaphore workaround that only existed for the old ThreadPool
- Fixes flaky scheduled CI failures where `test_galaxy_no_collection_version` failed with `PytestUnraisableExceptionWarning` due to coverage trace hooks conflicting with daemon worker threads

## Test plan
- [x] `pytest test/test_runner.py::test_map_syntax_check_workers`
- [x] `pytest src/ansiblelint/rules/galaxy.py::test_galaxy_no_collection_version`
- [x] Full `test/test_runner.py` x3 under `coverage run`
- [ ] CI green on PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of syntax-check processing by consistently using the supported worker execution path.
  * Ensured syntax checks run for every lintable item while preserving the expected result structure.
  * Updated the Ansible Navigator configuration schema to recognize `container` as a container engine.
  * Clarified that automatic container-engine selection falls back in the order: Podman, Docker, then Container.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->