### PR TITLE
fix: respect skip_list for yaml[comments] during --fix

### DIFF
--- a/src/ansiblelint/transformer.py
+++ b/src/ansiblelint/transformer.py
@@ -51,6 +51,10 @@ class Transformer:
         """Initialize a Transformer instance."""
         self.write_set = self.effective_write_set(options.write_list)
         self.write_exclude_set = self.effective_write_set(options.write_exclude_list)
+        self.fix_comment_spaces = not any(
+            tag in (options.skip_list or [])
+            for tag in ("yaml[comments]", "yaml")
+        )
         self.warn_list = set(options.warn_list)
 
         self.matches: list[MatchError] = result.matches
@@ -118,6 +122,7 @@ class Transformer:
                 yaml = FormattedYAML(
                     # Ansible only uses YAML 1.1, but others files should use newer 1.2 (ruamel.yaml defaults to 1.2)
                     version=(1, 1) if file.is_owned_by_ansible() else None,
+                    fix_comment_spaces=self.fix_comment_spaces,
                 )
 
                 ruamel_data = yaml.load(data)

--- a/src/ansiblelint/transformer.py
+++ b/src/ansiblelint/transformer.py
@@ -52,7 +52,8 @@ class Transformer:
         self.write_set = self.effective_write_set(options.write_list)
         self.write_exclude_set = self.effective_write_set(options.write_exclude_list)
         self.fix_comment_spaces = not any(
-            tag in (options.skip_list or []) for tag in ("yaml[comments]", "yaml")
+            tag in (options.skip_list or []) or tag in (options.warn_list or [])
+            for tag in ("yaml[comments]", "yaml")
         )
         self.warn_list = set(options.warn_list)
 

--- a/src/ansiblelint/transformer.py
+++ b/src/ansiblelint/transformer.py
@@ -52,8 +52,7 @@ class Transformer:
         self.write_set = self.effective_write_set(options.write_list)
         self.write_exclude_set = self.effective_write_set(options.write_exclude_list)
         self.fix_comment_spaces = not any(
-            tag in (options.skip_list or [])
-            for tag in ("yaml[comments]", "yaml")
+            tag in (options.skip_list or []) for tag in ("yaml[comments]", "yaml")
         )
         self.warn_list = set(options.warn_list)
 

--- a/src/ansiblelint/yaml_utils.py
+++ b/src/ansiblelint/yaml_utils.py
@@ -624,6 +624,10 @@ class FormattedEmitter(Emitter):
 
     _in_empty_flow_map = False
 
+    # Set to False when yaml[comments] is in skip_list to avoid reformatting
+    # comments even while other fixes are applied. See github issue #5048.
+    fix_comment_spaces = True
+
     @property
     def _is_root_level_sequence(self) -> bool:
         """Return True if this is a sequence at the root level of the yaml document."""
@@ -835,7 +839,8 @@ class FormattedEmitter(Emitter):
             # single blank lines in post comments
             value = self._re_repeat_blank_lines.sub("\n\n", value)
 
-        value = self._re_missing_comment_space.sub(r"\1 ", value)
+        if self.fix_comment_spaces:
+            value = self._re_missing_comment_space.sub(r"\1 ", value)
 
         comment.value = value
 
@@ -875,6 +880,7 @@ class FormattedYAML(YAML):
         plug_ins: list[str] | None = None,
         version: tuple[int, int] | None = None,
         config: dict[str, bool | int | str] | None = None,
+        fix_comment_spaces: bool = True,
     ):
         """Return a configured ``ruamel.yaml.YAML`` instance.
 
@@ -968,6 +974,16 @@ class FormattedYAML(YAML):
 
         # If someone doesn't want our FormattedEmitter, they can change it.
         self.Emitter = FormattedEmitter
+
+        # When yaml[comments] is in skip_list, disable the comment-space
+        # reformatting in the emitter so --fix doesn't touch comments even
+        # while applying other transforms (see github issue #5048).
+        if not fix_comment_spaces:
+
+            class _FormattedEmitterNoCommentFix(FormattedEmitter):
+                fix_comment_spaces = False
+
+            self.Emitter = _FormattedEmitterNoCommentFix
 
         # ignore invalid preferred_quote setting
         if preferred_quote in ['"', "'"]:

--- a/src/ansiblelint/yaml_utils.py
+++ b/src/ansiblelint/yaml_utils.py
@@ -884,12 +884,12 @@ class FormattedEmitter(Emitter):
 
         if self.fix_comment_spaces:
             value = self._re_missing_comment_space.sub(r"\1 ", value)
-
-        comment.value = value
-
-        # make sure that the eol comment only has one space before it.
-        if comment.column > self.column + 1 and not pre:
-            comment.column = self.column + 1
+            comment.value = value
+            # make sure that the eol comment only has one space before it.
+            if comment.column > self.column + 1 and not pre:
+                comment.column = self.column + 1
+        else:
+            comment.value = value
 
         return super().write_comment(comment, pre)
 

--- a/test/test_transformer.py
+++ b/test/test_transformer.py
@@ -824,53 +824,29 @@ def test_transformer_respects_yaml_comments_skip_list(
     When yaml[comments] is in skip_list, the Transformer should not
     reformat comment spacing even when other fixes are applied.
     """
-    # Create a file with comment that lacks space after #
-    playbook = tmp_path / "test.yml"
-    content = "---\nfoo: bar\n#test-comment\nbaz: qux\n"
-    playbook.write_text(content)
-
-    # Test 1: Without skip_list - should fix comment spacing
+    # Test the fix_comment_spaces flag behavior
+    # Without skip_list, fix_comment_spaces should be True
     options = Options()
     options.write_list = ["yaml"]
-    options.lintables = [str(playbook)]
+    options.lintables = [str(tmp_path / "test.yml")]
     result = get_matches(rules=default_rules_collection, options=options)
     transformer = Transformer(result, options)
-    transformer.run()
+    assert transformer.fix_comment_spaces is True
 
-    fixed_content = playbook.read_text()
-    # Should have added space after #
-    assert "# test-comment" in fixed_content or "#test-comment" in fixed_content
-
-    # Reset file
-    playbook.write_text(content)
-
-    # Test 2: With yaml[comments] in skip_list - should preserve #test-comment
+    # With yaml[comments] in skip_list, fix_comment_spaces should be False
     options2 = Options()
     options2.write_list = ["yaml"]
     options2.skip_list = ["yaml[comments]"]
-    options2.lintables = [str(playbook)]
+    options2.lintables = [str(tmp_path / "test.yml")]
     result2 = get_matches(rules=default_rules_collection, options=options2)
     transformer2 = Transformer(result2, options2)
     assert transformer2.fix_comment_spaces is False
-    transformer2.run()
 
-    fixed_content2 = playbook.read_text()
-    # Should preserve the comment without space
-    assert "#test-comment" in fixed_content2
-
-    # Reset file
-    playbook.write_text(content)
-
-    # Test 3: With yaml in skip_list - should also preserve #test-comment
+    # With yaml in skip_list, fix_comment_spaces should also be False
     options3 = Options()
     options3.write_list = ["yaml"]
     options3.skip_list = ["yaml"]
-    options3.lintables = [str(playbook)]
+    options3.lintables = [str(tmp_path / "test.yml")]
     result3 = get_matches(rules=default_rules_collection, options=options3)
     transformer3 = Transformer(result3, options3)
     assert transformer3.fix_comment_spaces is False
-    transformer3.run()
-
-    fixed_content3 = playbook.read_text()
-    # Should preserve the comment without space
-    assert "#test-comment" in fixed_content3

--- a/test/test_transformer.py
+++ b/test/test_transformer.py
@@ -813,3 +813,54 @@ def test_transform_not_applied(
     log_2 = f"{transformer.DUMP_MSG} {TransformTests.rewrite_part()}"
     assert logs[2].message == log_2
     assert logs[2].levelname == "DEBUG"
+
+
+def test_transformer_respects_yaml_comments_skip_list(
+    tmp_path: Path,
+    default_rules_collection: RulesCollection,
+) -> None:
+    """Test that yaml[comments] in skip_list prevents comment reformatting.
+
+    When yaml[comments] is in skip_list, the Transformer should not
+    reformat comment spacing even when other fixes are applied.
+    """
+    # Create a file with comment spacing issue
+    playbook = tmp_path / "test.yml"
+    playbook.write_text(
+        "---\n"
+        "- name: Test\n"
+        "  hosts: localhost\n"
+        "  tasks:\n"
+        "    - name: Task 1\n"
+        "      debug:\n"
+        "        msg:test  # comment without space\n"
+    )
+
+    # First without skip_list - should fix comments
+    options = Options()
+    options.write_list = ["yaml[comments]"]
+    options.lintables = [str(playbook)]
+    result = get_matches(rules=default_rules_collection, options=options)
+
+    transformer = Transformer(result, options)
+    assert transformer.fix_comment_spaces is True
+
+    # Now with skip_list - should NOT fix comments
+    options2 = Options()
+    options2.write_list = ["yaml[comments]"]
+    options2.skip_list = ["yaml[comments]"]
+    options2.lintables = [str(playbook)]
+    result2 = get_matches(rules=default_rules_collection, options=options2)
+
+    transformer2 = Transformer(result2, options2)
+    assert transformer2.fix_comment_spaces is False
+
+    # Test with "yaml" in skip_list also disables comment fixing
+    options3 = Options()
+    options3.write_list = ["yaml[comments]"]
+    options3.skip_list = ["yaml"]
+    options3.lintables = [str(playbook)]
+    result3 = get_matches(rules=default_rules_collection, options=options3)
+
+    transformer3 = Transformer(result3, options3)
+    assert transformer3.fix_comment_spaces is False

--- a/test/test_transformer.py
+++ b/test/test_transformer.py
@@ -850,3 +850,21 @@ def test_transformer_respects_yaml_comments_skip_list(
     result3 = get_matches(rules=default_rules_collection, options=options3)
     transformer3 = Transformer(result3, options3)
     assert transformer3.fix_comment_spaces is False
+
+    # With yaml[comments] in warn_list, fix_comment_spaces should be False
+    options4 = Options()
+    options4.write_list = ["yaml"]
+    options4.warn_list = ["yaml[comments]"]
+    options4.lintables = [str(tmp_path / "test.yml")]
+    result4 = get_matches(rules=default_rules_collection, options=options4)
+    transformer4 = Transformer(result4, options4)
+    assert transformer4.fix_comment_spaces is False
+
+    # With yaml in warn_list, fix_comment_spaces should also be False
+    options5 = Options()
+    options5.write_list = ["yaml"]
+    options5.warn_list = ["yaml"]
+    options5.lintables = [str(tmp_path / "test.yml")]
+    result5 = get_matches(rules=default_rules_collection, options=options5)
+    transformer5 = Transformer(result5, options5)
+    assert transformer5.fix_comment_spaces is False

--- a/test/test_transformer.py
+++ b/test/test_transformer.py
@@ -824,43 +824,53 @@ def test_transformer_respects_yaml_comments_skip_list(
     When yaml[comments] is in skip_list, the Transformer should not
     reformat comment spacing even when other fixes are applied.
     """
-    # Create a file with comment spacing issue
+    # Create a file with comment that lacks space after #
     playbook = tmp_path / "test.yml"
-    playbook.write_text(
-        "---\n"
-        "- name: Test\n"
-        "  hosts: localhost\n"
-        "  tasks:\n"
-        "    - name: Task 1\n"
-        "      debug:\n"
-        "        msg:test  # comment without space\n"
-    )
+    content = "---\nfoo: bar\n#test-comment\nbaz: qux\n"
+    playbook.write_text(content)
 
-    # First without skip_list - should fix comments
+    # Test 1: Without skip_list - should fix comment spacing
     options = Options()
-    options.write_list = ["yaml[comments]"]
+    options.write_list = ["yaml"]
     options.lintables = [str(playbook)]
     result = get_matches(rules=default_rules_collection, options=options)
-
     transformer = Transformer(result, options)
-    assert transformer.fix_comment_spaces is True
+    transformer.run()
+    
+    fixed_content = playbook.read_text()
+    # Should have added space after #
+    assert "# test-comment" in fixed_content or "#test-comment" in fixed_content
+    
+    # Reset file
+    playbook.write_text(content)
 
-    # Now with skip_list - should NOT fix comments
+    # Test 2: With yaml[comments] in skip_list - should preserve #test-comment
     options2 = Options()
-    options2.write_list = ["yaml[comments]"]
+    options2.write_list = ["yaml"]
     options2.skip_list = ["yaml[comments]"]
     options2.lintables = [str(playbook)]
     result2 = get_matches(rules=default_rules_collection, options=options2)
-
     transformer2 = Transformer(result2, options2)
     assert transformer2.fix_comment_spaces is False
+    transformer2.run()
 
-    # Test with "yaml" in skip_list also disables comment fixing
+    fixed_content2 = playbook.read_text()
+    # Should preserve the comment without space
+    assert "#test-comment" in fixed_content2
+
+    # Reset file
+    playbook.write_text(content)
+
+    # Test 3: With yaml in skip_list - should also preserve #test-comment
     options3 = Options()
-    options3.write_list = ["yaml[comments]"]
+    options3.write_list = ["yaml"]
     options3.skip_list = ["yaml"]
     options3.lintables = [str(playbook)]
     result3 = get_matches(rules=default_rules_collection, options=options3)
-
     transformer3 = Transformer(result3, options3)
     assert transformer3.fix_comment_spaces is False
+    transformer3.run()
+
+    fixed_content3 = playbook.read_text()
+    # Should preserve the comment without space
+    assert "#test-comment" in fixed_content3

--- a/test/test_transformer.py
+++ b/test/test_transformer.py
@@ -836,11 +836,11 @@ def test_transformer_respects_yaml_comments_skip_list(
     result = get_matches(rules=default_rules_collection, options=options)
     transformer = Transformer(result, options)
     transformer.run()
-    
+
     fixed_content = playbook.read_text()
     # Should have added space after #
     assert "# test-comment" in fixed_content or "#test-comment" in fixed_content
-    
+
     # Reset file
     playbook.write_text(content)
 

--- a/test/test_yaml_utils.py
+++ b/test/test_yaml_utils.py
@@ -1134,31 +1134,27 @@ def test_formatted_yaml_fix_comment_spaces_enabled() -> None:
     """Verify that comment spacing is fixed when fix_comment_spaces=True."""
     yaml = ansiblelint.yaml_utils.FormattedYAML(fix_comment_spaces=True)
 
-    input_with_bad_spacing = """---
-key: value  #bad spacing
-other:#missing space after hash
-  nested: data
-"""
+    # EOL inline comments missing a space after '#' – valid YAML
+    input_with_bad_spacing = "---\nkey: value  #bad spacing\nother: nested  #also missing\n"
     data = yaml.load(input_with_bad_spacing)
     output = yaml.dumps(data)
 
-    # With fix_comment_spaces=True, spacing should be normalized
-    assert "# bad spacing" in output or "#bad spacing" not in output
-    assert "#missing space" not in output
+    # With fix_comment_spaces=True the leading '#' must be followed by a space
+    assert "#bad spacing" not in output
+    assert "# bad spacing" in output
+    assert "#also missing" not in output
+    assert "# also missing" in output
 
 
 def test_formatted_yaml_fix_comment_spaces_disabled() -> None:
     """Verify that comment spacing is preserved when fix_comment_spaces=False."""
     yaml = ansiblelint.yaml_utils.FormattedYAML(fix_comment_spaces=False)
 
-    input_with_bad_spacing = """---
-key: value  #bad spacing
-other:#missing space
-  nested: data
-"""
+    # Same input – fix_comment_spaces=False means the '#' must NOT be touched
+    input_with_bad_spacing = "---\nkey: value  #bad spacing\nother: nested  #also missing\n"
     data = yaml.load(input_with_bad_spacing)
     output = yaml.dumps(data)
 
-    # With fix_comment_spaces=False, original spacing should be preserved
-    # Comments should not be modified
-    assert "#bad spacing" in output or "# bad spacing" in output
+    # With fix_comment_spaces=False the original spacing must be preserved
+    assert "#bad spacing" in output
+    assert "#also missing" in output

--- a/test/test_yaml_utils.py
+++ b/test/test_yaml_utils.py
@@ -1128,3 +1128,37 @@ def test_formatted_yaml_anchor_indentation() -> None:
 
     assert "  name: my_name" in output_anchor
     assert "            name: my_name" not in output_anchor
+
+
+def test_formatted_yaml_fix_comment_spaces_enabled() -> None:
+    """Verify that comment spacing is fixed when fix_comment_spaces=True."""
+    yaml = ansiblelint.yaml_utils.FormattedYAML(fix_comment_spaces=True)
+
+    input_with_bad_spacing = """---
+key: value  #bad spacing
+other:#missing space after hash
+  nested: data
+"""
+    data = yaml.load(input_with_bad_spacing)
+    output = yaml.dumps(data)
+
+    # With fix_comment_spaces=True, spacing should be normalized
+    assert "# bad spacing" in output or "#bad spacing" not in output
+    assert "#missing space" not in output
+
+
+def test_formatted_yaml_fix_comment_spaces_disabled() -> None:
+    """Verify that comment spacing is preserved when fix_comment_spaces=False."""
+    yaml = ansiblelint.yaml_utils.FormattedYAML(fix_comment_spaces=False)
+
+    input_with_bad_spacing = """---
+key: value  #bad spacing
+other:#missing space
+  nested: data
+"""
+    data = yaml.load(input_with_bad_spacing)
+    output = yaml.dumps(data)
+
+    # With fix_comment_spaces=False, original spacing should be preserved
+    # Comments should not be modified
+    assert "#bad spacing" in output or "# bad spacing" in output


### PR DESCRIPTION
Recreates PR - 5068

Summary
Fixes https://github.com/ansible/ansible-lint/issues/5048.

When yaml[comments] is in skip_list, --fix was still modifying comments (e.g. #test-comment → # test-comment). This is a regression introduced in v25.12.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated `--fix` behavior to preserve YAML comment formatting when comment-spacing checks are skipped.
  - YAML comments remain unchanged when either comment-specific or broader YAML checks are excluded.
  - Other applicable YAML formatting fixes continue to be applied without altering intentionally excluded comment formatting.
- **Tests**
  - Added coverage confirming comment preservation across the supported skip configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->